### PR TITLE
feat: map Graph issue status to incident phases

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -182,10 +182,13 @@ async def get_uptime_bars(
         if row.raw_graph_status != "backfill"
     }
 
+    # Only true incidents paint the uptime bars; advisories are
+    # informational ("Updates" category) and maintenance is scheduled,
+    # so neither should ding availability.
     incidents_result = await db.execute(
         select(Incident).where(
             Incident.service_name == service_name,
-            Incident.classification != "maintenance",
+            Incident.classification == "incident",
             Incident.is_suppressed.is_(False),
             Incident.start_datetime.is_not(None),
         )

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -3,9 +3,11 @@ from datetime import date, datetime
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import select as sa_select
 
 from app.config import settings
 from app.crud import (
+    add_state_change_entry,
     ensure_service_known,
     get_enabled_services,
     upsert_incident,
@@ -18,7 +20,7 @@ from app.graph_client import (
     fetch_health_overviews,
     fetch_recently_resolved_issues,
 )
-from app.models import GRAPH_STATUS_MAP
+from app.models import GRAPH_STATUS_MAP, Incident
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +39,24 @@ _GRAPH_CLASSIFICATION_MAP: dict[str, str] = {
     "plannedMaintenance": "maintenance",
 }
 
+# Maps the Microsoft Graph issue `status` field to one of our incident phases:
+#   active        – Investigating  (Untersuchung läuft)
+#   acknowledged  – Identified     (Ursache bekannt, Behebung startet)
+#   monitoring    – Monitoring     (Fix eingespielt, System wird beobachtet)
+#   resolved      – Resolved       (Behoben)
+# falsePositive is intentionally omitted; _classify_issue filters those out.
+_GRAPH_INCIDENT_PHASE_MAP: dict[str, str] = {
+    "investigating":               "active",
+    "investigationSuspended":      "active",
+    "serviceDegradation":          "acknowledged",
+    "serviceInterruption":         "acknowledged",
+    "restoringService":            "monitoring",
+    "extendedRecovery":            "monitoring",
+    "serviceRestored":             "resolved",
+    "postIncidentReportPublished": "resolved",
+    "resolved":                    "resolved",
+}
+
 
 def _classify_issue(issue: dict) -> str | None:
     """Return internal classification string, or None if the issue should be skipped."""
@@ -46,10 +66,22 @@ def _classify_issue(issue: dict) -> str | None:
 
 
 def _issue_status(issue: dict, classification: str) -> str:
-    """Map Graph API issue to our internal status string."""
-    if issue.get("isResolved"):
-        return "completed" if classification == "maintenance" else "resolved"
-    return "scheduled" if classification == "maintenance" else "active"
+    """Map a Graph API issue to one of our internal phase/status strings.
+
+    Maintenance items use their own lifecycle (scheduled / completed).
+    Incidents are mapped via _GRAPH_INCIDENT_PHASE_MAP from the Graph
+    `status` field – which Microsoft updates as the incident progresses
+    from Investigating → ServiceDegradation/Interruption → RestoringService
+    → ServiceRestored. We fall back to active / resolved if Graph hasn't
+    set a recognized status.
+    """
+    if classification == "maintenance":
+        return "completed" if issue.get("isResolved") else "scheduled"
+    raw_status = issue.get("status", "")
+    mapped = _GRAPH_INCIDENT_PHASE_MAP.get(raw_status)
+    if mapped:
+        return mapped
+    return "resolved" if issue.get("isResolved") else "active"
 
 
 def _parse_dt(value: str | None) -> datetime | None:
@@ -68,16 +100,29 @@ async def sync_issue_as_incident(db, issue: dict) -> None:
     Returns silently if the issue should be skipped (advisory, falsePositive,
     or unknown classification). Posts are only synced when present on the
     issue dict – historical fetches may omit them for performance.
+
+    When the mapped phase changes between two consecutive polls we record
+    a state_change timeline entry so the incident detail phase-bar reflects
+    Microsoft's progression (Investigating → Identified → Monitoring →
+    Resolved) as proper segments.
     """
     classification = _classify_issue(issue)
     if classification is None:
         return
     severity = _GRAPH_SEVERITY_MAP.get(issue.get("severity", ""), "")
+    new_status = _issue_status(issue, classification)
+
+    existing = await db.execute(
+        sa_select(Incident).where(Incident.graph_issue_id == issue["id"])
+    )
+    existing_incident = existing.scalar_one_or_none()
+    old_status = existing_incident.status if existing_incident else None
+
     fields: dict = {
         "title": issue.get("title", ""),
         "service_name": issue.get("service", ""),
         "classification": classification,
-        "status": _issue_status(issue, classification),
+        "status": new_status,
         "start_datetime": _parse_dt(issue.get("startDateTime")),
         "last_modified": _parse_dt(issue.get("lastModifiedDateTime")),
         "is_resolved": issue.get("isResolved", False),
@@ -87,6 +132,10 @@ async def sync_issue_as_incident(db, issue: dict) -> None:
         fields["scheduled_start"] = _parse_dt(issue.get("startDateTime"))
         fields["scheduled_end"] = _parse_dt(issue.get("endDateTime"))
     incident = await upsert_incident(db, graph_issue_id=issue["id"], **fields)
+
+    if old_status is not None and old_status != new_status:
+        await add_state_change_entry(db, incident.id, new_status)
+
     posts = issue.get("posts")
     if posts:
         await upsert_incident_updates(db, incident.id, posts)

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -33,10 +33,16 @@ _GRAPH_SEVERITY_MAP: dict[str, str] = {
 }
 
 # Maps Graph API classification to our internal classification.
-# advisory and unknown classifications are excluded (return None → skip).
+# Unknown classifications are dropped (return None → skip).
+# - "incident":            real outages
+# - "advisory":            informational notices that don't impact uptime
+# - "plannedMaintenance":  scheduled service maintenance
+# - "planForChange":       upcoming feature/UI changes – treated as maintenance
 _GRAPH_CLASSIFICATION_MAP: dict[str, str] = {
     "incident":           "incident",
+    "advisory":           "advisory",
     "plannedMaintenance": "maintenance",
+    "planForChange":      "maintenance",
 }
 
 # Maps the Microsoft Graph issue `status` field to one of our incident phases:
@@ -65,18 +71,38 @@ def _classify_issue(issue: dict) -> str | None:
     return _GRAPH_CLASSIFICATION_MAP.get(issue.get("classification", ""))
 
 
+def _maintenance_phase(issue: dict) -> str:
+    """Compute the current phase for a maintenance/planForChange item.
+
+    Three phases mirror the existing dropdown:
+      scheduled    – future window
+      in_progress  – we are inside [start, end] right now
+      completed    – Graph marked it resolved
+    """
+    if issue.get("isResolved"):
+        return "completed"
+    start = _parse_dt(issue.get("startDateTime"))
+    end = _parse_dt(issue.get("endDateTime"))
+    now = datetime.utcnow()
+    if start and end and start <= now < end:
+        return "in_progress"
+    return "scheduled"
+
+
 def _issue_status(issue: dict, classification: str) -> str:
     """Map a Graph API issue to one of our internal phase/status strings.
 
-    Maintenance items use their own lifecycle (scheduled / completed).
-    Incidents are mapped via _GRAPH_INCIDENT_PHASE_MAP from the Graph
-    `status` field – which Microsoft updates as the incident progresses
-    from Investigating → ServiceDegradation/Interruption → RestoringService
-    → ServiceRestored. We fall back to active / resolved if Graph hasn't
-    set a recognized status.
+    - Maintenance / planForChange items roll through scheduled →
+      in_progress → completed based on their start/end window.
+    - Incidents and advisories are mapped via _GRAPH_INCIDENT_PHASE_MAP
+      from the Graph `status` field – which Microsoft updates as the
+      incident progresses from Investigating →
+      ServiceDegradation/Interruption → RestoringService → ServiceRestored.
+      Fall back to active / resolved if Graph hasn't set a recognized
+      status.
     """
     if classification == "maintenance":
-        return "completed" if issue.get("isResolved") else "scheduled"
+        return _maintenance_phase(issue)
     raw_status = issue.get("status", "")
     mapped = _GRAPH_INCIDENT_PHASE_MAP.get(raw_status)
     if mapped:


### PR DESCRIPTION
## Summary

Hängt an PR #32. **Bitte erst #32 mergen, dann diesen** — der Base-Branch springt danach automatisch auf `main`.

Microsoft liefert in jedem Service-Health-Issue ein `status`-Feld, das den Lifecycle abbildet:

```
Investigating  →  ServiceDegradation / ServiceInterruption  →  RestoringService / ExtendedRecovery  →  ServiceRestored
```

Bislang verwerfen wir dieses Feld und setzen für jeden unresolved Graph-Incident pauschal `active` — auf der neuen Phasen-Bar landen also alle Microsoft-Incidents in der ersten gelben Phase, egal in welchem Stadium sie wirklich sind.

### Phase-Map (Incidents)

| Microsoft `status`                                | Phase              | Farbe |
|---------------------------------------------------|--------------------|-------|
| `investigating`, `investigationSuspended`         | Untersuchung läuft | 🟡    |
| `serviceDegradation`, `serviceInterruption`       | Identifiziert      | 🟠    |
| `restoringService`, `extendedRecovery`            | Überwachung        | 🔵    |
| `serviceRestored`, `postIncidentReportPublished`  | Behoben            | 🟢    |

Unbekannter / leerer Status fällt auf `active` bzw. `resolved` zurück (je nach `isResolved`). `falsePositive` wird wie bisher in `_classify_issue` rausgefiltert.

### Classification-Map (erweitert)

| Microsoft `classification` | Intern        | Behavior                                                 |
|----------------------------|---------------|----------------------------------------------------------|
| `incident`                 | `incident`    | färbt Uptime-Bars; Phasen via Graph-Status               |
| `advisory`                 | `advisory`    | **neu** — informativ („Updates"), kein Effekt auf Bars   |
| `plannedMaintenance`       | `maintenance` | scheduled / in_progress / completed                       |
| `planForChange`            | `maintenance` | **neu** — wie Wartung behandelt                           |

`get_uptime_bars` filtert jetzt strikt auf `classification == "incident"` — Advisories und Maintenance lassen die Balken grün, wie es ihrem Charakter entspricht.

### Maintenance-Phasen (gleiche Logik wie Incidents)

Neuer Helper `_maintenance_phase` rollt durch:

- `scheduled` — Fenster liegt in der Zukunft → 🔵
- `in_progress` — wir sind *innerhalb* `[startDateTime, endDateTime]` → 🟠
- `completed` — `isResolved=True` → 🟢

Das State-Change-Tracking in `sync_issue_as_incident` zeichnet diese Übergänge automatisch auf — die Phase-Bar der Detailansicht zeigt also auch bei Wartungen echte Segmente.

### Phasen-Übergänge als State-Change

In `sync_issue_as_incident` lese ich vor dem Upsert den alten `status` ein und vergleiche mit dem neu gemappten. Wenn er sich geändert hat, lege ich einen `state_change`-Timeline-Eintrag an. Resultat: die Phase-Bar bekommt für Graph-Incidents *und* Maintenance echte proportionale Segmente statt einer einzelnen gelben/blauen Fläche.

Gleichbleibende Pollings produzieren keine Duplikate (Test bestätigt).

## Test plan

- [x] Classification-Smoketest (`incident`, `advisory`, `plannedMaintenance`, `planForChange`, unbekannt)
- [x] Maintenance-Phase-Smoketest (future → `scheduled`, jetzt → `in_progress`, past → `completed`, `planForChange` → `in_progress`)
- [x] End-to-End: Issue von `investigating` → `serviceDegradation` → `restoringService` → erneut `restoringService` (keine Dublette) → `serviceRestored` erzeugt genau 3 state_change-Einträge
- [x] Uptime-Bar-Integration: Tag mit Advisory bleibt `operational`, Tag mit echtem Incident wird `degraded`
- [x] `ruff check` grün

### Manuell zu prüfen

- [ ] M365-Incidents in der Übersicht mit korrektem Phase-Dot
- [ ] Phase-Bar in der Detailansicht zeigt mehrere Segmente bei Statuswechseln
- [ ] Advisories tauchen in der Aktive-Liste auf, beeinflussen die Bars aber nicht
- [ ] Wartungen wechseln automatisch auf `in_progress`, sobald das Fenster offen ist
- [ ] Manuelle Incidents bleiben vom Mapping unberührt

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq