### PR TITLE
feat: compute uptime bars live from incidents (default green)

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -113,22 +113,38 @@ async def upsert_incident_updates(
         )
 
 
-async def count_status_days_in_window(
-    db: AsyncSession,
-    service_name: str,
-    days: int = 90,
-) -> int:
-    from sqlalchemy import func
-    today = date.today()
-    start_date = today - timedelta(days=days - 1)
-    result = await db.execute(
-        select(func.count(ServiceStatus.id)).where(
-            ServiceStatus.service_name == service_name,
-            ServiceStatus.date >= start_date,
-            ServiceStatus.date <= today,
-        )
-    )
-    return int(result.scalar_one() or 0)
+CRITICAL_SEVERITIES = {"critical"}
+
+
+def _incident_bar_status(severity: str | None) -> str:
+    """Map an incident's severity to the bar color it imposes.
+
+    Incidents with severity 'critical' make the day red (interrupted);
+    all other severities (including high/medium/low/empty) make it yellow
+    (degraded). Real ServiceStatus DB rows always override this.
+    """
+    sev = (severity or "").lower()
+    return "interrupted" if sev in CRITICAL_SEVERITIES else "degraded"
+
+
+def _incident_date_range(incident: Incident, today: date) -> tuple[date, date] | None:
+    """Return (start, end) date range an incident covers, or None to skip.
+
+    - Skips incidents without a start_datetime.
+    - End preference: end_datetime → last_modified (if resolved) → today.
+    """
+    if incident.start_datetime is None:
+        return None
+    start = incident.start_datetime.date()
+    if incident.end_datetime is not None:
+        end = incident.end_datetime.date()
+    elif incident.is_resolved and incident.last_modified is not None:
+        end = incident.last_modified.date()
+    else:
+        end = today
+    if end < start:
+        end = start
+    return start, end
 
 
 async def get_uptime_bars(
@@ -136,24 +152,71 @@ async def get_uptime_bars(
     service_name: str,
     days: int = 90,
 ) -> list[DayStatusSchema]:
+    """Build 90 day-bars for a service.
+
+    Logic:
+      1. Default every day to 'operational' (green) – missing data means
+         the service was healthy.
+      2. Overlay each non-maintenance, non-suppressed Incident across its
+         [start, end] date range:
+           - severity 'critical' → 'interrupted' (red)
+           - any other severity → 'degraded' (yellow)
+         Higher severity wins when ranges overlap.
+      3. Real entries from the service_status table (excluding synthetic
+         'backfill' rows) override everything – they're authoritative.
+    """
     today = date.today()
     start_date = today - timedelta(days=days - 1)
 
-    result = await db.execute(
-        select(ServiceStatus.date, ServiceStatus.status)
+    real_result = await db.execute(
+        select(ServiceStatus.date, ServiceStatus.status, ServiceStatus.raw_graph_status)
         .where(
             ServiceStatus.service_name == service_name,
             ServiceStatus.date >= start_date,
             ServiceStatus.date <= today,
         )
-        .order_by(ServiceStatus.date)
     )
-    rows = {r.date: r.status for r in result.fetchall()}
+    real_entries: dict[date, str] = {
+        row.date: row.status
+        for row in real_result.fetchall()
+        if row.raw_graph_status != "backfill"
+    }
+
+    incidents_result = await db.execute(
+        select(Incident).where(
+            Incident.service_name == service_name,
+            Incident.classification != "maintenance",
+            Incident.is_suppressed.is_(False),
+            Incident.start_datetime.is_not(None),
+        )
+    )
+    incidents = list(incidents_result.scalars().all())
+
+    computed: dict[date, str] = {}
+    for inc in incidents:
+        date_range = _incident_date_range(inc, today)
+        if date_range is None:
+            continue
+        inc_start, inc_end = date_range
+        if inc_end < start_date or inc_start > today:
+            continue
+        inc_status = _incident_bar_status(inc.severity)
+        cursor = max(inc_start, start_date)
+        end_clamped = min(inc_end, today)
+        while cursor <= end_clamped:
+            current = computed.get(cursor, "operational")
+            if _STATUS_SEVERITY.get(inc_status, 0) > _STATUS_SEVERITY.get(current, 0):
+                computed[cursor] = inc_status
+            cursor += timedelta(days=1)
 
     bars: list[DayStatusSchema] = []
     for i in range(days):
         d = start_date + timedelta(days=i)
-        bars.append(DayStatusSchema(date=d, status=rows.get(d, "no_data")))
+        if d in real_entries:
+            status = real_entries[d]
+        else:
+            status = computed.get(d, "operational")
+        bars.append(DayStatusSchema(date=d, status=status))
     return bars
 
 
@@ -402,83 +465,22 @@ async def get_uptime_percentage(
 ) -> float | None:
     """Return uptime % over the window. operational=1.0, degraded=0.5, interrupted=0.
 
-    no_data/unknown days are excluded from the denominator. Returns None when
-    no day in the window has data.
+    Derived from the same bar logic as get_uptime_bars so values stay
+    consistent with what's rendered. Returns None when no bar in the
+    window has a weighted status.
     """
-    today = date.today()
-    start_date = today - timedelta(days=days - 1)
-    result = await db.execute(
-        select(ServiceStatus.status).where(
-            ServiceStatus.service_name == service_name,
-            ServiceStatus.date >= start_date,
-            ServiceStatus.date <= today,
-        )
-    )
+    bars = await get_uptime_bars(db, service_name, days)
     weights = {"operational": 1.0, "degraded": 0.5, "interrupted": 0.0}
     total = 0
     score = 0.0
-    for row in result.fetchall():
-        status = row[0]
-        if status not in weights:
+    for bar in bars:
+        if bar.status not in weights:
             continue
         total += 1
-        score += weights[status]
+        score += weights[bar.status]
     if total == 0:
         return None
     return round(score / total * 100, 2)
-
-
-async def backfill_service_status_from_issues(
-    db: AsyncSession,
-    service_name: str,
-    issues: list[dict],
-    days: int = 90,
-) -> None:
-    today = date.today()
-    start_date = today - timedelta(days=days - 1)
-
-    _severity = {"operational": 0, "unknown": 1, "degraded": 2, "interrupted": 3}
-
-    def _parse_issue_date(val: str | None) -> date | None:
-        if not val:
-            return None
-        try:
-            dt = datetime.fromisoformat(val.replace("Z", "+00:00"))
-            return dt.date()
-        except (ValueError, AttributeError):
-            return None
-
-    day_status: dict[date, str] = {}
-    for issue in issues:
-        issue_start = _parse_issue_date(issue.get("startDateTime"))
-        issue_end = _parse_issue_date(issue.get("endDateTime") or issue.get("lastModifiedDateTime"))
-        if not issue_start:
-            continue
-        if issue_end is None or issue_end < issue_start:
-            issue_end = today
-        classification = issue.get("classification", "incident")
-        status = "interrupted" if classification == "incident" else "degraded"
-
-        cursor = max(issue_start, start_date)
-        end_clamped = min(issue_end, today)
-        while cursor <= end_clamped:
-            if _severity.get(status, 0) > _severity.get(day_status.get(cursor, "operational"), 0):
-                day_status[cursor] = status
-            cursor += timedelta(days=1)
-
-    result = await db.execute(
-        select(ServiceStatus.date).where(
-            ServiceStatus.service_name == service_name,
-            ServiceStatus.date >= start_date,
-        )
-    )
-    existing_dates = {row[0] for row in result.fetchall()}
-
-    for i in range(days):
-        d = start_date + timedelta(days=i)
-        if d not in existing_dates:
-            status = day_status.get(d, "operational")
-            await upsert_service_status(db, service_name, d, status, "backfill")
 
 
 async def set_service_status_manual(

--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -84,7 +84,7 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
     base_url = (
         f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
         f"?$filter=service eq '{service_name}' and startDateTime ge {since}"
-        f"&$select=id,service,classification,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity"
+        f"&$select=id,service,title,classification,status,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity"
         f"&$top=100"
     )
     all_issues: list[dict] = []

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -14,7 +14,6 @@ from app.crud import (
     add_incident_post,
     add_state_change_entry,
     admin_update_incident,
-    backfill_service_status_from_issues,
     create_manual_incident,
     ensure_service_known,
     get_all_incidents,
@@ -55,15 +54,25 @@ def _parse_form_dt(val: str | None) -> datetime | None:
 
 
 async def _backfill_service(service_name: str) -> None:
-    """Background task: fetch 90-day issue history and fill in missing status rows."""
+    """Background task: fetch 90-day issue history and store as Incidents.
+
+    The uptime bars on the status page derive their colors live from
+    Incidents (see get_uptime_bars in crud.py), so pre-populating the
+    Incidents table for the past 90 days seeds the bars immediately
+    after a service is enabled – no synthetic ServiceStatus rows needed.
+    """
+    from app.scheduler import sync_issue_as_incident  # local import: avoids circular dep
     try:
         issues = await fetch_issues_since(service_name, days=90)
+        synced = 0
         async with AsyncSessionLocal() as db:
-            await backfill_service_status_from_issues(db, service_name, issues, days=90)
+            for issue in issues:
+                await sync_issue_as_incident(db, issue)
+                synced += 1
             await db.commit()
-        logger.info("Backfill completed for %s (%d issues)", service_name, len(issues))
+        logger.info("Historical incident sync completed for %s (%d of %d issues)", service_name, synced, len(issues))
     except Exception:
-        logger.exception("Backfill failed for %s", service_name)
+        logger.exception("Historical incident sync failed for %s", service_name)
 
 
 # Tracks a pending delayed poll so it can be cancelled and restarted when

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -6,8 +6,6 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from app.config import settings
 from app.crud import (
-    backfill_service_status_from_issues,
-    count_status_days_in_window,
     ensure_service_known,
     get_enabled_services,
     upsert_incident,
@@ -18,7 +16,6 @@ from app.database import AsyncSessionLocal
 from app.graph_client import (
     fetch_active_issues,
     fetch_health_overviews,
-    fetch_issues_since,
     fetch_recently_resolved_issues,
 )
 from app.models import GRAPH_STATUS_MAP
@@ -63,6 +60,36 @@ def _parse_dt(value: str | None) -> datetime | None:
         return dt.replace(tzinfo=None)
     except (ValueError, AttributeError):
         return None
+
+
+async def sync_issue_as_incident(db, issue: dict) -> None:
+    """Upsert a Graph API issue as an Incident (and its posts, if present).
+
+    Returns silently if the issue should be skipped (advisory, falsePositive,
+    or unknown classification). Posts are only synced when present on the
+    issue dict – historical fetches may omit them for performance.
+    """
+    classification = _classify_issue(issue)
+    if classification is None:
+        return
+    severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
+    fields: dict = {
+        "title": issue.get("title", ""),
+        "service_name": issue.get("service", ""),
+        "classification": classification,
+        "status": _issue_status(issue, classification),
+        "start_datetime": _parse_dt(issue.get("startDateTime")),
+        "last_modified": _parse_dt(issue.get("lastModifiedDateTime")),
+        "is_resolved": issue.get("isResolved", False),
+        "severity": severity,
+    }
+    if classification == "maintenance":
+        fields["scheduled_start"] = _parse_dt(issue.get("startDateTime"))
+        fields["scheduled_end"] = _parse_dt(issue.get("endDateTime"))
+    incident = await upsert_incident(db, graph_issue_id=issue["id"], **fields)
+    posts = issue.get("posts")
+    if posts:
+        await upsert_incident_updates(db, incident.id, posts)
 
 
 async def poll_graph_api() -> None:
@@ -115,26 +142,9 @@ async def poll_graph_api() -> None:
             for issue in active_issues:
                 if issue.get("service") not in monitored:
                     continue
-                classification = _classify_issue(issue)
-                if classification is None:
-                    continue  # advisory, falsePositive, or unknown – skip
-                severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
-                fields: dict = {
-                    "title": issue.get("title", ""),
-                    "service_name": issue.get("service", ""),
-                    "classification": classification,
-                    "status": _issue_status(issue, classification),
-                    "start_datetime": _parse_dt(issue.get("startDateTime")),
-                    "last_modified": _parse_dt(issue.get("lastModifiedDateTime")),
-                    "is_resolved": issue.get("isResolved", False),
-                    "severity": severity,
-                }
-                if classification == "maintenance":
-                    fields["scheduled_start"] = _parse_dt(issue.get("startDateTime"))
-                    fields["scheduled_end"] = _parse_dt(issue.get("endDateTime"))
-                incident = await upsert_incident(db, graph_issue_id=issue["id"], **fields)
-                posts = issue.get("posts") or []
-                await upsert_incident_updates(db, incident.id, posts)
+                if _classify_issue(issue) is None:
+                    continue
+                await sync_issue_as_incident(db, issue)
                 synced += 1
             await db.commit()
             logger.info("Active issues committed: %d synced (of %d fetched).", synced, len(active_issues))
@@ -143,6 +153,10 @@ async def poll_graph_api() -> None:
             logger.exception("Active issues poll failed")
 
     # ── Phase 3: Recently resolved (30 days) – independent, safe to fail ────────
+    # The uptime bars compute live from Incidents in get_uptime_bars; keeping
+    # the last 30 days of resolved issues here means the bars stay accurate
+    # without a separate ServiceStatus backfill phase. For deeper history
+    # (30–90 days) admins trigger a one-shot sync when enabling a service.
     async with AsyncSessionLocal() as db:
         try:
             resolved_issues = await fetch_recently_resolved_issues(days=30)
@@ -150,54 +164,15 @@ async def poll_graph_api() -> None:
             for issue in resolved_issues:
                 if issue.get("service") not in monitored:
                     continue
-                classification = _classify_issue(issue)
-                if classification is None:
-                    continue  # advisory, falsePositive, or unknown – skip
-                severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
-                fields = {
-                    "title": issue.get("title", ""),
-                    "service_name": issue.get("service", ""),
-                    "classification": classification,
-                    "status": _issue_status(issue, classification),
-                    "start_datetime": _parse_dt(issue.get("startDateTime")),
-                    "last_modified": _parse_dt(issue.get("lastModifiedDateTime")),
-                    "is_resolved": issue.get("isResolved", False),
-                    "severity": severity,
-                }
-                if classification == "maintenance":
-                    fields["scheduled_start"] = _parse_dt(issue.get("startDateTime"))
-                    fields["scheduled_end"] = _parse_dt(issue.get("endDateTime"))
-                incident = await upsert_incident(db, graph_issue_id=issue["id"], **fields)
-                posts = issue.get("posts") or []
-                await upsert_incident_updates(db, incident.id, posts)
+                if _classify_issue(issue) is None:
+                    continue
+                await sync_issue_as_incident(db, issue)
                 synced += 1
             await db.commit()
             logger.info("Recently resolved committed: %d synced (of %d fetched).", synced, len(resolved_issues))
         except Exception:
             await db.rollback()
             logger.exception("Recently resolved issues poll failed – active issues unaffected")
-
-    # ── Phase 4: 90-day history backfill (only if gaps exist) ───────────────────
-    # After a container restart with a fresh volume, service_status is empty and
-    # the 90-day uptime bars show "no_data". Reconstruct missing days from the
-    # Graph API issue history: days with no incident → operational; days covered
-    # by an incident → degraded/interrupted.
-    for name in monitored:
-        async with AsyncSessionLocal() as db:
-            try:
-                existing = await count_status_days_in_window(db, name, days=90)
-                if existing >= 90:
-                    continue
-                issues = await fetch_issues_since(name, days=90)
-                await backfill_service_status_from_issues(db, name, issues, days=90)
-                await db.commit()
-                logger.info(
-                    "Backfill committed for %s: %d issues, filled %d missing days.",
-                    name, len(issues), 90 - existing,
-                )
-            except Exception:
-                await db.rollback()
-                logger.exception("Backfill failed for %s", name)
 
 
 def start_scheduler() -> None:


### PR DESCRIPTION
## Summary

Neue Logik für die 90-Tage-Verfügbarkeitsbalken auf der Statusseite:

1. **Default = grün** – fehlende Daten bedeuten, dass der Dienst gesund war (kein graues „no_data" mehr).
2. **Incidents überlagern** das Default-Grün anhand ihrer `start_datetime` → end (Ende = `end_datetime`, sonst `last_modified` bei resolved, sonst `today`):
   - `severity == "critical"` → **rot** (interrupted)
   - alle anderen Severities → **gelb** (degraded)
   - Bei Überlappung gewinnt die höhere Severity.
3. **Echte `service_status`-DB-Einträge haben immer Priorität** und überschreiben die Berechnung. Synthetische Backfill-Zeilen (`raw_graph_status="backfill"`) werden dabei ignoriert.

### Microsoft-Klassifizierung

Per [Microsoft-Doku](https://learn.microsoft.com/microsoft-365/enterprise/view-service-health#how-to-check-service-health) ist `serviceInterruption` der echte Ausfall („users can't access the service") und `serviceDegradation` ist „läuft, aber eingeschränkt". Tägliche `service_status`-Zeilen vom Graph-Polling spiegeln das bereits über das bestehende `GRAPH_STATUS_MAP` wider und übersteuern jetzt jede Incident-basierte Berechnung — Tage mit echtem Microsoft-Outage bleiben also korrekt rot.

### Architektur-Änderung

Damit die Live-Berechnung auch für die Tage 30–90 funktioniert (außerhalb der Reichweite von Phase 3 „Recently resolved"), wurde die alte ServiceStatus-Backfill-Logik ersetzt:

- **Entfernt**: `backfill_service_status_from_issues`, `count_status_days_in_window`, Scheduler-Phase 4.
- **Neu**: Shared Helper `scheduler.sync_issue_as_incident` upsertet Graph-Issues als Incidents (wiederverwendet in Phase 2 + 3). Beim Aktivieren eines Services im Admin-UI lädt der Hintergrund-Task jetzt die letzten 90 Tage Issues als Incidents in die DB, statt synthetische ServiceStatus-Zeilen zu schreiben.
- `get_uptime_percentage` leitet sich jetzt aus denselben Balken ab → Prozent und Farben bleiben konsistent.
- `fetch_issues_since` $select erweitert um `title` und `status` (sonst hätten historisch geladene Incidents keinen Titel).

## Test plan

Smoke-Test gegen lokale SQLite-DB grün (alle 7 Fälle):

- [x] Keine Daten → alle Tage grün, Verfügbarkeit 100 %
- [x] Incident mit `severity=high` über drei Tage → gelb auf diesen drei Tagen
- [x] Incident mit `severity=critical` → rot
- [x] Echte `serviceOperational`-Zeile überschreibt einen gelben Incident-Tag
- [x] Backfill-Zeile (`raw_graph_status="backfill"`) wird ignoriert
- [x] `maintenance`-Incidents werden ausgeschlossen
- [x] Noch aktiver Incident (kein `end_datetime`) deckt bis heute ab

### Manuell zu prüfen

- [ ] Frischer Container ohne historische `service_status`-Rows: Balken zeigen ab Tag 1 grün statt grau
- [ ] Service im Admin neu aktivieren → 90-Tage-Historie wird im Hintergrund als Incidents geladen, Balken füllen sich entsprechend
- [ ] Manueller Critical-Incident über Admin → die abgedeckten Tage werden rot
- [ ] Bei laufendem Graph-Poll: heute ist `serviceInterruption` → Tagesbalken bleibt rot (echter Eintrag schlägt jede Berechnung)

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_