### PR TITLE
Graph API severity mapping + per-incident suppression

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -75,6 +75,9 @@ async def upsert_incident(
         await db.flush()
     else:
         for k, v in fields.items():
+            # Don't overwrite severity if admin has set it manually
+            if k == "severity" and incident.source == "manual":
+                continue
             setattr(incident, k, v)
         await db.flush()
     return incident
@@ -143,7 +146,11 @@ async def get_active_incidents(
     stmt = (
         select(Incident)
         .options(selectinload(Incident.updates))
-        .where(Incident.is_resolved.is_(False), Incident.classification != "maintenance")
+        .where(
+            Incident.is_resolved.is_(False),
+            Incident.classification != "maintenance",
+            Incident.is_suppressed.is_(False),
+        )
         .order_by(desc(Incident.last_modified))
     )
     if service_name:
@@ -299,6 +306,26 @@ async def get_resolved_incidents(
     return list(result.scalars().all())
 
 
+async def toggle_suppress_incident(
+    db: AsyncSession,
+    incident_id: int,
+    suppress: bool,
+) -> None:
+    incident = await get_incident_by_id(db, incident_id)
+    if incident:
+        incident.is_suppressed = suppress
+        await db.flush()
+
+
+async def get_suppressed_incidents(db: AsyncSession) -> list[Incident]:
+    result = await db.execute(
+        select(Incident)
+        .where(Incident.is_suppressed.is_(True), Incident.is_resolved.is_(False))
+        .order_by(desc(Incident.last_modified))
+    )
+    return list(result.scalars().all())
+
+
 async def set_service_status_manual(
     db: AsyncSession,
     service_name: str,
@@ -342,14 +369,6 @@ async def build_status_page_data(
             )
             for inc in raw_incidents
         ]
-
-        # Elevate current_status if active incidents are more severe
-        if incident_schemas:
-            current_status = max(
-                current_status,
-                "degraded",
-                key=lambda s: _STATUS_SEVERITY.get(s, 0),
-            )
 
         overall_severity = max(
             overall_severity, _STATUS_SEVERITY.get(current_status, 0)

--- a/app/database.py
+++ b/app/database.py
@@ -44,6 +44,7 @@ async def init_db() -> None:
             "ALTER TABLE incidents ADD COLUMN scheduled_start DATETIME",
             "ALTER TABLE incidents ADD COLUMN scheduled_end DATETIME",
             "ALTER TABLE incident_updates ADD COLUMN update_type VARCHAR NOT NULL DEFAULT 'note'",
+            "ALTER TABLE incidents ADD COLUMN is_suppressed BOOLEAN NOT NULL DEFAULT 0",
         ]:
             try:
                 await conn.execute(text(stmt))

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -69,6 +69,10 @@ LABELS: dict[str, str] = {
     "admin.scheduled_end":        "Ende (geplant)",
     "admin.back":                 "Zurück",
     "admin.no_incidents":         "Keine aktiven Einträge.",
+    "admin.suppress":             "Ignorieren",
+    "admin.unsuppress":           "Wiederherstellen",
+    "admin.suppressed_heading":   "Ignorierte Meldungen",
+    "admin.no_suppressed":        "Keine ignorierten Meldungen.",
     "admin.no_maintenances":      "Keine geplanten Wartungen.",
     # Maintenance status
     "maintenance.scheduled":      "Geplant",

--- a/app/models.py
+++ b/app/models.py
@@ -79,6 +79,7 @@ class Incident(Base):
     start_datetime: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_modified: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     is_resolved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_suppressed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="graph")
     severity: Mapped[str] = mapped_column(String(32), nullable=False, server_default="")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -16,7 +16,9 @@ from app.crud import (
     get_incident_by_id,
     get_resolved_incidents,
     get_scheduled_maintenances,
+    get_suppressed_incidents,
     set_service_status_manual,
+    toggle_suppress_incident,
 )
 from app.dependencies import get_db
 from app.templates import templates
@@ -41,6 +43,7 @@ async def admin_dashboard(
 ):
     incidents = await get_all_incidents(db, include_resolved=False)
     resolved = await get_resolved_incidents(db, limit=10)
+    suppressed = await get_suppressed_incidents(db)
     maintenances = await get_scheduled_maintenances(db)
     return templates.TemplateResponse(
         request,
@@ -49,6 +52,7 @@ async def admin_dashboard(
             "user": user,
             "incidents": incidents,
             "resolved_incidents": resolved,
+            "suppressed_incidents": suppressed,
             "maintenances": maintenances,
             "services": settings.monitored_services_list,
             "page_title": f"Admin – {settings.APP_TITLE}",
@@ -178,6 +182,28 @@ async def set_service_status(
     await set_service_status_manual(db, service_name, status)
     await db.commit()
     return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/incidents/{incident_id}/suppress")
+async def suppress_incident(
+    incident_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    await toggle_suppress_incident(db, incident_id, suppress=True)
+    await db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/incidents/{incident_id}/unsuppress")
+async def unsuppress_incident(
+    incident_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    await toggle_suppress_incident(db, incident_id, suppress=False)
+    await db.commit()
+    return RedirectResponse(url=f"/admin/incidents/{incident_id}", status_code=303)
 
 
 @router.get("/maintenance/new")

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -14,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 scheduler = AsyncIOScheduler()
 
+_GRAPH_SEVERITY_MAP: dict[str, str] = {
+    "minor":    "low",
+    "moderate": "medium",
+    "major":    "high",
+}
+
 
 def _parse_dt(value: str | None) -> datetime | None:
     if not value:
@@ -63,6 +69,7 @@ async def poll_graph_api() -> None:
             for issue in issues:
                 if issue.get("service") not in monitored:
                     continue
+                severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
                 incident = await upsert_incident(
                     db,
                     graph_issue_id=issue["id"],
@@ -73,6 +80,7 @@ async def poll_graph_api() -> None:
                     start_datetime=_parse_dt(issue.get("startDateTime")),
                     last_modified=_parse_dt(issue.get("lastModifiedDateTime")),
                     is_resolved=issue.get("isResolved", False),
+                    severity=severity,
                 )
                 posts = issue.get("posts", [])
                 await upsert_incident_updates(db, incident.id, posts)

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -57,9 +57,8 @@
   {% if incidents %}
   <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
     {% for inc in incidents %}
-    <a href="/admin/incidents/{{ inc.id }}"
-       class="flex items-center justify-between px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors group">
-      <div>
+    <div class="flex items-center justify-between px-5 py-3 group">
+      <a href="/admin/incidents/{{ inc.id }}" class="flex-1 flex items-center gap-0 hover:opacity-80 transition-opacity min-w-0">
         <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
           {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
           {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
@@ -68,13 +67,16 @@
         {% if inc.severity %}
         <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5 {{ severity_badge_class(inc.severity) }}">{{ severity_label(inc.severity) }}</span>
         {% endif %}
-        <span class="font-medium text-sm text-gray-800 dark:text-gray-200">{{ inc.title }}</span>
-        <span class="text-sm text-gray-400 dark:text-gray-500 ml-2">· {{ inc.service_name }}</span>
-      </div>
-      <svg class="w-4 h-4 text-gray-400 group-hover:text-gray-600 dark:group-hover:text-gray-300 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
-      </svg>
-    </a>
+        <span class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate">{{ inc.title }}</span>
+        <span class="text-sm text-gray-400 dark:text-gray-500 ml-2 shrink-0">· {{ inc.service_name }}</span>
+      </a>
+      <form method="post" action="/admin/incidents/{{ inc.id }}/suppress" class="ml-3 shrink-0">
+        <button type="submit"
+                class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+          {{ L["admin.suppress"] }}
+        </button>
+      </form>
+    </div>
     {% endfor %}
   </div>
   {% else %}
@@ -111,6 +113,40 @@
   </div>
 </section>
 {% endif %}
+
+{# ── Ignorierte Meldungen ────────────────────────────────────────────────────── #}
+<section class="mb-8">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+    {{ L["admin.suppressed_heading"] }}
+  </h2>
+  {% if suppressed_incidents %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden opacity-60">
+    {% for inc in suppressed_incidents %}
+    <div class="flex items-center justify-between px-5 py-3">
+      <div class="min-w-0 flex-1">
+        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
+          {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
+          {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
+          {{ incident_type_label(inc.classification) }}
+        </span>
+        <span class="text-sm text-gray-500 dark:text-gray-400 line-through decoration-gray-300 dark:decoration-gray-600">{{ inc.title }}</span>
+        <span class="text-xs text-gray-400 dark:text-gray-500 ml-2">· {{ inc.service_name }}</span>
+      </div>
+      <form method="post" action="/admin/incidents/{{ inc.id }}/unsuppress" class="ml-3 shrink-0">
+        <button type="submit"
+                class="text-xs px-2.5 py-1 rounded-lg border border-emerald-200 dark:border-emerald-800 text-emerald-600 hover:text-emerald-800 hover:border-emerald-400 dark:text-emerald-400 transition-colors">
+          {{ L["admin.unsuppress"] }}
+        </button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-400 dark:text-gray-500 shadow-sm">
+    {{ L["admin.no_suppressed"] }}
+  </div>
+  {% endif %}
+</section>
 
 {# ── Geplante Wartungen ──────────────────────────────────────────────────────── #}
 <section>

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -16,6 +16,22 @@
     {{ severity_label(incident.severity) }}
   </span>
   {% endif %}
+  <div class="ml-auto flex items-center gap-2">
+    {% if incident.is_suppressed %}
+    <span class="text-xs px-2 py-0.5 rounded-full bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400">{{ L["admin.suppressed_heading"] }}</span>
+    <form method="post" action="/admin/incidents/{{ incident.id }}/unsuppress">
+      <button type="submit" class="text-xs px-2.5 py-1 rounded-lg border border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-700 dark:text-emerald-400 transition-colors">
+        {{ L["admin.unsuppress"] }}
+      </button>
+    </form>
+    {% else %}
+    <form method="post" action="/admin/incidents/{{ incident.id }}/suppress">
+      <button type="submit" class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:border-gray-400 hover:text-gray-700 dark:text-gray-400 transition-colors">
+        {{ L["admin.suppress"] }}
+      </button>
+    </form>
+    {% endif %}
+  </div>
 </div>
 
 <div class="grid gap-6 lg:grid-cols-3">


### PR DESCRIPTION
## Summary

- **Severity auto-mapping**: Graph API `severity` field (`minor/moderate/major`) is now mapped to our `low/medium/high` badges on every poll. Manual incidents keep admin-set severity.
- **Per-incident suppression**: Admin can suppress any incident with one click — it disappears from the public status page and doesn't affect the overall status banner
- **Status badge decoupled**: Service status badge now reflects `healthOverviews` only — irrelevant Graph API issues no longer push the badge to "degraded"

## Admin UX

- Each active incident row in the dashboard has an **"Ignorieren"** button (inline form POST, no page navigation needed)
- Suppressed incidents appear in a separate dimmed **"Ignorierte Meldungen"** section with a **"Wiederherstellen"** button
- The incident detail page also shows a suppress/unsuppress toggle button

## Test plan

- [ ] Graph API poll: check that `severity` field is mapped (minor→low, medium→medium, major→high) in DB
- [ ] Click "Ignorieren" on an active incident → disappears from `/`
- [ ] Service badge stays `operational` even with active (suppressed) incidents
- [ ] Click "Wiederherstellen" → incident reappears on `/`
- [ ] Manual incident severity is not overwritten by scheduler
- [ ] CI: all 4 checks green

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_