### PR TITLE
UI finetuning: softer rounded corners and lighter font weights

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
           <path d="M11.5 2.75a.75.75 0 0 1 .75.75v7.19l2.72-2.72a.75.75 0 1 1 1.06 1.06l-4 4a.75.75 0 0 1-1.06 0l-4-4a.75.75 0 1 1 1.06-1.06l2.72 2.72V3.5a.75.75 0 0 1 .75-.75Z"/>
           <path d="M3.75 15a.75.75 0 0 1 .75-.75h14a.75.75 0 0 1 0 1.5h-14A.75.75 0 0 1 3.75 15ZM3.75 19a.75.75 0 0 1 .75-.75h14a.75.75 0 0 1 0 1.5h-14A.75.75 0 0 1 3.75 19Z"/>
         </svg>
-        <span class="font-semibold text-gray-900 dark:text-white tracking-tight">
+        <span class="font-medium text-gray-900 dark:text-white tracking-tight">
           {{ page_title | default("M365 Dienststatus") }}
         </span>
       </div>

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -1,9 +1,9 @@
 {# Renders one incident card with update timeline. Expects `incident` in scope. #}
-<div class="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 border-l-4 {{ incident_border_class(incident.classification) }} shadow-sm mb-4 overflow-hidden">
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 border-l-4 {{ incident_border_class(incident.classification) }} shadow-sm mb-4 overflow-hidden">
   <div class="p-4">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="font-semibold text-gray-900 dark:text-white leading-snug">{{ incident.title }}</h3>
+        <h3 class="font-medium text-gray-900 dark:text-white leading-snug">{{ incident.title }}</h3>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           <span class="font-medium">{{ L["incident.affects"] }}:</span> {{ incident.service_name }}
           &nbsp;·&nbsp;
@@ -19,7 +19,7 @@
 
     {% if incident.updates %}
     <div class="mt-4 space-y-3 border-t border-gray-100 dark:border-gray-800 pt-4">
-      <p class="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">{{ L["incident.updates"] }}</p>
+      <p class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{{ L["incident.updates"] }}</p>
       {% for update in incident.updates | reverse %}
       <div class="flex gap-3">
         <div class="shrink-0 flex flex-col items-center">

--- a/templates/partials/service_row.html
+++ b/templates/partials/service_row.html
@@ -1,7 +1,7 @@
 {# Renders one service card. Expects `service` (ServiceStatusSchema) in scope. #}
-<div class="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 p-4 mb-3 shadow-sm">
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-3 shadow-sm">
   <div class="flex items-center justify-between">
-    <span class="font-semibold text-gray-900 dark:text-white">{{ service.service_name }}</span>
+    <span class="font-medium text-gray-800 dark:text-gray-100">{{ service.service_name }}</span>
     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ status_badge_class(service.current_status) }}">
       {% if service.current_status == "operational" %}
       <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="3"/></svg>

--- a/templates/status.html
+++ b/templates/status.html
@@ -4,7 +4,7 @@
 
 {# ── Overall status banner ──────────────────────────────────────────────────── #}
 {% set overall = data.overall_status %}
-<div class="rounded-xl px-5 py-4 mb-6 flex items-center justify-between
+<div class="rounded-2xl px-5 py-4 mb-6 flex items-center justify-between
   {% if overall == 'operational' %}
     bg-emerald-50 border border-emerald-200 dark:bg-emerald-950/30 dark:border-emerald-800
   {% elif overall == 'interrupted' %}
@@ -16,13 +16,13 @@
   <div class="flex items-center gap-3">
     {% if overall == 'operational' %}
       <div class="w-3 h-3 rounded-full bg-emerald-500 shadow shadow-emerald-300 dark:shadow-emerald-900"></div>
-      <span class="font-semibold text-emerald-800 dark:text-emerald-300">{{ L["page.all_good"] }}</span>
+      <span class="font-medium text-emerald-800 dark:text-emerald-300">{{ L["page.all_good"] }}</span>
     {% elif overall == 'interrupted' %}
       <div class="w-3 h-3 rounded-full bg-red-500 shadow shadow-red-300 dark:shadow-red-900 animate-pulse"></div>
-      <span class="font-semibold text-red-800 dark:text-red-300">{{ L["page.incidents_active"] }}</span>
+      <span class="font-medium text-red-800 dark:text-red-300">{{ L["page.incidents_active"] }}</span>
     {% else %}
       <div class="w-3 h-3 rounded-full bg-amber-500 shadow shadow-amber-300 dark:shadow-amber-900 animate-pulse"></div>
-      <span class="font-semibold text-amber-800 dark:text-amber-300">{{ L["page.some_degraded"] }}</span>
+      <span class="font-medium text-amber-800 dark:text-amber-300">{{ L["page.some_degraded"] }}</span>
     {% endif %}
   </div>
   {% if data.last_updated %}
@@ -34,7 +34,7 @@
 
 {# ── Service uptime rows ─────────────────────────────────────────────────────── #}
 <section class="mb-8">
-  <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
     {{ L["page.uptime_heading"] }}
   </h2>
   {% for service in data.services %}
@@ -45,7 +45,7 @@
 {# ── Active incidents ─────────────────────────────────────────────────────────── #}
 {% set has_incidents = data.services | selectattr("active_incidents") | list | length > 0 %}
 <section>
-  <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
     {{ L["page.incidents_heading"] }}
   </h2>
   {% if has_incidents %}
@@ -55,7 +55,7 @@
       {% endfor %}
     {% endfor %}
   {% else %}
-  <div class="bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
     {{ L["page.no_incidents"] }}
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary

- **Rounded corners**: all cards `rounded-xl` → `rounded-2xl` for a softer, less harsh appearance
- **Card borders**: `border-gray-200` → `border-gray-100` (lighter, more airy)
- **Typography**: `font-semibold` → `font-medium` throughout — service names, status banner, section headings, incident titles, and nav title; keeps text readable without feeling heavy
- Service name color: `text-gray-900` → `text-gray-800` (marginally softer)

## Test plan

- [ ] Status page loads with visibly softer card corners
- [ ] Service names and headings render at medium weight (not bold)
- [ ] Status banner still clearly readable in all three states (operational / degraded / interrupted)
- [ ] Incident cards and update timeline look correct
- [ ] Dark mode unaffected

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_