### PR TITLE
fix: backfill OData filter, uptime % position, version visibility

### DIFF
--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from urllib.parse import quote
 
 import httpx
 import msal
@@ -82,10 +81,9 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
     """Fetch all issues (including resolved) for a service over the past N days, for backfill."""
     token = await _get_access_token()
     since = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00Z")
-    name_encoded = quote(service_name, safe="")
     base_url = (
         f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
-        f"?$filter=service eq '{name_encoded}' and startDateTime ge {since}"
+        f"?$filter=service eq '{service_name}' and startDateTime ge {since}"
         f"&$select=id,service,classification,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity"
         f"&$top=100"
     )

--- a/templates/admin/base_admin.html
+++ b/templates/admin/base_admin.html
@@ -50,7 +50,7 @@
         </a>
       </div>
     </nav>
-    <p class="text-[10px] text-gray-300 dark:text-gray-600 text-right mt-2 pr-1 select-none">
+    <p class="text-[10px] text-gray-400 dark:text-gray-500 text-right mt-2 pr-1 select-none">
       v{{ APP_VERSION }}
     </p>
   </aside>

--- a/templates/partials/uptime_bar.html
+++ b/templates/partials/uptime_bar.html
@@ -10,11 +10,8 @@
 </div>
 <div class="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">
   <span>vor 90 Tagen</span>
-  {% if service.uptime_percentage is not none %}
-  <span class="text-gray-500 dark:text-gray-400">
-    <span class="font-medium text-gray-700 dark:text-gray-200">{{ "%.2f"|format(service.uptime_percentage) }} %</span>
-    {{ L["page.uptime_suffix"] }}
-  </span>
-  {% endif %}
   <span>heute</span>
+  {% if service.uptime_percentage is not none %}
+  <span class="font-medium text-gray-600 dark:text-gray-300 ml-3">{{ "%.2f"|format(service.uptime_percentage) }} %</span>
+  {% endif %}
 </div>


### PR DESCRIPTION
Drei Bugfixes die nach dem Merge von #26 entstanden sind:

- **Backfill**: `quote()` kodierte `Exchange Online` → `Exchange%20Online` im OData-`$filter`, wodurch die Graph API keine Issues fand und alle Tage fälschlicherweise als `operational` gespeichert wurden.
- **Uptime %**: Prozentwert steht jetzt rechts außen neben „heute", ohne „verfügbar"-Text.
- **Versionsanzeige**: `text-gray-300` war im Light-Mode quasi unsichtbar → auf `text-gray-400` erhöht.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab8AnwUQE2NofVpXrqwYaB)_