### PR TITLE
feat: admin service management, brand colors & container rename

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -295,14 +295,19 @@ async def add_state_change_entry(
 async def get_resolved_incidents(
     db: AsyncSession,
     limit: int = 20,
+    days: int | None = None,
 ) -> list[Incident]:
-    result = await db.execute(
+    stmt = (
         select(Incident)
         .options(selectinload(Incident.updates))
         .where(Incident.is_resolved.is_(True), Incident.classification != "maintenance")
         .order_by(desc(Incident.last_modified))
         .limit(limit)
     )
+    if days is not None:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        stmt = stmt.where(Incident.last_modified >= cutoff)
+    result = await db.execute(stmt)
     return list(result.scalars().all())
 
 

--- a/app/crud.py
+++ b/app/crud.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models import Incident, IncidentUpdate, ServiceStatus
+from app.models import Incident, IncidentUpdate, MonitoredService, ServiceStatus
 from app.schemas import (
     DayStatusSchema,
     IncidentSchema,
@@ -324,6 +324,96 @@ async def get_suppressed_incidents(db: AsyncSession) -> list[Incident]:
         .order_by(desc(Incident.last_modified))
     )
     return list(result.scalars().all())
+
+
+async def get_enabled_services(db: AsyncSession) -> list[str]:
+    result = await db.execute(
+        select(MonitoredService.service_name)
+        .where(MonitoredService.is_enabled.is_(True))
+        .order_by(MonitoredService.service_name)
+    )
+    return [row[0] for row in result.fetchall()]
+
+
+async def get_all_monitored_services(db: AsyncSession) -> list[MonitoredService]:
+    result = await db.execute(
+        select(MonitoredService).order_by(MonitoredService.service_name)
+    )
+    return list(result.scalars().all())
+
+
+async def ensure_service_known(db: AsyncSession, service_name: str) -> MonitoredService:
+    result = await db.execute(
+        select(MonitoredService).where(MonitoredService.service_name == service_name)
+    )
+    svc = result.scalar_one_or_none()
+    if svc is None:
+        svc = MonitoredService(service_name=service_name, is_enabled=False)
+        db.add(svc)
+        await db.flush()
+    return svc
+
+
+async def set_service_enabled(
+    db: AsyncSession, service_name: str, is_enabled: bool
+) -> MonitoredService:
+    svc = await ensure_service_known(db, service_name)
+    svc.is_enabled = is_enabled
+    await db.flush()
+    return svc
+
+
+async def backfill_service_status_from_issues(
+    db: AsyncSession,
+    service_name: str,
+    issues: list[dict],
+    days: int = 90,
+) -> None:
+    today = date.today()
+    start_date = today - timedelta(days=days - 1)
+
+    _severity = {"operational": 0, "unknown": 1, "degraded": 2, "interrupted": 3}
+
+    def _parse_issue_date(val: str | None) -> date | None:
+        if not val:
+            return None
+        try:
+            dt = datetime.fromisoformat(val.replace("Z", "+00:00"))
+            return dt.date()
+        except (ValueError, AttributeError):
+            return None
+
+    day_status: dict[date, str] = {}
+    for issue in issues:
+        issue_start = _parse_issue_date(issue.get("startDateTime"))
+        issue_end = _parse_issue_date(issue.get("endDateTime") or issue.get("lastModifiedDateTime"))
+        if not issue_start:
+            continue
+        if issue_end is None or issue_end < issue_start:
+            issue_end = today
+        classification = issue.get("classification", "incident")
+        status = "interrupted" if classification == "incident" else "degraded"
+
+        cursor = max(issue_start, start_date)
+        end_clamped = min(issue_end, today)
+        while cursor <= end_clamped:
+            if _severity.get(status, 0) > _severity.get(day_status.get(cursor, "operational"), 0):
+                day_status[cursor] = status
+            cursor += timedelta(days=1)
+
+    result = await db.execute(
+        select(ServiceStatus.date).where(
+            ServiceStatus.service_name == service_name,
+            ServiceStatus.date >= start_date,
+        )
+    )
+    existing_dates = {row[0] for row in result.fetchall()}
+
+    for i in range(days):
+        d = start_date + timedelta(days=i)
+        if d not in existing_dates:
+            status = day_status.get(d, "operational")
+            await upsert_service_status(db, service_name, d, status, "backfill")
 
 
 async def set_service_status_manual(

--- a/app/database.py
+++ b/app/database.py
@@ -1,6 +1,6 @@
 import os
 
-from sqlalchemy import event, text
+from sqlalchemy import event, func, select, text
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from app.config import settings
-from app.models import Base
+from app.models import Base, MonitoredService
 
 os.makedirs("data", exist_ok=True)
 
@@ -50,3 +50,11 @@ async def init_db() -> None:
                 await conn.execute(text(stmt))
             except Exception:  # noqa: S110
                 pass  # column already exists
+
+    # Seed monitored_services from env var if the table is empty
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(func.count()).select_from(MonitoredService))
+        if result.scalar_one() == 0:
+            for name in settings.monitored_services_list:
+                db.add(MonitoredService(service_name=name, is_enabled=True))
+            await db.commit()

--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+from datetime import datetime, timedelta
+from urllib.parse import quote
 
 import httpx
 import msal
@@ -47,6 +49,29 @@ async def fetch_health_overviews() -> list[dict]:
         )
         resp.raise_for_status()
         return resp.json().get("value", [])
+
+
+async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
+    """Fetch all issues (including resolved) for a service over the past N days, for backfill."""
+    token = await _get_access_token()
+    since = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00Z")
+    name_encoded = quote(service_name, safe="")
+    base_url = (
+        f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
+        f"?$filter=service eq '{name_encoded}' and startDateTime ge {since}"
+        f"&$select=id,service,classification,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity"
+        f"&$top=100"
+    )
+    all_issues: list[dict] = []
+    async with httpx.AsyncClient(timeout=60) as client:
+        url: str | None = base_url
+        while url:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+            resp.raise_for_status()
+            data = resp.json()
+            all_issues.extend(data.get("value", []))
+            url = data.get("@odata.nextLink")
+    return all_issues
 
 
 async def fetch_active_issues() -> list[dict]:

--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -74,6 +74,28 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
     return all_issues
 
 
+async def fetch_recently_resolved_issues(days: int = 30) -> list[dict]:
+    """Returns resolved issues whose lastModifiedDateTime is within the past N days."""
+    token = await _get_access_token()
+    since = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00Z")
+    base_url = (
+        f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
+        f"?$filter=isResolved eq true and lastModifiedDateTime ge {since}"
+        f"&$expand=posts"
+        f"&$top=100"
+    )
+    all_issues: list[dict] = []
+    async with httpx.AsyncClient(timeout=60) as client:
+        url: str | None = base_url
+        while url:
+            resp = await client.get(url, headers={"Authorization": f"Bearer {token}"})
+            resp.raise_for_status()
+            data = resp.json()
+            all_issues.extend(data.get("value", []))
+            url = data.get("@odata.nextLink")
+    return all_issues
+
+
 async def fetch_active_issues() -> list[dict]:
     """Returns all unresolved service health issues, with posts expanded."""
     token = await _get_access_token()

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -80,4 +80,11 @@ LABELS: dict[str, str] = {
     "maintenance.completed":      "Abgeschlossen",
     # Incident type
     "incident.type.maintenance":  "Wartung",
+    # Service management
+    "admin.service_management":   "Dienstverwaltung",
+    "admin.discover_services":    "Von Microsoft laden",
+    "admin.service_enable":       "Aktivieren",
+    "admin.service_disable":      "Deaktivieren",
+    "admin.no_known_services":    "Noch keine Dienste bekannt.",
+    "admin.service_backfill_hint": "90-Tage-Verlauf wird im Hintergrund geladen…",
 }

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -80,6 +80,12 @@ LABELS: dict[str, str] = {
     "maintenance.completed":      "Abgeschlossen",
     # Incident type
     "incident.type.maintenance":  "Wartung",
+    # Incident history (public page)
+    "page.history_heading":       "Kürzlich behoben",
+    "page.history_subheading":    "Letzte 30 Tage",
+    "page.history_empty":         "Keine behobenen Störungen in den letzten 30 Tagen.",
+    "page.history_show":          "Störungs-Verlauf anzeigen",
+    "incident.resolved_at":       "Behoben am",
     # Service management
     "admin.service_management":   "Dienstverwaltung",
     "admin.discover_services":    "Von Microsoft laden",

--- a/app/models.py
+++ b/app/models.py
@@ -34,15 +34,15 @@ GRAPH_STATUS_MAP: dict[str, str] = {
 }
 
 STATUS_TAILWIND_BAR: dict[str, str] = {
-    "operational": "bg-emerald-500",
-    "degraded":    "bg-amber-400",
-    "interrupted": "bg-red-500",
+    "operational": "bg-[#28a745]",
+    "degraded":    "bg-[#ffc107]",
+    "interrupted": "bg-[#dc3545]",
     "no_data":     "bg-gray-200 dark:bg-gray-700",
     "unknown":     "bg-gray-300 dark:bg-gray-600",
 }
 
 STATUS_BADGE_CLASSES: dict[str, str] = {
-    "operational": "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-400",
+    "operational": "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400",
     "degraded":    "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400",
     "interrupted": "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400",
     "unknown":     "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
@@ -111,3 +111,12 @@ class IncidentUpdate(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     incident: Mapped["Incident"] = relationship("Incident", back_populates="updates")
+
+
+class MonitoredService(Base):
+    __tablename__ = "monitored_services"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    service_name: Mapped[str] = mapped_column(String(128), unique=True, nullable=False, index=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,8 +1,11 @@
+import asyncio
+import logging
 from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
 from fastapi.responses import RedirectResponse
+from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_auth
@@ -11,17 +14,27 @@ from app.crud import (
     add_incident_post,
     add_state_change_entry,
     admin_update_incident,
+    backfill_service_status_from_issues,
     create_manual_incident,
+    ensure_service_known,
     get_all_incidents,
+    get_all_monitored_services,
+    get_enabled_services,
     get_incident_by_id,
     get_resolved_incidents,
     get_scheduled_maintenances,
     get_suppressed_incidents,
+    set_service_enabled,
     set_service_status_manual,
     toggle_suppress_incident,
 )
+from app.database import AsyncSessionLocal
 from app.dependencies import get_db
+from app.graph_client import fetch_health_overviews, fetch_issues_since
+from app.models import MonitoredService
 from app.templates import templates
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -35,6 +48,18 @@ def _parse_form_dt(val: str | None) -> datetime | None:
         return None
 
 
+async def _backfill_service(service_name: str) -> None:
+    """Background task: fetch 90-day issue history and fill in missing status rows."""
+    try:
+        issues = await fetch_issues_since(service_name, days=90)
+        async with AsyncSessionLocal() as db:
+            await backfill_service_status_from_issues(db, service_name, issues, days=90)
+            await db.commit()
+        logger.info("Backfill completed for %s (%d issues)", service_name, len(issues))
+    except Exception:
+        logger.exception("Backfill failed for %s", service_name)
+
+
 @router.get("/")
 async def admin_dashboard(
     request: Request,
@@ -45,6 +70,8 @@ async def admin_dashboard(
     resolved = await get_resolved_incidents(db, limit=10)
     suppressed = await get_suppressed_incidents(db)
     maintenances = await get_scheduled_maintenances(db)
+    all_services = await get_all_monitored_services(db)
+    enabled_services = [s.service_name for s in all_services if s.is_enabled]
     return templates.TemplateResponse(
         request,
         "admin/dashboard.html",
@@ -54,7 +81,8 @@ async def admin_dashboard(
             "resolved_incidents": resolved,
             "suppressed_incidents": suppressed,
             "maintenances": maintenances,
-            "services": settings.monitored_services_list,
+            "all_services": all_services,
+            "services": enabled_services,
             "page_title": f"Admin – {settings.APP_TITLE}",
         },
     )
@@ -63,14 +91,16 @@ async def admin_dashboard(
 @router.get("/incidents/new")
 async def new_incident_form(
     request: Request,
+    db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
+    enabled_services = await get_enabled_services(db)
     return templates.TemplateResponse(
         request,
         "admin/incident_form.html",
         {
             "user": user,
-            "services": settings.monitored_services_list,
+            "services": enabled_services,
             "page_title": "Neue Störung / Hinweis",
         },
     )
@@ -108,13 +138,14 @@ async def incident_detail(
     incident = await get_incident_by_id(db, incident_id)
     if incident is None:
         raise HTTPException(status_code=404, detail="Nicht gefunden")
+    enabled_services = await get_enabled_services(db)
     return templates.TemplateResponse(
         request,
         "admin/incident_detail.html",
         {
             "user": user,
             "incident": incident,
-            "services": settings.monitored_services_list,
+            "services": enabled_services,
             "page_title": incident.title,
         },
     )
@@ -172,6 +203,46 @@ async def add_post(
     return RedirectResponse(url=f"/admin/incidents/{incident_id}", status_code=303)
 
 
+@router.post("/services/refresh")
+async def refresh_services(
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    """Fetch all services from Graph API and register any new ones as disabled."""
+    try:
+        overviews = await fetch_health_overviews()
+        for svc in overviews:
+            name = svc.get("service", "")
+            if name:
+                await ensure_service_known(db, name)
+        await db.commit()
+    except Exception:
+        logger.exception("Service discovery failed")
+    return RedirectResponse(url="/admin", status_code=303)
+
+
+@router.post("/services/{service_name}/toggle")
+async def toggle_service(
+    service_name: str,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    """Enable or disable a service on the status page. Triggers backfill when enabling."""
+    result = await db.execute(
+        sa_select(MonitoredService).where(MonitoredService.service_name == service_name)
+    )
+    svc = result.scalar_one_or_none()
+    currently_enabled = svc.is_enabled if svc else False
+    new_state = not currently_enabled
+    await set_service_enabled(db, service_name, new_state)
+    await db.commit()
+
+    if new_state:
+        asyncio.create_task(_backfill_service(service_name))
+
+    return RedirectResponse(url="/admin", status_code=303)
+
+
 @router.post("/services/{service_name}/status")
 async def set_service_status(
     service_name: str,
@@ -209,14 +280,16 @@ async def unsuppress_incident(
 @router.get("/maintenance/new")
 async def new_maintenance_form(
     request: Request,
+    db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
+    enabled_services = await get_enabled_services(db)
     return templates.TemplateResponse(
         request,
         "admin/maintenance_form.html",
         {
             "user": user,
-            "services": settings.monitored_services_list,
+            "services": enabled_services,
             "page_title": "Neue Wartung",
         },
     )

--- a/app/routers/status.py
+++ b/app/routers/status.py
@@ -4,7 +4,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_auth
 from app.config import settings
-from app.crud import build_status_page_data, get_scheduled_maintenances
+from app.crud import (
+    build_status_page_data,
+    get_enabled_services,
+    get_resolved_incidents,
+    get_scheduled_maintenances,
+)
 from app.dependencies import get_db
 from app.templates import templates
 
@@ -17,8 +22,12 @@ async def status_page(
     user: dict = Depends(require_auth),
     db: AsyncSession = Depends(get_db),
 ):
-    data = await build_status_page_data(db, settings.monitored_services_list)
+    enabled = await get_enabled_services(db)
+    # Fall back to env var list if DB hasn't been seeded yet
+    service_names = enabled or settings.monitored_services_list
+    data = await build_status_page_data(db, service_names)
     maintenances = await get_scheduled_maintenances(db)
+    recent_resolved = await get_resolved_incidents(db, limit=50, days=30)
     return templates.TemplateResponse(
         request,
         "status.html",
@@ -26,6 +35,7 @@ async def status_page(
             "user": user,
             "data": data,
             "maintenances": maintenances,
+            "recent_resolved": recent_resolved,
             "page_title": settings.APP_TITLE,
         },
     )

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -5,7 +5,13 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import settings
-from app.crud import upsert_incident, upsert_incident_updates, upsert_service_status
+from app.crud import (
+    ensure_service_known,
+    get_enabled_services,
+    upsert_incident,
+    upsert_incident_updates,
+    upsert_service_status,
+)
 from app.database import AsyncSessionLocal
 from app.graph_client import fetch_active_issues, fetch_health_overviews
 from app.models import GRAPH_STATUS_MAP
@@ -32,7 +38,14 @@ def _parse_dt(value: str | None) -> datetime | None:
 
 
 async def poll_graph_api() -> None:
-    monitored = settings.monitored_services_list
+    # Read enabled services from DB (not env var) so admin toggles take effect
+    async with AsyncSessionLocal() as db:
+        monitored = await get_enabled_services(db)
+
+    if not monitored:
+        logger.info("No enabled services configured. Skipping poll.")
+        return
+
     today = date.today()
     logger.info("Graph API poll started for services: %s", monitored)
 
@@ -44,6 +57,10 @@ async def poll_graph_api() -> None:
 
             for svc in overviews:
                 name = svc.get("service", "")
+                if not name:
+                    continue
+                # Discover all services returned by Graph API (mark as known but not enabled)
+                await ensure_service_known(db, name)
                 if name not in monitored:
                     continue
                 seen_services.add(name)

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -13,7 +13,11 @@ from app.crud import (
     upsert_service_status,
 )
 from app.database import AsyncSessionLocal
-from app.graph_client import fetch_active_issues, fetch_health_overviews
+from app.graph_client import (
+    fetch_active_issues,
+    fetch_health_overviews,
+    fetch_recently_resolved_issues,
+)
 from app.models import GRAPH_STATUS_MAP
 
 logger = logging.getLogger(__name__)
@@ -79,11 +83,14 @@ async def poll_graph_api() -> None:
             await db.rollback()
             logger.exception("Health overview poll failed")
 
-    # ── Phase 2: Active incidents (separate session – failure won't roll back phase 1) ──
+    # ── Phase 2: Active + recently resolved incidents ────────────────────────────
     async with AsyncSessionLocal() as db:
         try:
-            issues = await fetch_active_issues()
-            for issue in issues:
+            active_issues = await fetch_active_issues()
+            resolved_issues = await fetch_recently_resolved_issues(days=30)
+            all_issues = active_issues + resolved_issues
+
+            for issue in all_issues:
                 if issue.get("service") not in monitored:
                     continue
                 severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
@@ -103,11 +110,15 @@ async def poll_graph_api() -> None:
                 await upsert_incident_updates(db, incident.id, posts)
 
             await db.commit()
-            logger.info("Graph API poll completed successfully.")
+            logger.info(
+                "Graph API poll completed: %d active, %d recently resolved.",
+                len(active_issues),
+                len(resolved_issues),
+            )
 
         except Exception:
             await db.rollback()
-            logger.exception("Active issues poll failed")
+            logger.exception("Issues poll failed")
 
 
 def start_scheduler() -> None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: m365-statuspage:latest
-    container_name: m365-statuspage
+    image: pyur-statuspage:latest
+    container_name: pyur-statuspage
     restart: unless-stopped
     ports:
       - "8000:8000"

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -21,6 +21,51 @@
   </div>
 </div>
 
+{# ── Dienstverwaltung ────────────────────────────────────────────────────────── #}
+<section class="mb-8">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {{ L["admin.service_management"] }}
+    </h2>
+    <form method="post" action="/admin/services/refresh">
+      <button type="submit"
+              class="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+        </svg>
+        {{ L["admin.discover_services"] }}
+      </button>
+    </form>
+  </div>
+
+  {% if all_services %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
+    {% for svc in all_services %}
+    <div class="flex items-center justify-between px-5 py-3 gap-4 {{ '' if svc.is_enabled else 'opacity-60' }}">
+      <span class="font-medium text-sm {{ 'text-gray-800 dark:text-gray-200' if svc.is_enabled else 'text-gray-500 dark:text-gray-400' }}">
+        {{ svc.service_name }}
+      </span>
+      <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/toggle">
+        <button type="submit"
+                class="text-xs px-2.5 py-1 rounded-lg border transition-colors
+                  {% if svc.is_enabled %}border-gray-200 dark:border-gray-700 text-gray-500 hover:text-red-600 hover:border-red-300 dark:text-gray-400 dark:hover:text-red-400
+                  {% else %}border-emerald-200 dark:border-emerald-800 text-emerald-600 hover:text-emerald-800 hover:border-emerald-400 dark:text-emerald-400{% endif %}">
+          {{ L["admin.service_disable"] if svc.is_enabled else L["admin.service_enable"] }}
+        </button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
+    {{ L["admin.no_known_services"] }}
+    <form method="post" action="/admin/services/refresh" class="inline ml-1">
+      <button type="submit" class="text-blue-600 dark:text-blue-400 hover:underline">{{ L["admin.discover_services"] }}</button>
+    </form>
+  </div>
+  {% endif %}
+</section>
+
 {# ── Dienststatus überschreiben ──────────────────────────────────────────────── #}
 <section class="mb-8">
   <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,9 +13,9 @@
           fontFamily: { sans: ['Inter', 'system-ui', 'sans-serif'] },
           colors: {
             brand: {
-              DEFAULT: '#6B2382',
-              dark:    '#4F1A63',
-              light:   '#8B35A8',
+              DEFAULT: '#005EA8',
+              dark:    '#004A87',
+              light:   '#1A73BE',
             }
           }
         }

--- a/templates/status.html
+++ b/templates/status.html
@@ -91,7 +91,7 @@
 
 {# ── Active incidents ─────────────────────────────────────────────────────────── #}
 {% set has_incidents = data.services | selectattr("active_incidents") | list | length > 0 %}
-<section>
+<section class="mb-6">
   <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
     {{ L["page.incidents_heading"] }}
   </h2>
@@ -106,6 +106,97 @@
     {{ L["page.no_incidents"] }}
   </div>
   {% endif %}
+</section>
+
+{# ── Incident history (last 30 days, collapsed by default) ────────────────────── #}
+<section>
+  <details class="group">
+    <summary class="flex items-center gap-2 cursor-pointer list-none select-none mb-3">
+      <svg class="w-4 h-4 text-gray-400 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+      </svg>
+      <span class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        {{ L["page.history_heading"] }}
+      </span>
+      <span class="text-xs text-gray-400 dark:text-gray-500">&middot; {{ L["page.history_subheading"] }}</span>
+      {% if recent_resolved %}
+      <span class="ml-auto text-xs px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+        {{ recent_resolved | length }}
+      </span>
+      {% endif %}
+    </summary>
+
+    {% if recent_resolved %}
+    <div class="space-y-2">
+      {% for incident in recent_resolved %}
+      <details class="group/item bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+        <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer list-none select-none hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+          <svg class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0 transition-transform group-open/item:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+          </svg>
+          <div class="flex items-center gap-1.5 shrink-0">
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+              {% if incident.classification == 'incident' %}bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400
+              {% else %}bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400{% endif %}">
+              {{ incident_type_label(incident.classification) }}
+            </span>
+            {% if incident.severity %}
+            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{ severity_badge_class(incident.severity) }}">
+              {{ severity_label(incident.severity) }}
+            </span>
+            {% endif %}
+          </div>
+          <span class="text-sm font-medium text-gray-600 dark:text-gray-400 truncate min-w-0">
+            {{ incident.title }}
+          </span>
+          <div class="ml-auto flex items-center gap-3 shrink-0">
+            <span class="text-xs text-gray-400 dark:text-gray-500 hidden sm:block">{{ incident.service_name }}</span>
+            <span class="text-xs px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+              {{ L["incident.resolved"] }}
+            </span>
+            <span class="text-xs text-gray-400 dark:text-gray-500">{{ incident.last_modified | strftime_de }}</span>
+          </div>
+        </summary>
+        <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 pt-3">
+          {% if incident.description %}
+          <div class="text-sm text-gray-600 dark:text-gray-300 mb-3 prose prose-sm dark:prose-invert max-w-none [&_a]:text-blue-600 [&_a]:underline">
+            {{ incident.description | render_md | safe }}
+          </div>
+          {% endif %}
+          {% set note_updates = incident.updates | selectattr("update_type", "equalto", "note") | list %}
+          {% if note_updates %}
+          <div class="space-y-3">
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">{{ L["incident.updates"] }}</p>
+            {% for update in note_updates | reverse %}
+            <div class="flex gap-3">
+              <div class="shrink-0 flex flex-col items-center">
+                <div class="w-2 h-2 rounded-full bg-gray-300 dark:bg-gray-600 mt-1.5"></div>
+                {% if not loop.last %}<div class="w-px flex-1 bg-gray-200 dark:bg-gray-700 my-1"></div>{% endif %}
+              </div>
+              <div class="pb-2 min-w-0">
+                <p class="text-xs text-gray-400 dark:text-gray-500 mb-1">{{ update.post_created_at | strftime_de }}</p>
+                <div class="text-sm text-gray-700 dark:text-gray-300 prose prose-sm dark:prose-invert max-w-none [&_a]:text-blue-600 [&_a]:underline">
+                  {{ update.content | render_md | safe }}
+                </div>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+          {% else %}
+          <p class="text-xs text-gray-400 dark:text-gray-500">
+            {{ L["incident.since"] }}: {{ incident.start_datetime | strftime_de }}
+          </p>
+          {% endif %}
+        </div>
+      </details>
+      {% endfor %}
+    </div>
+    {% else %}
+    <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
+      {{ L["page.history_empty"] }}
+    </div>
+    {% endif %}
+  </details>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Dienstverwaltung im Admin**: Neuer Abschnitt im Admin-Dashboard zeigt alle bekannten M365-Dienste mit Aktivieren/Deaktivieren-Toggle. Aktivierung löst automatischen 90-Tage-Backfill aus Graph API aus.
- **Dienst-Erkennung**: Button „Von Microsoft laden" ruft `healthOverviews` ab und registriert alle zurückgegebenen Dienste (neue als deaktiviert). Der Scheduler entdeckt Dienste nun auch bei jedem regulären Poll automatisch.
- **DB-gesteuerte Dienste**: `MONITORED_SERVICES` Env-Var ist nur noch Initialwert für neue Deployments; der Scheduler liest aktive Dienste aus der DB – Admin-Änderungen greifen sofort.
- **Farbschema**: Navleiste von PYUR-Lila auf Neutral Blue (#005EA8); Statusfarben: Grün (#28a745), Orange (#ffc107), Rot (#dc3545).
- **Container/Image**: umbenannt von `m365-statuspage` → `pyur-statuspage`.

## Test plan

- [ ] Admin-Dashboard zeigt „Dienstverwaltung"-Sektion
- [ ] „Von Microsoft laden" registriert alle Graph-API-Dienste
- [ ] Deaktivieren entfernt Dienst von der Statuspage, Aktivieren fügt ihn wieder hinzu
- [ ] Aktivierung eines neuen Dienstes löst Backfill aus (90-Tage-Balken erscheinen)
- [ ] Navleiste zeigt blaue Farbe (#005EA8)
- [ ] Statusbalken: Grün / Orange / Rot statt Emerald / Amber / Red
- [ ] CI grün

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_