### PR TITLE
Apply brand color to navigation bar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,13 @@
       theme: {
         extend: {
           fontFamily: { sans: ['Inter', 'system-ui', 'sans-serif'] },
+          colors: {
+            brand: {
+              DEFAULT: '#6B2382',
+              dark:    '#4F1A63',
+              light:   '#8B35A8',
+            }
+          }
         }
       }
     }
@@ -27,7 +34,7 @@
 <body class="h-full bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 font-sans antialiased transition-colors duration-200">
 
   <!-- Navigation -->
-  <nav class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 sticky top-0 z-10">
+  <nav class="bg-brand dark:bg-brand-dark border-b border-brand-dark sticky top-0 z-10">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
       <div class="flex items-center gap-2">
         <!-- M365 four-square icon -->
@@ -37,7 +44,7 @@
           <rect x="1"  y="13" width="10" height="10" rx="1.5" fill="#05a6f0"/>
           <rect x="13" y="13" width="10" height="10" rx="1.5" fill="#ffba08"/>
         </svg>
-        <span class="font-medium text-gray-900 dark:text-white tracking-tight">
+        <span class="font-medium text-white tracking-tight">
           {{ page_title | default("M365 Dienststatus") }}
         </span>
       </div>
@@ -47,7 +54,7 @@
         <button
           id="theme-toggle"
           aria-label="Farbschema wechseln"
-          class="p-1.5 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-gray-200 dark:hover:bg-gray-800 transition-colors"
+          class="p-1.5 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors"
         >
           <svg id="icon-sun" class="w-4 h-4 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8Z"/>
@@ -58,12 +65,12 @@
         </button>
 
         {% if user is defined and user %}
-        <span class="text-sm text-gray-500 dark:text-gray-400 hidden sm:block">
+        <span class="text-sm text-white/60 hidden sm:block">
           {{ user.get("name") or user.get("preferred_username") or user.get("email", "") }}
         </span>
         <a
           href="/auth/logout"
-          class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
+          class="text-sm font-medium text-white/80 hover:text-white transition-colors"
         >{{ L["page.logout"] }}</a>
         {% endif %}
       </div>


### PR DESCRIPTION
## Summary

- Nav background: corporate purple `#6B2382` (light) / `#4F1A63` (dark)
- Nav text, icons, username, logout link all adjusted to white with opacity for hierarchy
- Dark-mode toggle hover uses `white/10` overlay instead of gray
- Brand color registered as Tailwind token (`brand.DEFAULT`, `brand.dark`, `brand.light`) for reuse
- No company name or logo added — branding is purely color-based

## Test plan

- [ ] Nav bar renders in purple in light mode
- [ ] Dark mode shows slightly darker purple nav
- [ ] White text and icons are readable (contrast)
- [ ] Dark mode toggle and logout link still work

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_