### PR TITLE
fix(admin): keep sidebar on detail pages, drop resolved list, show severity in suppressed

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -86,34 +86,6 @@
   {% endif %}
 </section>
 
-{# ── Kürzlich behoben ────────────────────────────────────────────────────────── #}
-{% if resolved_incidents %}
-<section class="mb-8">
-  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
-    Kürzlich behoben
-  </h2>
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden opacity-70">
-    {% for inc in resolved_incidents %}
-    <a href="/admin/incidents/{{ inc.id }}"
-       class="flex items-center justify-between px-5 py-3 hover:bg-gray-50 dark:hover:bg-gray-800/50 hover:opacity-100 transition-colors group">
-      <div>
-        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
-          {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
-          {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
-          {{ incident_type_label(inc.classification) }}
-        </span>
-        <span class="font-medium text-sm text-gray-600 dark:text-gray-400 line-through decoration-gray-300 dark:decoration-gray-600">{{ inc.title }}</span>
-        <span class="text-xs text-gray-400 dark:text-gray-500 ml-2">{{ inc.last_modified | strftime_de }}</span>
-      </div>
-      <span class="text-xs px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 shrink-0">
-        {{ L["incident.resolved"] }}
-      </span>
-    </a>
-    {% endfor %}
-  </div>
-</section>
-{% endif %}
-
 {# ── Ignorierte Meldungen ────────────────────────────────────────────────────── #}
 <section class="mb-8">
   <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
@@ -122,16 +94,19 @@
   {% if suppressed_incidents %}
   <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden opacity-60">
     {% for inc in suppressed_incidents %}
-    <div class="flex items-center justify-between px-5 py-3">
-      <div class="min-w-0 flex-1">
+    <div class="flex items-center justify-between px-5 py-3 group">
+      <a href="/admin/incidents/{{ inc.id }}" class="flex-1 flex items-center gap-0 min-w-0 hover:opacity-80 transition-opacity">
         <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
           {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
           {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
           {{ incident_type_label(inc.classification) }}
         </span>
-        <span class="text-sm text-gray-500 dark:text-gray-400 line-through decoration-gray-300 dark:decoration-gray-600">{{ inc.title }}</span>
-        <span class="text-xs text-gray-400 dark:text-gray-500 ml-2">· {{ inc.service_name }}</span>
-      </div>
+        {% if inc.severity %}
+        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5 {{ severity_badge_class(inc.severity) }}">{{ severity_label(inc.severity) }}</span>
+        {% endif %}
+        <span class="text-sm text-gray-500 dark:text-gray-400 line-through decoration-gray-300 dark:decoration-gray-600 truncate">{{ inc.title }}</span>
+        <span class="text-xs text-gray-400 dark:text-gray-500 ml-2 shrink-0">· {{ inc.service_name }}</span>
+      </a>
       <form method="post" action="/admin/incidents/{{ inc.id }}/unsuppress" class="ml-3 shrink-0">
         <button type="submit"
                 class="text-xs px-2.5 py-1 rounded-lg border border-emerald-200 dark:border-emerald-800 text-emerald-600 hover:text-emerald-800 hover:border-emerald-400 dark:text-emerald-400 transition-colors">

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -1,6 +1,6 @@
-{% extends "base.html" %}
+{% extends "admin/base_admin.html" %}
 
-{% block content %}
+{% block admin_content %}
 <div class="mb-6 flex items-center gap-3">
   <a href="/admin" class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
     ← {{ L["admin.back"] }}

--- a/templates/admin/incident_form.html
+++ b/templates/admin/incident_form.html
@@ -1,6 +1,6 @@
-{% extends "base.html" %}
+{% extends "admin/base_admin.html" %}
 
-{% block content %}
+{% block admin_content %}
 <div class="mb-6 flex items-center gap-3">
   <a href="/admin" class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
     ← {{ L["admin.back"] }}

--- a/templates/admin/maintenance_form.html
+++ b/templates/admin/maintenance_form.html
@@ -1,6 +1,6 @@
-{% extends "base.html" %}
+{% extends "admin/base_admin.html" %}
 
-{% block content %}
+{% block admin_content %}
 <div class="mb-6 flex items-center gap-3">
   <a href="/admin" class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
     ← {{ L["admin.back"] }}


### PR DESCRIPTION
## Behebt drei Punkte im Admin-Bereich

1. **Adminwindows zurück möglichkeit fehl** — `incident_detail.html`, `incident_form.html` und `maintenance_form.html` erweitern jetzt `admin/base_admin.html` statt `base.html`, damit die rechte Admin-Sidebar (Allgemein/Einstellungen/Debug) auf Detail- und Formularseiten erhalten bleibt und ein klarer Rückweg existiert.
2. **Kürzlich behobene Störungen aus dem Admin entfernen** — Der Abschnitt „Kürzlich behoben" auf dem Admin-Dashboard wurde entfernt. Behobene Vorfälle sind weiterhin auf der öffentlichen Status-Seite im Verlauf einsehbar.
3. **Severity fehlt in der Übersicht** — In „Ignorierte Meldungen" werden jetzt Severity-Badge angezeigt, und jede Zeile verlinkt auf die Detailseite (Beschreibung & weitere Details).

## Test plan
- [ ] Admin-Dashboard öffnen: kein „Kürzlich behoben" Abschnitt mehr
- [ ] Auf eine Störung klicken: Admin-Sidebar bleibt sichtbar, Navigation zwischen Allgemein/Einstellungen/Debug möglich
- [ ] „Neue Störung"/„Neue Wartung" öffnen: Sidebar bleibt sichtbar
- [ ] Eine Störung unterdrücken: in „Ignorierte Meldungen" wird Severity-Badge angezeigt, Klick öffnet Detail

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnnAAHHyCE6F1y1rbZyoBt)_