### PR TITLE
feat: service groups on status page

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -430,17 +430,29 @@ async def get_suppressed_incidents(db: AsyncSession) -> list[Incident]:
 
 
 async def get_enabled_services(db: AsyncSession) -> list[str]:
+    # NULL group sorts last (asc nulls last is not portable on SQLite,
+    # so we coerce NULL -> "￿" which sorts after any real string)
+    from sqlalchemy import case
+    group_sort = case(
+        (MonitoredService.group_name.is_(None), "￿"),
+        else_=MonitoredService.group_name,
+    )
     result = await db.execute(
         select(MonitoredService.service_name)
         .where(MonitoredService.is_enabled.is_(True))
-        .order_by(MonitoredService.service_name)
+        .order_by(group_sort, MonitoredService.service_name)
     )
     return [row[0] for row in result.fetchall()]
 
 
 async def get_all_monitored_services(db: AsyncSession) -> list[MonitoredService]:
+    from sqlalchemy import case
+    group_sort = case(
+        (MonitoredService.group_name.is_(None), "￿"),
+        else_=MonitoredService.group_name,
+    )
     result = await db.execute(
-        select(MonitoredService).order_by(MonitoredService.service_name)
+        select(MonitoredService).order_by(group_sort, MonitoredService.service_name)
     )
     return list(result.scalars().all())
 
@@ -473,6 +485,27 @@ async def set_show_uptime_percentage(
     svc.show_uptime_percentage = show
     await db.flush()
     return svc
+
+
+async def set_service_group(
+    db: AsyncSession, service_name: str, group_name: str | None
+) -> MonitoredService:
+    svc = await ensure_service_known(db, service_name)
+    cleaned = (group_name or "").strip() or None
+    svc.group_name = cleaned
+    await db.flush()
+    return svc
+
+
+async def get_known_groups(db: AsyncSession) -> list[str]:
+    """Distinct, non-empty group names for the datalist autocomplete."""
+    result = await db.execute(
+        select(MonitoredService.group_name)
+        .where(MonitoredService.group_name.is_not(None))
+        .distinct()
+        .order_by(MonitoredService.group_name)
+    )
+    return [row[0] for row in result.fetchall() if row[0]]
 
 
 async def get_uptime_percentage(
@@ -515,18 +548,23 @@ async def build_status_page_data(
     services: list[ServiceStatusSchema] = []
     overall_severity = 0
 
-    show_flags_result = await db.execute(
-        select(MonitoredService.service_name, MonitoredService.show_uptime_percentage)
+    svc_meta_result = await db.execute(
+        select(
+            MonitoredService.service_name,
+            MonitoredService.show_uptime_percentage,
+            MonitoredService.group_name,
+        )
         .where(MonitoredService.service_name.in_(service_names))
     )
-    show_flags = {row[0]: row[1] for row in show_flags_result.fetchall()}
+    svc_meta = {row[0]: {"show_uptime": row[1], "group": row[2]} for row in svc_meta_result.fetchall()}
 
     for name in service_names:
         current_status = await get_service_current_status(db, name)
         uptime_days = await get_uptime_bars(db, name)
         raw_incidents = await get_active_incidents(db, service_name=name)
+        meta = svc_meta.get(name, {})
         uptime_pct = (
-            await get_uptime_percentage(db, name) if show_flags.get(name, True) else None
+            await get_uptime_percentage(db, name) if meta.get("show_uptime", True) else None
         )
 
         incident_schemas = [
@@ -564,6 +602,7 @@ async def build_status_page_data(
                 uptime_days=uptime_days,
                 active_incidents=incident_schemas,
                 uptime_percentage=uptime_pct,
+                group_name=meta.get("group"),
             )
         )
 

--- a/app/database.py
+++ b/app/database.py
@@ -47,6 +47,7 @@ async def init_db() -> None:
             "ALTER TABLE incidents ADD COLUMN is_suppressed BOOLEAN NOT NULL DEFAULT 0",
             "ALTER TABLE incidents ADD COLUMN end_datetime DATETIME",
             "ALTER TABLE monitored_services ADD COLUMN show_uptime_percentage BOOLEAN NOT NULL DEFAULT 1",
+            "ALTER TABLE monitored_services ADD COLUMN group_name VARCHAR(64)",
             "ALTER TABLE incident_updates ADD COLUMN notify_subscribers BOOLEAN NOT NULL DEFAULT 0",
         ]:
             try:

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -117,4 +117,12 @@ LABELS: dict[str, str] = {
     "admin.uptime_toggle_hint":   "Gesamtverfügbarkeit der letzten 90 Tage auf der Statusseite ein-/ausblenden",
     "page.uptime_90d":            "Gesamtverfügbarkeit (90 Tage)",
     "page.uptime_suffix":         "verfügbar",
+    # Service groups
+    "admin.service_group":            "Gruppe",
+    "admin.service_group_placeholder": "z. B. Microsoft 365",
+    "admin.service_group_save":       "Übernehmen",
+    "admin.service_group_hint":       "Leer lassen = ohne Gruppe (erscheint unter „Sonstiges“)",
+    "page.group_other":               "Sonstiges",
+    "page.group_count":               "{count} Dienste",
+    "page.group_count_one":           "1 Dienst",
 }

--- a/app/models.py
+++ b/app/models.py
@@ -126,4 +126,5 @@ class MonitoredService(Base):
     show_uptime_percentage: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default="1", default=True
     )
+    group_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -20,10 +20,12 @@ from app.crud import (
     get_all_monitored_services,
     get_enabled_services,
     get_incident_by_id,
+    get_known_groups,
     get_resolved_incidents,
     get_scheduled_maintenances,
     get_suppressed_incidents,
     set_service_enabled,
+    set_service_group,
     set_service_status_manual,
     set_show_uptime_percentage,
     toggle_suppress_incident,
@@ -172,12 +174,14 @@ async def admin_settings(
     nav: dict = Depends(admin_nav_context),
 ):
     all_services = await get_all_monitored_services(db)
+    known_groups = await get_known_groups(db)
     return templates.TemplateResponse(
         request,
         "admin/settings.html",
         {
             "user": user,
             "all_services": all_services,
+            "known_groups": known_groups,
             "page_title": f"Einstellungen – {settings.APP_TITLE}",
             **nav,
         },
@@ -386,6 +390,19 @@ async def toggle_uptime_display(
     svc = result.scalar_one_or_none()
     new_state = not (svc.show_uptime_percentage if svc else True)
     await set_show_uptime_percentage(db, service_name, new_state)
+    await db.commit()
+    return RedirectResponse(url="/admin/settings", status_code=303)
+
+
+@router.post("/services/{service_name}/group")
+async def update_service_group(
+    service_name: str,
+    group_name: Annotated[str, Form()] = "",
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    """Assign (or clear) the group for a monitored service."""
+    await set_service_group(db, service_name, group_name)
     await db.commit()
     return RedirectResponse(url="/admin/settings", status_code=303)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -38,6 +38,7 @@ class ServiceStatusSchema(BaseModel):
     uptime_days: list[DayStatusSchema]
     active_incidents: list[IncidentSchema] = []
     uptime_percentage: float | None = None
+    group_name: str | None = None
 
 
 class StatusPageSchema(BaseModel):

--- a/app/templates.py
+++ b/app/templates.py
@@ -71,6 +71,21 @@ templates.env.globals["phase_dot_class"] = (
     lambda s: PHASE_DOT.get(s, "bg-gray-300 dark:bg-gray-600")
 )
 
+
+def _group_services(services, fallback_label: str):
+    """Bucket services by group_name (None → fallback_label), preserving the
+    incoming order. Used by status.html instead of Jinja's groupby, which
+    cannot sort mixed None/str keys."""
+    buckets: dict[str, list] = {}
+    for s in services:
+        key = s.group_name or fallback_label
+        buckets.setdefault(key, []).append(s)
+    return list(buckets.items())
+
+
+templates.env.globals["group_services"] = _group_services
+
+
 # ── Filters ───────────────────────────────────────────────────────────────────
 def _strftime_de(dt: datetime | None, fmt: str = "%d.%m.%Y %H:%M Uhr") -> str:
     if dt is None:

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -24,14 +24,40 @@
 
   <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">{{ L["admin.service_backfill_hint"] }}</p>
 
+  {# Shared datalist for group autocomplete across all rows #}
+  <datalist id="known-groups">
+    {% for g in known_groups %}<option value="{{ g }}">{% endfor %}
+  </datalist>
+
   {% if all_services %}
   <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
     {% for svc in all_services %}
-    <div class="flex items-center justify-between px-5 py-3 gap-4 {{ '' if svc.is_enabled else 'opacity-60' }}">
-      <span class="font-medium text-sm {{ 'text-gray-800 dark:text-gray-200' if svc.is_enabled else 'text-gray-500 dark:text-gray-400' }}">
-        {{ svc.service_name }}
-      </span>
-      <div class="flex items-center gap-2">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between px-5 py-3 gap-3 {{ '' if svc.is_enabled else 'opacity-60' }}">
+      <div class="flex items-center gap-3 min-w-0">
+        <span class="font-medium text-sm {{ 'text-gray-800 dark:text-gray-200' if svc.is_enabled else 'text-gray-500 dark:text-gray-400' }} truncate">
+          {{ svc.service_name }}
+        </span>
+        {% if svc.group_name %}
+        <span class="inline-flex shrink-0 items-center text-[11px] font-medium px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+          {{ svc.group_name }}
+        </span>
+        {% endif %}
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/group"
+              class="flex items-center gap-1">
+          <input type="text"
+                 name="group_name"
+                 list="known-groups"
+                 value="{{ svc.group_name or '' }}"
+                 placeholder="{{ L['admin.service_group_placeholder'] }}"
+                 title="{{ L['admin.service_group_hint'] }}"
+                 class="text-xs px-2 py-1 w-36 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+          <button type="submit"
+                  class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+            {{ L["admin.service_group_save"] }}
+          </button>
+        </form>
         <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/uptime-toggle">
           <button type="submit"
                   title="{{ L['admin.uptime_toggle_hint'] }}"

--- a/templates/status.html
+++ b/templates/status.html
@@ -37,8 +37,27 @@
   <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
     {{ L["page.uptime_heading"] }}
   </h2>
-  {% for service in data.services %}
-    {% include "partials/service_row.html" %}
+  {# Services are pre-sorted by (group, name) in get_enabled_services.
+     group_services() buckets them while preserving that order — Jinja's
+     groupby would re-sort and fail on mixed None/str keys. Headers shown
+     only when there are 2+ distinct groups. #}
+  {% set grouped = group_services(data.services, L['page.group_other']) %}
+  {% set show_headers = grouped | length > 1 %}
+  {% for group_label, group_services in grouped %}
+    {% set svc_list = group_services | list %}
+    {% if show_headers %}
+    <div class="flex items-baseline justify-between mt-5 mb-2 first:mt-0">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+        {{ group_label }}
+      </h3>
+      <span class="text-[11px] text-gray-400 dark:text-gray-500">
+        {% if svc_list | length == 1 %}{{ L['page.group_count_one'] }}{% else %}{{ L['page.group_count'].format(count=svc_list | length) }}{% endif %}
+      </span>
+    </div>
+    {% endif %}
+    {% for service in svc_list %}
+      {% include "partials/service_row.html" %}
+    {% endfor %}
   {% endfor %}
 </section>
 


### PR DESCRIPTION
## Summary

Implements **#36** — optional grouping for monitored services. Public statuspage renders services bucketed under headers like "Microsoft 365", "Identität", "Interne Systeme" instead of one flat list.

### Was sich ändert

**Datenmodell**
- Neue Spalte `monitored_services.group_name VARCHAR(64) NULL` (additive Migration)
- `ServiceStatusSchema.group_name: str | None`

**Admin (`/admin/settings`)**
- Inline-Form pro Service: Text-Input für Gruppenname mit gemeinsamem `<datalist>` für Autocomplete aus bereits vergebenen Gruppen
- Aktuelle Gruppe wird als Indigo-Badge angezeigt
- Leerer Wert = "ohne Gruppe" (→ erscheint später unter "Sonstiges")
- Neuer POST-Endpoint `/admin/services/{name}/group`

**Public Statuspage (`/`)**
- Services werden nach `group_name` gebündelt
- Header pro Gruppe (uppercase tracking-wider) + Dienste-Count (`X Dienste`)
- Header werden **nur** angezeigt wenn ≥ 2 unterschiedliche Gruppen existieren — bei Single-Tenant-Setups bleibt alles wie vorher (kein Lärm)
- Services ohne Gruppe landen in "Sonstiges"

**Sortierung**
- `get_enabled_services` und `get_all_monitored_services` sortieren nach `(group_name ASC NULLS LAST, service_name ASC)` via Portable `CASE`-Expression
- Im Template gibt es einen kleinen `group_services()`-Helper in `app/templates.py`, der ordnungserhaltend buckets — Jinjas eingebautes `groupby` würde re-sortieren und an gemischten None/str-Keys crashen

### Smoke-Test (lokal)

Mit 5 Services und 2 Gruppen (Microsoft 365, Identität) + 1 ungrouped:
- Public `/` → HTTP 200, 3 Header sauber gerendert (Identität / Microsoft 365 / Sonstiges)
- Admin `/admin/settings` → HTTP 200, alle 4 gesetzten Gruppen als Indigo-Badge sichtbar
- POST `/admin/services/.../group` → HTTP 303 Redirect zurück
- Single-Group-Setup (alles ohne Gruppe) → keine Header sichtbar ✓

### Geänderte Dateien

| Datei | Änderung |
|---|---|
| `app/models.py` | `group_name` Field auf `MonitoredService` |
| `app/database.py` | Additive Migration `ALTER TABLE … ADD COLUMN group_name` |
| `app/schemas.py` | `group_name` auf `ServiceStatusSchema` |
| `app/crud.py` | `set_service_group`, `get_known_groups`, Sort-Order angepasst, `build_status_page_data` injiziert Gruppe |
| `app/routers/admin.py` | POST `/services/{name}/group` + `known_groups` ins Settings-Context |
| `app/templates.py` | `group_services()`-Helper |
| `app/i18n.py` | 7 neue Labels (Service group + page.group_other) |
| `templates/admin/settings.html` | Pro-Zeile Form + Badge + Datalist |
| `templates/status.html` | Group-Header-Rendering |

## Test plan

- [ ] CI: py_compile, Docker-Build, Integration-Tests
- [ ] Migration läuft sauber gegen bestehende DBs (kein Verlust existierender Services)
- [ ] Public Statuspage: Header erscheinen ab 2 Gruppen, verschwinden bei nur einer
- [ ] Admin: Gruppe setzen → Badge erscheint, Datalist enthält Vorschläge
- [ ] Gruppe per leerem Wert wieder entfernbar → Service landet in "Sonstiges"
- [ ] Dark-Mode-Kontrast auf den Gruppen-Headern + Indigo-Badges

Refs #36

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_