### PR TITLE
fix: incident message display + debounced delayed poll

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -60,15 +60,34 @@ async def _backfill_service(service_name: str) -> None:
         logger.exception("Backfill failed for %s", service_name)
 
 
+# Tracks a pending delayed poll so it can be cancelled and restarted when
+# another service is enabled before the timer fires (debounce behaviour).
+_pending_poll_task: asyncio.Task | None = None
+
+
 async def _delayed_poll(delay: float = 8.0) -> None:
-    """Wait briefly, then run a full Graph API poll so the new service appears current."""
+    """Wait N seconds, then run a full Graph API poll.
+
+    Each call to schedule_delayed_poll() cancels any previous pending task
+    so only one poll fires, 8 s after the *last* service toggle.
+    """
     await asyncio.sleep(delay)
     try:
         from app.scheduler import poll_graph_api  # local import avoids circular dep
         await poll_graph_api()
         logger.info("Delayed poll completed after enabling service.")
+    except asyncio.CancelledError:
+        pass  # task was cancelled because another service was enabled
     except Exception:
         logger.exception("Delayed poll failed")
+
+
+def _schedule_delayed_poll(delay: float = 8.0) -> None:
+    """Cancel any pending delayed poll and start a fresh one."""
+    global _pending_poll_task
+    if _pending_poll_task and not _pending_poll_task.done():
+        _pending_poll_task.cancel()
+    _pending_poll_task = asyncio.create_task(_delayed_poll(delay))
 
 
 @router.get("/")
@@ -257,7 +276,7 @@ async def toggle_service(
 
     if new_state:
         asyncio.create_task(_backfill_service(service_name))
-        asyncio.create_task(_delayed_poll(delay=8.0))
+        _schedule_delayed_poll(delay=8.0)  # debounced: cancels any pending poll first
 
     return RedirectResponse(url="/admin", status_code=303)
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -83,14 +83,11 @@ async def poll_graph_api() -> None:
             await db.rollback()
             logger.exception("Health overview poll failed")
 
-    # ── Phase 2: Active + recently resolved incidents ────────────────────────────
+    # ── Phase 2: Active incidents (independent – failure here doesn't touch phase 3) ──
     async with AsyncSessionLocal() as db:
         try:
             active_issues = await fetch_active_issues()
-            resolved_issues = await fetch_recently_resolved_issues(days=30)
-            all_issues = active_issues + resolved_issues
-
-            for issue in all_issues:
+            for issue in active_issues:
                 if issue.get("service") not in monitored:
                     continue
                 severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
@@ -106,19 +103,41 @@ async def poll_graph_api() -> None:
                     is_resolved=issue.get("isResolved", False),
                     severity=severity,
                 )
-                posts = issue.get("posts", [])
+                posts = issue.get("posts") or []
                 await upsert_incident_updates(db, incident.id, posts)
-
             await db.commit()
-            logger.info(
-                "Graph API poll completed: %d active, %d recently resolved.",
-                len(active_issues),
-                len(resolved_issues),
-            )
-
+            logger.info("Active issues committed: %d processed.", len(active_issues))
         except Exception:
             await db.rollback()
-            logger.exception("Issues poll failed")
+            logger.exception("Active issues poll failed")
+
+    # ── Phase 3: Recently resolved (30 days) – independent, safe to fail ────────
+    async with AsyncSessionLocal() as db:
+        try:
+            resolved_issues = await fetch_recently_resolved_issues(days=30)
+            for issue in resolved_issues:
+                if issue.get("service") not in monitored:
+                    continue
+                severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
+                incident = await upsert_incident(
+                    db,
+                    graph_issue_id=issue["id"],
+                    title=issue.get("title", ""),
+                    service_name=issue.get("service", ""),
+                    classification=issue.get("classification", "incident"),
+                    status="resolved" if issue.get("isResolved") else "active",
+                    start_datetime=_parse_dt(issue.get("startDateTime")),
+                    last_modified=_parse_dt(issue.get("lastModifiedDateTime")),
+                    is_resolved=issue.get("isResolved", False),
+                    severity=severity,
+                )
+                posts = issue.get("posts") or []
+                await upsert_incident_updates(db, incident.id, posts)
+            await db.commit()
+            logger.info("Recently resolved issues committed: %d processed.", len(resolved_issues))
+        except Exception:
+            await db.rollback()
+            logger.exception("Recently resolved issues poll failed – active issues unaffected")
 
 
 def start_scheduler() -> None:


### PR DESCRIPTION
## Root cause – messages not showing

Phase 2 of `poll_graph_api` fetched **both** active and recently-resolved issues inside a single `try/except` block and a single DB session. If `fetch_recently_resolved_issues` raised an exception (e.g. the Graph API returned an error for the combined OData filter), **the entire block was rolled back** — including the active incident posts that had already been written. On the next poll the same thing happened again, so posts were never committed.

## Fixes

### Scheduler – isolated phases
- **Phase 2** now handles only active issues (own session + try/except)
- **Phase 3** handles recently-resolved issues (own session + try/except)
- A failure in phase 3 no longer affects phase 2 in any way
- `issue.get("posts") or []` replaces `issue.get("posts", [])` to guard against the API returning an explicit `null`

### Admin – debounced delayed poll
`_schedule_delayed_poll()` cancels any pending delayed-poll task before creating a new one. Enabling 3 services in quick succession now fires a **single** poll 8 s after the last toggle instead of 3 overlapping polls.

## Test plan
- [ ] Enable a service → posts from Graph API appear on the incident cards after the next poll
- [ ] Enable 3 services within a few seconds → only one poll runs ~8 s after the last toggle (check logs)
- [ ] Deliberately break `fetch_recently_resolved_issues` (e.g. bad filter) → active incidents still update correctly
- [ ] CI grün

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_