### PR TITLE
feat: incident end_datetime – actual resolution time field

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -45,6 +45,7 @@ async def init_db() -> None:
             "ALTER TABLE incidents ADD COLUMN scheduled_end DATETIME",
             "ALTER TABLE incident_updates ADD COLUMN update_type VARCHAR NOT NULL DEFAULT 'note'",
             "ALTER TABLE incidents ADD COLUMN is_suppressed BOOLEAN NOT NULL DEFAULT 0",
+            "ALTER TABLE incidents ADD COLUMN end_datetime DATETIME",
         ]:
             try:
                 await conn.execute(text(stmt))

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -65,6 +65,7 @@ LABELS: dict[str, str] = {
     "admin.service_label":        "Dienst",
     "admin.classification_label": "Typ",
     "admin.status_label":         "Status",
+    "admin.end_datetime":         "Ende (tatsächlich)",
     "admin.scheduled_start":      "Beginn (geplant)",
     "admin.scheduled_end":        "Ende (geplant)",
     "admin.back":                 "Zurück",

--- a/app/models.py
+++ b/app/models.py
@@ -83,6 +83,7 @@ class Incident(Base):
     source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="graph")
     severity: Mapped[str] = mapped_column(String(32), nullable=False, server_default="")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    end_datetime: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     scheduled_start: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     scheduled_end: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -159,6 +159,7 @@ async def update_incident(
     severity: Annotated[str | None, Form()] = None,
     description: Annotated[str | None, Form()] = None,
     is_resolved: Annotated[str | None, Form()] = None,
+    end_datetime: Annotated[str | None, Form()] = None,
     scheduled_start: Annotated[str | None, Form()] = None,
     scheduled_end: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
@@ -169,12 +170,19 @@ async def update_incident(
     old_resolved = old.is_resolved if old else False
     new_resolved = is_resolved == "on"
 
+    parsed_end = _parse_form_dt(end_datetime)
+    # Auto-set end_datetime to now when marking resolved and no end time was given
+    if new_resolved and not parsed_end and not (old and old.end_datetime):
+        from datetime import datetime as _dt
+        parsed_end = _dt.utcnow()
+
     updates: dict = {
         "title": title,
         "status": status,
         "severity": severity or "",
         "description": description or None,
         "is_resolved": new_resolved,
+        "end_datetime": parsed_end,
     }
     if scheduled_start is not None or scheduled_end is not None:
         updates["scheduled_start"] = _parse_form_dt(scheduled_start)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -173,8 +173,7 @@ async def update_incident(
     parsed_end = _parse_form_dt(end_datetime)
     # Auto-set end_datetime to now when marking resolved and no end time was given
     if new_resolved and not parsed_end and not (old and old.end_datetime):
-        from datetime import datetime as _dt
-        parsed_end = _dt.utcnow()
+        parsed_end = datetime.utcnow()
 
     updates: dict = {
         "title": title,

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -112,6 +112,17 @@
         </div>
         {% endif %}
 
+        {% if incident.classification != "maintenance" %}
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {{ L["admin.end_datetime"] }}
+          </label>
+          <input type="datetime-local" name="end_datetime"
+                 value="{{ incident.end_datetime.strftime('%Y-%m-%dT%H:%M') if incident.end_datetime else '' }}"
+                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+        </div>
+        {% endif %}
+
         <div class="flex items-center gap-3 pt-1">
           <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
             <input type="checkbox" name="is_resolved" value="on"
@@ -184,6 +195,9 @@
 
     <div class="mt-4 text-xs text-gray-400 dark:text-gray-500 space-y-0.5">
       <p>{{ L["incident.since"] }}: {{ incident.start_datetime | strftime_de }}</p>
+      {% if incident.end_datetime %}
+      <p>{{ L["admin.end_datetime"] }}: {{ incident.end_datetime | strftime_de }}</p>
+      {% endif %}
       <p>Quelle: {{ incident.source }}</p>
       <p class="font-mono truncate">ID: {{ incident.graph_issue_id }}</p>
     </div>

--- a/templates/status.html
+++ b/templates/status.html
@@ -154,7 +154,9 @@
             <span class="text-xs px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
               {{ L["incident.resolved"] }}
             </span>
-            <span class="text-xs text-gray-400 dark:text-gray-500">{{ incident.last_modified | strftime_de }}</span>
+            <span class="text-xs text-gray-400 dark:text-gray-500">
+              {{ (incident.end_datetime or incident.last_modified) | strftime_de }}
+            </span>
           </div>
         </summary>
         <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 pt-3">
@@ -185,6 +187,9 @@
           {% else %}
           <p class="text-xs text-gray-400 dark:text-gray-500">
             {{ L["incident.since"] }}: {{ incident.start_datetime | strftime_de }}
+            {% if incident.end_datetime %}
+            &nbsp;·&nbsp;{{ L["admin.end_datetime"] }}: {{ incident.end_datetime | strftime_de }}
+            {% endif %}
           </p>
           {% endif %}
         </div>


### PR DESCRIPTION
## Summary

- New `end_datetime` field on `Incident` (nullable DateTime, DB migration included)
- Admin incident detail form: "Ende (tatsächlich)" datetime picker appears for incidents and advisories
- When marking an incident resolved without setting an end time, `end_datetime` is auto-set to the current UTC timestamp
- Timeline sidebar in admin shows the end time when set
- Public history section ("Kürzlich behoben") displays `end_datetime` as the resolved time (falls back to `last_modified`); expanded detail shows both start and end

## Test plan

- [ ] Open an existing incident in admin → "Ende (tatsächlich)" field visible below Status/Schweregrad
- [ ] Set an end time and save → appears in the timeline sidebar
- [ ] Mark as resolved without setting end time → end_datetime auto-fills to now
- [ ] Public page history section shows the correct end time per incident
- [ ] Maintenance incidents do NOT show the end_datetime field (they use scheduled_end)
- [ ] CI grün

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_