### PR TITLE
feat: admin sidebar with Einstellungen, Debug tabs and service management page

### DIFF
--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -75,12 +75,18 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
 
 
 async def fetch_recently_resolved_issues(days: int = 30) -> list[dict]:
-    """Returns resolved issues whose lastModifiedDateTime is within the past N days."""
+    """Returns resolved issues that started within the past N days.
+
+    The Graph API does not support filtering on lastModifiedDateTime, so we
+    filter on startDateTime (a supported property) and accept that a small
+    number of long-running incidents resolved just inside the window may be
+    missed while keeping the query valid.
+    """
     token = await _get_access_token()
     since = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00Z")
     base_url = (
         f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
-        f"?$filter=isResolved eq true and lastModifiedDateTime ge {since}"
+        f"?$filter=isResolved eq true and startDateTime ge {since}"
         f"&$expand=posts"
         f"&$top=100"
     )

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -30,7 +30,12 @@ from app.crud import (
 )
 from app.database import AsyncSessionLocal
 from app.dependencies import get_db
-from app.graph_client import fetch_health_overviews, fetch_issues_since
+from app.graph_client import (
+    fetch_active_issues,
+    fetch_health_overviews,
+    fetch_issues_since,
+    fetch_recently_resolved_issues,
+)
 from app.models import MonitoredService
 from app.templates import templates
 
@@ -100,8 +105,7 @@ async def admin_dashboard(
     resolved = await get_resolved_incidents(db, limit=10)
     suppressed = await get_suppressed_incidents(db)
     maintenances = await get_scheduled_maintenances(db)
-    all_services = await get_all_monitored_services(db)
-    enabled_services = [s.service_name for s in all_services if s.is_enabled]
+    enabled_services = await get_enabled_services(db)
     return templates.TemplateResponse(
         request,
         "admin/dashboard.html",
@@ -111,9 +115,26 @@ async def admin_dashboard(
             "resolved_incidents": resolved,
             "suppressed_incidents": suppressed,
             "maintenances": maintenances,
-            "all_services": all_services,
             "services": enabled_services,
             "page_title": f"Admin – {settings.APP_TITLE}",
+        },
+    )
+
+
+@router.get("/settings")
+async def admin_settings(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    all_services = await get_all_monitored_services(db)
+    return templates.TemplateResponse(
+        request,
+        "admin/settings.html",
+        {
+            "user": user,
+            "all_services": all_services,
+            "page_title": f"Einstellungen – {settings.APP_TITLE}",
         },
     )
 
@@ -255,7 +276,7 @@ async def refresh_services(
         await db.commit()
     except Exception:
         logger.exception("Service discovery failed")
-    return RedirectResponse(url="/admin", status_code=303)
+    return RedirectResponse(url="/admin/settings", status_code=303)
 
 
 @router.post("/services/{service_name}/toggle")
@@ -278,7 +299,7 @@ async def toggle_service(
         asyncio.create_task(_backfill_service(service_name))
         _schedule_delayed_poll(delay=8.0)  # debounced: cancels any pending poll first
 
-    return RedirectResponse(url="/admin", status_code=303)
+    return RedirectResponse(url="/admin/settings", status_code=303)
 
 
 @router.post("/services/{service_name}/status")
@@ -355,3 +376,70 @@ async def create_maintenance(
     )
     await db.commit()
     return RedirectResponse(url=f"/admin/incidents/{incident.id}", status_code=303)
+
+
+# ── Debug / Diagnostics ───────────────────────────────────────────────────────
+
+@router.get("/debug")
+async def debug_page(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    enabled = await get_enabled_services(db)
+    return templates.TemplateResponse(
+        request,
+        "admin/debug.html",
+        {
+            "user": user,
+            "enabled_services": set(enabled),
+            "active_issues": None,
+            "resolved_issues": None,
+            "overviews": None,
+            "errors": [],
+            "page_title": "Debug – Graph API",
+        },
+    )
+
+
+@router.post("/debug/fetch")
+async def debug_fetch(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    """Live-fetch all Microsoft service health data and display raw results."""
+    enabled = await get_enabled_services(db)
+    errors: list[str] = []
+    overviews: list[dict] = []
+    active_issues: list[dict] = []
+    resolved_issues: list[dict] = []
+
+    try:
+        overviews = await fetch_health_overviews()
+    except Exception as exc:
+        errors.append(f"Health Overviews: {exc}")
+
+    try:
+        active_issues = await fetch_active_issues()
+    except Exception as exc:
+        errors.append(f"Aktive Störungen: {exc}")
+
+    try:
+        resolved_issues = await fetch_recently_resolved_issues(days=30)
+    except Exception as exc:
+        errors.append(f"Kürzlich behoben: {exc}")
+
+    return templates.TemplateResponse(
+        request,
+        "admin/debug.html",
+        {
+            "user": user,
+            "enabled_services": set(enabled),
+            "overviews": overviews,
+            "active_issues": active_issues,
+            "resolved_issues": resolved_issues,
+            "errors": errors,
+            "page_title": "Debug – Graph API",
+        },
+    )

--- a/templates/admin/base_admin.html
+++ b/templates/admin/base_admin.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block container_class %}max-w-6xl{% endblock %}
+
+{% block content %}
+<div class="flex gap-6 items-start">
+
+  {# ── Main content area ────────────────────────────────────────── #}
+  <div class="flex-1 min-w-0">
+    {% block admin_content %}{% endblock %}
+  </div>
+
+  {# ── Right sidebar navigation ──────────────────────────────────── #}
+  <aside class="w-44 shrink-0 sticky top-20">
+    <nav class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+      <div class="px-2 pt-3 pb-2 space-y-0.5">
+        <p class="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 px-2 pb-1">Admin</p>
+
+        {# Allgemein #}
+        <a href="/admin"
+           class="flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors
+             {% if request.url.path == '/admin' %}bg-blue-50 text-[#005EA8] dark:bg-blue-950/30 dark:text-blue-300 font-medium
+             {% else %}text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200{% endif %}">
+          <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h8M4 18h16"/>
+          </svg>
+          Allgemein
+        </a>
+
+        {# Einstellungen #}
+        <a href="/admin/settings"
+           class="flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors
+             {% if request.url.path == '/admin/settings' %}bg-blue-50 text-[#005EA8] dark:bg-blue-950/30 dark:text-blue-300 font-medium
+             {% else %}text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200{% endif %}">
+          <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
+          </svg>
+          Einstellungen
+        </a>
+
+        {# Debug #}
+        <a href="/admin/debug"
+           class="flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors
+             {% if request.url.path.startswith('/admin/debug') %}bg-blue-50 text-[#005EA8] dark:bg-blue-950/30 dark:text-blue-300 font-medium
+             {% else %}text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200{% endif %}">
+          <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"/>
+          </svg>
+          Debug
+        </a>
+      </div>
+    </nav>
+  </aside>
+
+</div>
+{% endblock %}

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,6 +1,6 @@
-{% extends "base.html" %}
+{% extends "admin/base_admin.html" %}
 
-{% block content %}
+{% block admin_content %}
 <div class="mb-6 flex items-center justify-between">
   <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ L["admin.dashboard"] }}</h1>
   <div class="flex gap-2">
@@ -20,51 +20,6 @@
     </a>
   </div>
 </div>
-
-{# ── Dienstverwaltung ────────────────────────────────────────────────────────── #}
-<section class="mb-8">
-  <div class="flex items-center justify-between mb-3">
-    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
-      {{ L["admin.service_management"] }}
-    </h2>
-    <form method="post" action="/admin/services/refresh">
-      <button type="submit"
-              class="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
-        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
-        </svg>
-        {{ L["admin.discover_services"] }}
-      </button>
-    </form>
-  </div>
-
-  {% if all_services %}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
-    {% for svc in all_services %}
-    <div class="flex items-center justify-between px-5 py-3 gap-4 {{ '' if svc.is_enabled else 'opacity-60' }}">
-      <span class="font-medium text-sm {{ 'text-gray-800 dark:text-gray-200' if svc.is_enabled else 'text-gray-500 dark:text-gray-400' }}">
-        {{ svc.service_name }}
-      </span>
-      <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/toggle">
-        <button type="submit"
-                class="text-xs px-2.5 py-1 rounded-lg border transition-colors
-                  {% if svc.is_enabled %}border-gray-200 dark:border-gray-700 text-gray-500 hover:text-red-600 hover:border-red-300 dark:text-gray-400 dark:hover:text-red-400
-                  {% else %}border-emerald-200 dark:border-emerald-800 text-emerald-600 hover:text-emerald-800 hover:border-emerald-400 dark:text-emerald-400{% endif %}">
-          {{ L["admin.service_disable"] if svc.is_enabled else L["admin.service_enable"] }}
-        </button>
-      </form>
-    </div>
-    {% endfor %}
-  </div>
-  {% else %}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
-    {{ L["admin.no_known_services"] }}
-    <form method="post" action="/admin/services/refresh" class="inline ml-1">
-      <button type="submit" class="text-blue-600 dark:text-blue-400 hover:underline">{{ L["admin.discover_services"] }}</button>
-    </form>
-  </div>
-  {% endif %}
-</section>
 
 {# ── Dienststatus überschreiben ──────────────────────────────────────────────── #}
 <section class="mb-8">

--- a/templates/admin/debug.html
+++ b/templates/admin/debug.html
@@ -1,0 +1,221 @@
+{% extends "admin/base_admin.html" %}
+
+{% block admin_content %}
+<div class="mb-6">
+  <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Debug – Microsoft Graph API</h1>
+</div>
+
+{# ── Fetch button ─────────────────────────────────────────────────────────── #}
+<form method="post" action="/admin/debug/fetch" class="mb-8">
+  <button type="submit"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gray-900 hover:bg-gray-700 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium transition-colors">
+    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+    </svg>
+    Alle Microsoft Meldungen abrufen
+  </button>
+  <span class="text-xs text-gray-400 dark:text-gray-500 ml-3">Ruft live von Graph API ab – alle Dienste, ungefiltert</span>
+</form>
+
+{# ── Errors ───────────────────────────────────────────────────────────────── #}
+{% if errors %}
+<div class="mb-6 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-2xl px-5 py-4">
+  <p class="text-sm font-medium text-red-800 dark:text-red-300 mb-1">API-Fehler</p>
+  {% for err in errors %}
+  <p class="text-sm text-red-700 dark:text-red-400 font-mono">{{ err }}</p>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if active_issues is not none or resolved_issues is not none or overviews is not none %}
+
+{# ── Health Overviews ─────────────────────────────────────────────────────── #}
+{% if overviews is not none %}
+<section class="mb-8">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+    Dienst-Status (healthOverviews) — {{ overviews | length }} Dienste
+  </h2>
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-gray-100 dark:border-gray-800 text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wide">
+          <th class="px-4 py-2.5 text-left">Dienst</th>
+          <th class="px-4 py-2.5 text-left">Graph-Status</th>
+          <th class="px-4 py-2.5 text-left">Gemappt</th>
+          <th class="px-4 py-2.5 text-left">Überwacht</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-100 dark:divide-gray-800">
+        {% for svc in overviews | sort(attribute="service") %}
+        {% set raw = svc.get("status", "?") %}
+        {% set mapped = {"serviceOperational": "operational", "serviceRestored": "operational", "serviceInformation": "operational", "degradedPerformance": "degraded", "serviceDegradation": "degraded", "extendedRecovery": "degraded", "investigationSuspended": "degraded", "serviceInterruption": "interrupted", "restoringService": "interrupted", "falsePositive": "operational"}.get(raw, "unknown") %}
+        <tr class="{{ 'bg-blue-50/40 dark:bg-blue-950/10' if svc.get('service') in enabled_services else '' }}">
+          <td class="px-4 py-2.5 font-medium text-gray-800 dark:text-gray-200">{{ svc.get("service", "?") }}</td>
+          <td class="px-4 py-2.5 font-mono text-xs text-gray-500 dark:text-gray-400">{{ raw }}</td>
+          <td class="px-4 py-2.5">
+            <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium
+              {% if mapped == 'operational' %}bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-400
+              {% elif mapped == 'degraded' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
+              {% elif mapped == 'interrupted' %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400
+              {% else %}bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400{% endif %}">
+              {{ mapped }}
+            </span>
+          </td>
+          <td class="px-4 py-2.5">
+            {% if svc.get("service") in enabled_services %}
+            <span class="text-xs px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">aktiv</span>
+            {% else %}
+            <span class="text-xs text-gray-400 dark:text-gray-600">—</span>
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endif %}
+
+{# ── Active Issues ────────────────────────────────────────────────────────── #}
+{% if active_issues is not none %}
+<section class="mb-8">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+    Aktive Störungen — {{ active_issues | length }} Meldungen
+  </h2>
+  {% if active_issues %}
+  <div class="space-y-2">
+    {% for issue in active_issues | sort(attribute="service") %}
+    <details class="group bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden {{ 'border-l-4 border-l-blue-400' if issue.get('service') in enabled_services else 'opacity-60' }}">
+      <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer list-none select-none hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+        <svg class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+        </svg>
+        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full shrink-0
+          {% if issue.get('classification') == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
+          {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
+          {{ issue.get("classification", "?") }}
+        </span>
+        {% if issue.get("severity") %}
+        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full shrink-0
+          {% if issue.get('severity') == 'major' %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400
+          {% elif issue.get('severity') == 'moderate' %}bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-400
+          {% else %}bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-400{% endif %}">
+          {{ issue.get("severity") }}
+        </span>
+        {% endif %}
+        <div class="min-w-0 flex-1">
+          <span class="text-sm font-medium text-gray-800 dark:text-gray-200 truncate block">{{ issue.get("title", "?") }}</span>
+        </div>
+        <div class="shrink-0 flex items-center gap-3 text-xs text-gray-400 dark:text-gray-500">
+          <span>{{ issue.get("service", "?") }}</span>
+          {% if issue.get("service") in enabled_services %}
+          <span class="px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">überwacht</span>
+          {% endif %}
+          <span>{{ (issue.get("posts") or []) | length }} Posts</span>
+          <span class="font-mono">{{ issue.get("id", "") }}</span>
+        </div>
+      </summary>
+      <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 pt-3 space-y-2">
+        <div class="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+          <span><span class="font-medium">Start:</span> {{ issue.get("startDateTime", "—") }}</span>
+          <span><span class="font-medium">Geändert:</span> {{ issue.get("lastModifiedDateTime", "—") }}</span>
+          <span><span class="font-medium">Status:</span> {{ issue.get("status", "—") }}</span>
+          <span><span class="font-medium">Feature:</span> {{ issue.get("feature", "—") }}</span>
+        </div>
+        {% set posts = issue.get("posts") or [] %}
+        {% if posts %}
+        <div class="mt-3 space-y-2">
+          <p class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Posts ({{ posts | length }})</p>
+          {% for post in posts %}
+          <div class="bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-2">
+            <p class="text-xs text-gray-400 dark:text-gray-500 mb-1">{{ post.get("createdDateTime", "—") }} · {{ post.get("postType", "") }}</p>
+            <div class="text-xs text-gray-700 dark:text-gray-300 font-mono break-all">
+              {{ (post.get("description") or {}).get("content", "—")[:500] }}{% if (post.get("description") or {}).get("content", "") | length > 500 %}…{% endif %}
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+    </details>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-400 dark:text-gray-500 shadow-sm">
+    Keine aktiven Störungen bei Microsoft gemeldet.
+  </div>
+  {% endif %}
+</section>
+{% endif %}
+
+{# ── Recently Resolved ────────────────────────────────────────────────────── #}
+{% if resolved_issues is not none %}
+<section>
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+    Kürzlich behoben (30 Tage) — {{ resolved_issues | length }} Meldungen
+  </h2>
+  {% if resolved_issues %}
+  <div class="space-y-2 opacity-80">
+    {% for issue in resolved_issues | sort(attribute="service") %}
+    <details class="group bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden {{ 'border-l-4 border-l-blue-400' if issue.get('service') in enabled_services else '' }}">
+      <summary class="flex items-center gap-3 px-4 py-2.5 cursor-pointer list-none select-none hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+        <svg class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+        </svg>
+        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full shrink-0
+          {% if issue.get('classification') == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
+          {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
+          {{ issue.get("classification", "?") }}
+        </span>
+        <span class="text-sm text-gray-600 dark:text-gray-400 truncate min-w-0 flex-1">{{ issue.get("title", "?") }}</span>
+        <div class="shrink-0 flex items-center gap-3 text-xs text-gray-400 dark:text-gray-500">
+          <span>{{ issue.get("service", "?") }}</span>
+          {% if issue.get("service") in enabled_services %}
+          <span class="px-1.5 py-0.5 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">überwacht</span>
+          {% endif %}
+          <span class="px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">behoben</span>
+          <span>{{ (issue.get("posts") or []) | length }} Posts</span>
+          <span class="font-mono">{{ issue.get("id", "") }}</span>
+        </div>
+      </summary>
+      <div class="px-4 pb-4 border-t border-gray-100 dark:border-gray-800 pt-3 space-y-2">
+        <div class="grid grid-cols-2 gap-x-6 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+          <span><span class="font-medium">Start:</span> {{ issue.get("startDateTime", "—") }}</span>
+          <span><span class="font-medium">Behoben:</span> {{ issue.get("lastModifiedDateTime", "—") }}</span>
+          <span><span class="font-medium">Status:</span> {{ issue.get("status", "—") }}</span>
+          <span><span class="font-medium">Feature:</span> {{ issue.get("feature", "—") }}</span>
+        </div>
+        {% set posts = issue.get("posts") or [] %}
+        {% if posts %}
+        <div class="mt-3 space-y-2">
+          <p class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">Posts ({{ posts | length }})</p>
+          {% for post in posts %}
+          <div class="bg-gray-50 dark:bg-gray-800 rounded-lg px-3 py-2">
+            <p class="text-xs text-gray-400 dark:text-gray-500 mb-1">{{ post.get("createdDateTime", "—") }} · {{ post.get("postType", "") }}</p>
+            <div class="text-xs text-gray-700 dark:text-gray-300 font-mono break-all">
+              {{ (post.get("description") or {}).get("content", "—")[:500] }}{% if (post.get("description") or {}).get("content", "") | length > 500 %}…{% endif %}
+            </div>
+          </div>
+          {% endfor %}
+        </div>
+        {% endif %}
+      </div>
+    </details>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-400 dark:text-gray-500 shadow-sm">
+    Keine behobenen Störungen in den letzten 30 Tagen.
+  </div>
+  {% endif %}
+</section>
+{% endif %}
+
+{% else %}
+{# ── Placeholder before first fetch ──────────────────────────────────────── #}
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-12 text-center shadow-sm">
+  <p class="text-gray-400 dark:text-gray-500 text-sm">Noch keine Daten abgerufen. Klicke auf „Alle Microsoft Meldungen abrufen".</p>
+</div>
+{% endif %}
+
+{% endblock admin_content %}

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -1,0 +1,55 @@
+{% extends "admin/base_admin.html" %}
+
+{% block admin_content %}
+<div class="mb-6">
+  <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Einstellungen</h1>
+</div>
+
+{# ── Dienstverwaltung ────────────────────────────────────────────────────────── #}
+<section class="mb-8">
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {{ L["admin.service_management"] }}
+    </h2>
+    <form method="post" action="/admin/services/refresh">
+      <button type="submit"
+              class="inline-flex items-center gap-1.5 text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+        <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
+        </svg>
+        {{ L["admin.discover_services"] }}
+      </button>
+    </form>
+  </div>
+
+  <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">{{ L["admin.service_backfill_hint"] }}</p>
+
+  {% if all_services %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
+    {% for svc in all_services %}
+    <div class="flex items-center justify-between px-5 py-3 gap-4 {{ '' if svc.is_enabled else 'opacity-60' }}">
+      <span class="font-medium text-sm {{ 'text-gray-800 dark:text-gray-200' if svc.is_enabled else 'text-gray-500 dark:text-gray-400' }}">
+        {{ svc.service_name }}
+      </span>
+      <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/toggle">
+        <button type="submit"
+                class="text-xs px-2.5 py-1 rounded-lg border transition-colors
+                  {% if svc.is_enabled %}border-gray-200 dark:border-gray-700 text-gray-500 hover:text-red-600 hover:border-red-300 dark:text-gray-400 dark:hover:text-red-400
+                  {% else %}border-emerald-200 dark:border-emerald-800 text-emerald-600 hover:text-emerald-800 hover:border-emerald-400 dark:text-emerald-400{% endif %}">
+          {{ L["admin.service_disable"] if svc.is_enabled else L["admin.service_enable"] }}
+        </button>
+      </form>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
+    {{ L["admin.no_known_services"] }}
+    <form method="post" action="/admin/services/refresh" class="inline ml-1">
+      <button type="submit" class="text-blue-600 dark:text-blue-400 hover:underline">{{ L["admin.discover_services"] }}</button>
+    </form>
+  </div>
+  {% endif %}
+</section>
+
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -82,7 +82,7 @@
   </nav>
 
   <!-- Main content -->
-  <main class="max-w-4xl mx-auto px-4 sm:px-6 py-8">
+  <main class="{% block container_class %}max-w-4xl{% endblock %} mx-auto px-4 sm:px-6 py-8">
     {% block content %}{% endblock %}
   </main>
 


### PR DESCRIPTION
## Summary

- Add right-sidebar navigation to admin area (Allgemein / Einstellungen / Debug)
- Move Dienstverwaltung (service enable/disable toggles) to new `/admin/settings` page (Einstellungen tab)
- Add `/admin/debug` page for live Graph API inspection — live-fetch all Microsoft service health messages unfiltered
- Dashboard (Allgemein) keeps: status override, active incidents, resolved, suppressed, maintenances
- Widen admin area to `max-w-6xl` via `{% block container_class %}` in `base.html`
- Service refresh and toggle actions redirect back to `/admin/settings`
- Active sidebar item is highlighted with brand blue

## Test plan

- [ ] `/admin` shows sidebar with "Allgemein" highlighted; Dienstverwaltung no longer on this page
- [ ] `/admin/settings` shows sidebar with "Einstellungen" highlighted; service toggle/refresh redirects back here
- [ ] `/admin/debug` shows sidebar with "Debug" highlighted; "Abrufen" button fetches live Graph API data
- [ ] Sidebar links work from all three pages
- [ ] Dark mode renders correctly across all three pages

https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANdPV9Y1CS9M3wdrJU4CZ)_