### PR TITLE
feat: incident form polish, phase visualization, delete

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -303,9 +303,12 @@ async def create_manual_incident(
     status: str = "active",
     severity: str = "",
     description: str | None = None,
+    start_datetime: datetime | None = None,
     scheduled_start: datetime | None = None,
     scheduled_end: datetime | None = None,
 ) -> Incident:
+    now = datetime.utcnow()
+    start = start_datetime or now
     incident = Incident(
         graph_issue_id=f"manual-{uuid.uuid4().hex[:12]}",
         title=title,
@@ -314,8 +317,8 @@ async def create_manual_incident(
         status=status,
         severity=severity,
         description=description or None,
-        start_datetime=datetime.utcnow(),
-        last_modified=datetime.utcnow(),
+        start_datetime=start,
+        last_modified=now,
         is_resolved=False,
         source="manual",
         scheduled_start=scheduled_start,
@@ -341,16 +344,27 @@ async def admin_update_incident(
     return incident
 
 
+async def delete_incident(db: AsyncSession, incident_id: int) -> bool:
+    incident = await get_incident_by_id(db, incident_id)
+    if incident is None:
+        return False
+    await db.delete(incident)
+    await db.flush()
+    return True
+
+
 async def add_incident_post(
     db: AsyncSession,
     incident_id: int,
     content: str,
+    notify_subscribers: bool = True,
 ) -> IncidentUpdate:
     update = IncidentUpdate(
         incident_id=incident_id,
         content=_sanitize_html(content),
         update_type="note",
         post_created_at=datetime.utcnow(),
+        notify_subscribers=notify_subscribers,
     )
     db.add(update)
     await db.flush()

--- a/app/database.py
+++ b/app/database.py
@@ -47,6 +47,7 @@ async def init_db() -> None:
             "ALTER TABLE incidents ADD COLUMN is_suppressed BOOLEAN NOT NULL DEFAULT 0",
             "ALTER TABLE incidents ADD COLUMN end_datetime DATETIME",
             "ALTER TABLE monitored_services ADD COLUMN show_uptime_percentage BOOLEAN NOT NULL DEFAULT 1",
+            "ALTER TABLE incident_updates ADD COLUMN notify_subscribers BOOLEAN NOT NULL DEFAULT 0",
         ]:
             try:
                 await conn.execute(text(stmt))

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -50,14 +50,24 @@ LABELS: dict[str, str] = {
     "admin.title_label":          "Titel",
     "admin.description_label":    "Beschreibung",
     "admin.severity_label":       "Schweregrad",
+    "admin.start_datetime":       "Beginn",
+    "admin.now":                  "Jetzt",
+    "admin.notify_subscribers":   "Subscriber benachrichtigen",
+    "admin.delete":               "Löschen",
+    "admin.delete_confirm":       "Diesen Eintrag wirklich löschen?",
     # Severity levels
     "severity.critical":          "Kritisch",
     "severity.high":              "Hoch",
     "severity.medium":            "Mittel",
     "severity.low":               "Niedrig",
-    # State change timeline entries
-    "state.active":               "Aktiv",
-    "state.acknowledged":         "Bestätigt",
+    # State change timeline entries  (Incident-Phasen)
+    # active        → Investigating  – Problem bekannt, Ursache wird gesucht
+    # acknowledged  → Identified     – Ursache gefunden, Behebung startet
+    # monitoring    → Monitoring     – Fix eingespielt, System wird beobachtet
+    # resolved      → Resolved       – Störung offiziell vorbei
+    "state.active":               "Untersuchung läuft",
+    "state.acknowledged":         "Identifiziert",
+    "state.monitoring":           "Überwachung",
     "state.resolved":             "Behoben",
     "state.scheduled":            "Geplant",
     "state.in_progress":          "In Durchführung",

--- a/app/models.py
+++ b/app/models.py
@@ -109,6 +109,9 @@ class IncidentUpdate(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
     update_type: Mapped[str] = mapped_column(String(32), nullable=False, server_default="note")
     post_created_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    notify_subscribers: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="0", default=False
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
 
     incident: Mapped["Incident"] = relationship("Incident", back_populates="updates")

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -28,6 +28,7 @@ from app.crud import (
     set_show_uptime_percentage,
     toggle_suppress_incident,
 )
+from app.crud import delete_incident as crud_delete_incident
 from app.database import AsyncSessionLocal
 from app.dependencies import get_db
 from app.graph_client import (
@@ -51,6 +52,36 @@ def _parse_form_dt(val: str | None) -> datetime | None:
         return datetime.fromisoformat(val)
     except (ValueError, TypeError):
         return None
+
+
+def _compute_phase_segments(incident) -> list[dict]:
+    """Build proportional phase segments for an incident's lifetime.
+
+    Each segment is {"status": str, "weight": float} where weight is the
+    duration of that phase in seconds (or 1 if start/end is unknown).
+    The first phase is "active" from incident.start_datetime; each
+    state-change update splits into a new phase; the last phase runs
+    until end_datetime (or now if still open).
+    """
+    if incident.start_datetime is None:
+        return []
+    state_changes = sorted(
+        [u for u in incident.updates if u.update_type == "state_change" and u.post_created_at],
+        key=lambda u: u.post_created_at,
+    )
+    end = incident.end_datetime or datetime.utcnow()
+    boundaries: list[tuple[datetime, str]] = [(incident.start_datetime, "active")]
+    for sc in state_changes:
+        boundaries.append((sc.post_created_at, sc.content))
+    boundaries.append((end, boundaries[-1][1]))
+
+    segments: list[dict] = []
+    for i in range(len(boundaries) - 1):
+        t0, status = boundaries[i]
+        t1, _ = boundaries[i + 1]
+        duration = max((t1 - t0).total_seconds(), 1.0)
+        segments.append({"status": status, "weight": duration})
+    return segments
 
 
 async def _backfill_service(service_name: str) -> None:
@@ -174,6 +205,7 @@ async def create_incident(
     classification: Annotated[str, Form()],
     severity: Annotated[str | None, Form()] = None,
     description: Annotated[str | None, Form()] = None,
+    start_datetime: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
@@ -184,6 +216,7 @@ async def create_incident(
         classification=classification,
         severity=severity or "",
         description=description or None,
+        start_datetime=_parse_form_dt(start_datetime),
     )
     await db.commit()
     return RedirectResponse(url=f"/admin/incidents/{incident.id}", status_code=303)
@@ -207,6 +240,7 @@ async def incident_detail(
             "user": user,
             "incident": incident,
             "services": enabled_services,
+            "phase_segments": _compute_phase_segments(incident),
             "page_title": incident.title,
         },
     )
@@ -259,14 +293,33 @@ async def update_incident(
     return RedirectResponse(url=f"/admin/incidents/{incident_id}", status_code=303)
 
 
+@router.post("/incidents/{incident_id}/delete")
+async def delete_incident(
+    incident_id: int,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    deleted = await crud_delete_incident(db, incident_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Nicht gefunden")
+    await db.commit()
+    return RedirectResponse(url="/admin", status_code=303)
+
+
 @router.post("/incidents/{incident_id}/posts")
 async def add_post(
     incident_id: int,
     content: Annotated[str, Form()],
+    notify_subscribers: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
-    await add_incident_post(db, incident_id, content)
+    await add_incident_post(
+        db,
+        incident_id,
+        content,
+        notify_subscribers=notify_subscribers == "on",
+    )
     await db.commit()
     return RedirectResponse(url=f"/admin/incidents/{incident_id}", status_code=303)
 

--- a/app/templates.py
+++ b/app/templates.py
@@ -42,6 +42,22 @@ SEVERITY_BADGE: dict[str, str] = {
     "low":      "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-400",
 }
 
+# Standard incident-response phases mapped to a single colour each.
+# active        → Investigating  (yellow)
+# acknowledged  → Identified     (orange)
+# monitoring    → Monitoring     (blue)
+# resolved/completed → Resolved  (green)
+# scheduled/in_progress (maintenance) → blue / amber
+PHASE_DOT: dict[str, str] = {
+    "active":       "bg-yellow-400",
+    "acknowledged": "bg-orange-400",
+    "monitoring":   "bg-blue-400",
+    "resolved":     "bg-emerald-500",
+    "completed":    "bg-emerald-500",
+    "scheduled":    "bg-blue-400",
+    "in_progress":  "bg-amber-400",
+}
+
 templates.env.globals["severity_badge_class"] = (
     lambda s: SEVERITY_BADGE.get(s, "")
 )
@@ -50,6 +66,9 @@ templates.env.globals["severity_label"] = (
 )
 templates.env.globals["state_label"] = (
     lambda s: LABELS.get(f"state.{s}", s)
+)
+templates.env.globals["phase_dot_class"] = (
+    lambda s: PHASE_DOT.get(s, "bg-gray-300 dark:bg-gray-600")
 )
 
 # ── Filters ───────────────────────────────────────────────────────────────────

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -59,6 +59,8 @@
     {% for inc in incidents %}
     <div class="flex items-center justify-between px-5 py-3 group">
       <a href="/admin/incidents/{{ inc.id }}" class="flex-1 flex items-center gap-0 hover:opacity-80 transition-opacity min-w-0">
+        <span class="w-2.5 h-2.5 rounded-full mr-2 shrink-0 {{ phase_dot_class('resolved' if inc.is_resolved else inc.status) }}"
+              title="{{ state_label('resolved' if inc.is_resolved else inc.status) }}"></span>
         <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
           {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
           {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -31,6 +31,12 @@
       </button>
     </form>
     {% endif %}
+    <form method="post" action="/admin/incidents/{{ incident.id }}/delete"
+          onsubmit="return confirm('{{ L[&quot;admin.delete_confirm&quot;] }}');">
+      <button type="submit" class="text-xs px-2.5 py-1 rounded-lg border border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors">
+        {{ L["admin.delete"] }}
+      </button>
+    </form>
   </div>
 </div>
 
@@ -95,6 +101,7 @@
                     class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
               <option value="active"       {% if incident.status == "active"       %}selected{% endif %}>{{ L["state.active"] }}</option>
               <option value="acknowledged" {% if incident.status == "acknowledged" %}selected{% endif %}>{{ L["state.acknowledged"] }}</option>
+              <option value="monitoring"   {% if incident.status == "monitoring"   %}selected{% endif %}>{{ L["state.monitoring"] }}</option>
               <option value="resolved"     {% if incident.status == "resolved"     %}selected{% endif %}>{{ L["incident.resolved"] }}</option>
             </select>
           </div>
@@ -114,10 +121,16 @@
 
         {% if incident.classification != "maintenance" %}
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            {{ L["admin.end_datetime"] }}
-          </label>
-          <input type="datetime-local" name="end_datetime"
+          <div class="flex items-center justify-between mb-1">
+            <label for="end_datetime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              {{ L["admin.end_datetime"] }}
+            </label>
+            <button type="button" id="end-now-btn"
+                    class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors">
+              {{ L["admin.now"] }}
+            </button>
+          </div>
+          <input type="datetime-local" name="end_datetime" id="end_datetime"
                  value="{{ incident.end_datetime.strftime('%Y-%m-%dT%H:%M') if incident.end_datetime else '' }}"
                  class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
         </div>
@@ -149,10 +162,17 @@
         <textarea name="content" rows="4" required
                   placeholder="{{ L['admin.post_placeholder'] }} (Markdown)"
                   class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"></textarea>
-        <button type="submit"
-                class="px-4 py-2 rounded-lg bg-gray-900 hover:bg-gray-700 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium transition-colors">
-          {{ L["admin.add_update"] }}
-        </button>
+        <div class="flex items-center justify-between">
+          <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input type="checkbox" name="notify_subscribers" value="on" checked
+                   class="rounded border-gray-300 dark:border-gray-600 text-blue-500 focus:ring-blue-500">
+            {{ L["admin.notify_subscribers"] }}
+          </label>
+          <button type="submit"
+                  class="px-4 py-2 rounded-lg bg-gray-900 hover:bg-gray-700 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium transition-colors">
+            {{ L["admin.add_update"] }}
+          </button>
+        </div>
       </form>
     </div>
 
@@ -161,6 +181,25 @@
   {# ── Right: Timeline ──────────────────────────────────────────────────────── #}
   <div>
     <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">{{ L["incident.updates"] }}</h2>
+
+    {% if phase_segments %}
+    {# Thin colored phase bar showing incident phases over time (oldest left, newest right). #}
+    <div class="mb-4">
+      <div class="flex h-1.5 w-full rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800" role="img"
+           aria-label="Incident-Phasen">
+        {% for seg in phase_segments %}
+        <div class="h-full {{ phase_dot_class(seg.status) }}"
+             style="flex-grow: {{ seg.weight }};"
+             title="{{ state_label(seg.status) }}"></div>
+        {% endfor %}
+      </div>
+      <div class="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">
+        <span>{{ incident.start_datetime | strftime_de }}</span>
+        <span>{{ (incident.end_datetime | strftime_de) if incident.end_datetime else "heute" }}</span>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="space-y-2">
       {% for update in incident.updates | sort(attribute="post_created_at", reverse=True) %}
         {% if update.update_type == "state_change" %}
@@ -204,4 +243,17 @@
   </div>
 
 </div>
+
+<script>
+  (function () {
+    const endInput = document.getElementById("end_datetime");
+    const endBtn = document.getElementById("end-now-btn");
+    if (!endInput || !endBtn) return;
+    const fmtLocal = (d) => {
+      const pad = (n) => String(n).padStart(2, "0");
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    };
+    endBtn.addEventListener("click", () => { endInput.value = fmtLocal(new Date()); });
+  })();
+</script>
 {% endblock %}

--- a/templates/admin/incident_form.html
+++ b/templates/admin/incident_form.html
@@ -59,6 +59,20 @@
     </div>
 
     <div>
+      <div class="flex items-center justify-between mb-1">
+        <label for="start_datetime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {{ L["admin.start_datetime"] }}
+        </label>
+        <button type="button" id="start-now-btn"
+                class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors">
+          {{ L["admin.now"] }}
+        </button>
+      </div>
+      <input type="datetime-local" name="start_datetime" id="start_datetime"
+             class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+    </div>
+
+    <div>
       <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
         {{ L["admin.description_label"] }}
         <span class="font-normal text-gray-400">(optional)</span>
@@ -77,4 +91,18 @@
 
   </form>
 </div>
+
+<script>
+  (function () {
+    const fmtLocal = (d) => {
+      const pad = (n) => String(n).padStart(2, "0");
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    };
+    const input = document.getElementById("start_datetime");
+    const btn = document.getElementById("start-now-btn");
+    const setNow = () => { input.value = fmtLocal(new Date()); };
+    setNow();
+    btn.addEventListener("click", setNow);
+  })();
+</script>
 {% endblock %}

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -3,7 +3,11 @@
   <div class="p-4">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <h3 class="font-medium text-gray-900 dark:text-white leading-snug">{{ incident.title }}</h3>
+        <h3 class="font-medium text-gray-900 dark:text-white leading-snug flex items-center gap-2">
+          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ phase_dot_class('resolved' if incident.is_resolved else incident.status) }}"
+                title="{{ state_label('resolved' if incident.is_resolved else incident.status) }}"></span>
+          <span>{{ incident.title }}</span>
+        </h3>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           <span class="font-medium">{{ L["incident.affects"] }}:</span> {{ incident.service_name }}
           &nbsp;·&nbsp;


### PR DESCRIPTION
## Summary

UI- und Daten-Polish rund um Incidents. Bereitet außerdem den Subscriber-Backend-PR (folgt) vor, indem `incident_updates.notify_subscribers` als Flag in der DB landet.

### Formular-Verbesserungen
- **Neuer Incident**: kompaktes `<input type="datetime-local">` für **Beginn**, per JS mit aktueller Zeit vorbefüllt. Daneben ein winziger „Jetzt"-Link zum Zurücksetzen.
- **Detail/Abschluss**: gleiche „Jetzt"-Logik neben `end_datetime`. Der Server setzt `end_datetime` automatisch auf jetzt, wenn der Resolve-Haken gesetzt wird und kein Endwert eingetragen ist (existierende Logik).
- **Update hinzufügen**: Checkbox „Subscriber benachrichtigen" (Default **ON**). Wert landet auf `incident_updates.notify_subscribers`.

### Incident-Phasen (Standard-Modell)
Status-Werte gemappt auf die vier Phasen:

| Status        | Phase          | Bedeutung                                          | Farbe |
|---------------|----------------|----------------------------------------------------|-------|
| `active`      | Untersuchung läuft | Problem bekannt, Ursache wird gesucht          | 🟡    |
| `acknowledged`| Identifiziert  | Ursache gefunden, Behebung startet                 | 🟠    |
| `monitoring`  | Überwachung    | Fix eingespielt, System wird beobachtet            | 🔵    |
| `resolved`    | Behoben        | Störung offiziell vorbei                           | 🟢    |

- **Phase-Dot** im Admin-Dashboard und auf der öffentlichen Statusseite (`incident_card.html`).
- **Phase-Bar** in der Incident-Detailansicht: dünner mehrfarbiger Streifen oberhalb der Timeline, dessen Segmente proportional zur Dauer der jeweiligen Phase sind. Berechnet aus `start_datetime`, den `state_change`-Updates und `end_datetime` (bzw. `now`).
- Neue Status-Option **„Überwachung"** im Dropdown.

### Löschen
- Neue Route `POST /admin/incidents/{id}/delete` (`crud.delete_incident`) plus roter Button im Detail-Header mit JS-Confirm. Cascade-Delete sorgt für saubere Updates-Tabelle.

### Schema
Additive Migration in `init_db`:
```sql
ALTER TABLE incident_updates ADD COLUMN notify_subscribers BOOLEAN NOT NULL DEFAULT 0
```
Default 0, damit weder automatische State-Change-Einträge noch importierte Graph-API-Posts irrtümlich Benachrichtigungen auslösen — nur manuell mit Häkchen gesetzte Updates flaggen sich für den Notifier (kommt in PR 2).

### Verlauf aus Graph-Posts
Bereits durch die bestehende `upsert_incident_updates`-Funktion abgedeckt: `fetch_active_issues` und `fetch_recently_resolved_issues` ziehen Posts mit, die als `IncidentUpdate`-Zeilen in der DB landen — also sind die Graph-Verlaufseinträge schon Teil des Timelines.

## Test plan

- [x] `ruff check` grün, `py_compile` grün
- [x] `_compute_phase_segments` Smoke-Test:
  - Eingefügt: start → ack (1h) → monitor (2h) → resolved (1h) → end now → Segmente 1h/2h/1h/~0h
  - Offen ohne Updates → ein einziges `active`-Segment

### Manuell zu prüfen

- [ ] Neuer Incident: Beginn ist mit aktueller Zeit gefüllt, „Jetzt"-Link setzt zurück, Server speichert korrekten Wert
- [ ] Update mit Häkchen wird mit `notify_subscribers=1` in DB gespeichert
- [ ] Update ohne Häkchen mit `notify_subscribers=0`
- [ ] Phase-Dots erscheinen im Admin-Dashboard und auf der öffentlichen Statusseite in der richtigen Farbe
- [ ] Phase-Bar in der Detail-Ansicht zeigt die Segmente proportional und in den korrekten Farben
- [ ] „Löschen"-Button entfernt den Incident inklusive aller Updates und leitet zum Dashboard zurück
- [ ] Status auf „Überwachung" setzen → Bar zeigt blaues Segment

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_