### PR TITLE
feat: delayed Graph API poll after enabling a service

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -60,6 +60,17 @@ async def _backfill_service(service_name: str) -> None:
         logger.exception("Backfill failed for %s", service_name)
 
 
+async def _delayed_poll(delay: float = 8.0) -> None:
+    """Wait briefly, then run a full Graph API poll so the new service appears current."""
+    await asyncio.sleep(delay)
+    try:
+        from app.scheduler import poll_graph_api  # local import avoids circular dep
+        await poll_graph_api()
+        logger.info("Delayed poll completed after enabling service.")
+    except Exception:
+        logger.exception("Delayed poll failed")
+
+
 @router.get("/")
 async def admin_dashboard(
     request: Request,
@@ -246,6 +257,7 @@ async def toggle_service(
 
     if new_state:
         asyncio.create_task(_backfill_service(service_name))
+        asyncio.create_task(_delayed_poll(delay=8.0))
 
     return RedirectResponse(url="/admin", status_code=303)
 


### PR DESCRIPTION
## Summary

When an admin enables a service in Dienstverwaltung, two background tasks now run:

1. **Immediate backfill** – 90-day historical issue data (unchanged)
2. **Delayed poll after 8 s** – full `poll_graph_api()` run that fetches current health overviews and active/recently-resolved incidents for all enabled services, including the one just activated

The 8-second delay ensures:
- The HTTP redirect has completed before the poll starts writing
- The DB commit enabling the service is visible to the poll's session
- The admin can refresh the dashboard ~10 s later and see a live status badge instead of "Keine Daten"

## Test plan

- [ ] Enable a previously disabled service in admin Dienstverwaltung
- [ ] Wait ~10 s, refresh admin dashboard → service shows current status badge
- [ ] No errors in container logs during the delayed poll
- [ ] CI grün

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_