### PR TITLE
Backfill 90-day service history from Graph API on poll

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -113,6 +113,24 @@ async def upsert_incident_updates(
         )
 
 
+async def count_status_days_in_window(
+    db: AsyncSession,
+    service_name: str,
+    days: int = 90,
+) -> int:
+    from sqlalchemy import func
+    today = date.today()
+    start_date = today - timedelta(days=days - 1)
+    result = await db.execute(
+        select(func.count(ServiceStatus.id)).where(
+            ServiceStatus.service_name == service_name,
+            ServiceStatus.date >= start_date,
+            ServiceStatus.date <= today,
+        )
+    )
+    return int(result.scalar_one() or 0)
+
+
 async def get_uptime_bars(
     db: AsyncSession,
     service_name: str,

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -6,6 +6,8 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import settings
 from app.crud import (
+    backfill_service_status_from_issues,
+    count_status_days_in_window,
     ensure_service_known,
     get_enabled_services,
     upsert_incident,
@@ -16,6 +18,7 @@ from app.database import AsyncSessionLocal
 from app.graph_client import (
     fetch_active_issues,
     fetch_health_overviews,
+    fetch_issues_since,
     fetch_recently_resolved_issues,
 )
 from app.models import GRAPH_STATUS_MAP
@@ -173,6 +176,28 @@ async def poll_graph_api() -> None:
         except Exception:
             await db.rollback()
             logger.exception("Recently resolved issues poll failed – active issues unaffected")
+
+    # ── Phase 4: 90-day history backfill (only if gaps exist) ───────────────────
+    # After a container restart with a fresh volume, service_status is empty and
+    # the 90-day uptime bars show "no_data". Reconstruct missing days from the
+    # Graph API issue history: days with no incident → operational; days covered
+    # by an incident → degraded/interrupted.
+    for name in monitored:
+        async with AsyncSessionLocal() as db:
+            try:
+                existing = await count_status_days_in_window(db, name, days=90)
+                if existing >= 90:
+                    continue
+                issues = await fetch_issues_since(name, days=90)
+                await backfill_service_status_from_issues(db, name, issues, days=90)
+                await db.commit()
+                logger.info(
+                    "Backfill committed for %s: %d issues, filled %d missing days.",
+                    name, len(issues), 90 - existing,
+                )
+            except Exception:
+                await db.rollback()
+                logger.exception("Backfill failed for %s", name)
 
 
 def start_scheduler() -> None:


### PR DESCRIPTION
## Problem

Nach einem Container-Neustart mit frischem Volume war die 90-Tage-Verlaufsleiste pro Dienst leer (`no_data`), weil `service_status` nur einen Eintrag pro Tag durch den 10-min-Poll erhält. Es gab bereits eine `backfill_service_status_from_issues`-Funktion sowie einen Admin-Trigger, aber kein automatisches Auffüllen beim Start.

## Änderung

- Neue Phase 4 in `poll_graph_api`: Pro überwachtem Dienst wird geprüft, ob im 90-Tage-Fenster noch Tage fehlen. Falls ja, werden via `fetch_issues_since(service_name, days=90)` die Incidents der letzten 90 Tage aus `/admin/serviceAnnouncement/issues` geladen und über `backfill_service_status_from_issues` eingespielt:
  - Tage ohne Incident → `operational`
  - Tage mit Incident → `degraded` (advisory/maintenance) bzw. `interrupted` (incident)
  - `raw_graph_status` wird auf `"backfill"` gesetzt, damit reale Polldaten klar unterscheidbar bleiben.
- Neue Helper `count_status_days_in_window` in `crud.py`, damit der Backfill nur dann tatsächlich Graph-Calls macht, wenn die Historie nicht bereits vollständig ist. Sobald alle 90 Tage existieren, überspringt der Poll diese Phase ohne Extra-API-Aufruf.
- Backfill ist idempotent: Tage, für die bereits ein echter Status vorliegt, werden nicht überschrieben.

## Test plan

- [ ] Mit leerem Volume starten — Verlaufsbalken zeigen nach erstem Poll grüne/rote Felder statt `no_data`.
- [ ] Logs zeigen `Backfill committed for <service>: N issues, filled M missing days.`
- [ ] Zweiter Poll innerhalb derselben Session überspringt Phase 4 (kein zusätzlicher Graph-Call).
- [ ] Manueller Status für „heute" bleibt nach Backfill erhalten.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab8AnwUQE2NofVpXrqwYaB)_