### PR TITLE
feat: modern-look bundle — toasts, pulse, empty states, color audit

### DIFF
--- a/app/templates.py
+++ b/app/templates.py
@@ -35,6 +35,32 @@ templates.env.globals["incident_type_label"] = (
 )
 
 
+# ── Severity & status colour system ───────────────────────────────────────────
+#
+# Single source of truth for every coloured chip, dot, border, badge and bar
+# rendered anywhere in the app. Whenever a template needs a colour for one of
+# these dimensions, it should go through a helper here — not hardcode a
+# Tailwind class — so a future palette tweak only happens in one place.
+#
+# Dimensions and their colour families:
+#
+#   service status        operational   degraded   interrupted   unknown
+#                         green         amber      red           gray
+#
+#   incident severity     critical      high       medium        low
+#                         red           orange     amber         blue
+#
+#   incident phase        active        acknowledged   monitoring   resolved
+#                         yellow        orange         blue         emerald
+#
+#   incident type         incident      advisory   maintenance
+#                         red           amber      blue
+#
+# Pulse animation: an active phase (active / acknowledged / monitoring) and a
+# non-operational service status both pulse — see PULSE_PHASES below and
+# `status_dot_pulse()`. Tailwind's animate-pulse is suppressed automatically
+# under `prefers-reduced-motion: reduce` (base.html).
+
 SEVERITY_BADGE: dict[str, str] = {
     "critical": "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400",
     "high":     "bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-400",
@@ -42,7 +68,7 @@ SEVERITY_BADGE: dict[str, str] = {
     "low":      "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-400",
 }
 
-# Standard incident-response phases mapped to a single colour each.
+# Incident-response phases:
 # active        → Investigating  (yellow)
 # acknowledged  → Identified     (orange)
 # monitoring    → Monitoring     (blue)
@@ -58,6 +84,11 @@ PHASE_DOT: dict[str, str] = {
     "in_progress":  "bg-amber-400",
 }
 
+# Phases / statuses that should *visually pulse* to signal "something is
+# happening right now". Resolved/completed/scheduled stay static.
+PULSE_PHASES: set[str] = {"active", "acknowledged", "monitoring", "in_progress"}
+PULSE_STATUSES: set[str] = {"degraded", "interrupted"}
+
 templates.env.globals["severity_badge_class"] = (
     lambda s: SEVERITY_BADGE.get(s, "")
 )
@@ -69,6 +100,12 @@ templates.env.globals["state_label"] = (
 )
 templates.env.globals["phase_dot_class"] = (
     lambda s: PHASE_DOT.get(s, "bg-gray-300 dark:bg-gray-600")
+)
+templates.env.globals["phase_pulse_class"] = (
+    lambda s: "animate-pulse" if s in PULSE_PHASES else ""
+)
+templates.env.globals["status_pulse_class"] = (
+    lambda s: "animate-pulse" if s in PULSE_STATUSES else ""
 )
 
 

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -17,9 +17,10 @@
   <div class="p-4">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
+        {% set _phase = 'resolved' if incident.is_resolved else incident.status %}
         <h3 class="font-medium text-gray-900 dark:text-white leading-snug flex items-center gap-2">
-          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ phase_dot_class('resolved' if incident.is_resolved else incident.status) }}"
-                title="{{ state_label('resolved' if incident.is_resolved else incident.status) }}"></span>
+          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ phase_dot_class(_phase) }} {{ phase_pulse_class(_phase) }}"
+                title="{{ state_label(_phase) }}"></span>
           <span>{{ incident.title }}</span>
         </h3>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">

--- a/templates/partials/service_row.html
+++ b/templates/partials/service_row.html
@@ -4,7 +4,7 @@
      data-service="{{ service.service_name }}">
   <div class="flex items-center justify-between">
     <span class="font-medium text-gray-800 dark:text-gray-100">{{ service.service_name }}</span>
-    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ status_badge_class(service.current_status) }}">
+    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ status_badge_class(service.current_status) }} {{ status_pulse_class(service.current_status) }}">
       {% if service.current_status == "operational" %}
       <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 8 8"><circle cx="4" cy="4" r="3"/></svg>
       {% elif service.current_status == "interrupted" %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -121,8 +121,14 @@
       {% endfor %}
     {% endfor %}
   {% else %}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
-    {{ L["page.no_incidents"] }}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-8 shadow-sm">
+    <div class="flex flex-col items-center text-center gap-2">
+      <div class="w-10 h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
+        <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+      </div>
+      <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ L["empty.public.all_good"] }}</p>
+      <p class="text-xs text-gray-500 dark:text-gray-400">{{ L["empty.public.all_good_sub"] }}</p>
+    </div>
   </div>
   {% endif %}
 </section>
@@ -224,8 +230,9 @@
       {% endfor %}
     </div>
     {% else %}
-    <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
-      {{ L["page.history_empty"] }}
+    <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-6 shadow-sm flex items-center gap-3 text-sm text-gray-600 dark:text-gray-300">
+      <svg class="w-5 h-5 shrink-0 text-emerald-500 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      <span>{{ L["empty.public.history"] }}</span>
     </div>
     {% endif %}
   </details>


### PR DESCRIPTION
## Summary

Bundles 4 kleine UX-Polish-Themen in einen PR (#45 + #48 + #49 + #51) — alles, was die App moderner anfühlen lässt, ohne dass eine einzelne Änderung Scope-Creep hat.

### 🍞 Toast Notifications (#48)

- Neuer `app/flash.py`-Helper: `flash(request, msg, level)` legt Messages in der Session ab
- `admin_nav_context` pop-t sie beim nächsten Render via `consume_flashes(request)` → single-shot
- Container in `base_admin.html` rendert Stack oben rechts mit 4 Levels (success/error/info/warning)
- Auto-Dismiss nach 4s (stagger 200ms), manueller X-Button, prefers-reduced-motion-konform
- 12 Admin-POST-Routes verkabelt: Service Toggle, Group Save, Uptime Toggle, Status Set, Discover, Incident CRUD, Update Post, Suppress, Unsuppress, Maintenance Create

### 💓 Pulse Animation (#45)

- Phase-Dots pulsieren bei `active` / `acknowledged` / `monitoring` / `in_progress`
- Service-Badges pulsieren bei `degraded` / `interrupted`
- `resolved` / `completed` / `scheduled` / `operational` stehen still
- Zwei neue Template-Globals: `phase_pulse_class()` und `status_pulse_class()`
- Globaler `@media (prefers-reduced-motion: reduce)` in `base.html` killt alle Animationen für opt-out-Nutzer

### ✨ Empty States mit Charme (#49)

| Stelle | Vorher | Nachher |
|---|---|---|
| Public, keine Incidents | "Keine aktiven Störungen gemeldet." | Grünes Checkmark + "Alles läuft rund. — Aktuell keine Störungen — Daumen hoch." |
| Public, History leer | "Keine behobenen Störungen…" | Icon + "Sauberer Monat — keine behobenen Störungen…" |
| Admin, Incidents leer | "Keine aktiven Einträge." | Icon + Headline + Sub: "Sobald eine Meldung reinkommt, erscheint sie hier." |
| Admin, Suppressed leer | "Keine ignorierten Meldungen." | Icon + warmer Text |
| Admin, Wartungen leer | "Keine geplanten Wartungen." | Icon + warmer Text |
| Settings, keine Services | Plain Link | Centered Icon + CTA-Button "Jetzt von Microsoft laden" |

### 🎨 Severity-Farb-Audit (#51)

- Doku-Block in `app/templates.py` als **Single Source of Truth** für alle 4 Dimensionen (Status, Severity, Phase, Type) und welche Tailwind-Familie pro Dimension genutzt wird
- Keine Class-Changes nötig — Audit bestätigt dass die bestehende Nutzung konsistent ist
- Beim nächsten Palette-Tweak nur die `_BADGE/_DOT/_BORDER`-Maps anpassen, nicht durch alle Templates jagen

## Smoke Test (lokal)

```
✅ Public empty state: "Alles läuft rund" + "Daumen hoch" sichtbar
✅ Toast erscheint nach Service-Toggle: "Dienst deaktiviert"
✅ Single-shot: Toast-Container ist beim nächsten GET WEG
✅ Phase-Dot: bg-yellow-400 animate-pulse korrekt gerendert für active
```

## Geänderte Dateien

| Datei | Was |
|---|---|
| `app/flash.py` (neu) | Session-Flash-Helper |
| `app/dependencies.py` | `admin_nav_context` pop-t Flashes |
| `app/templates.py` | Doku-Block + pulse helpers |
| `app/i18n.py` | 18 neue Labels (toast.* + empty.*) |
| `app/routers/admin.py` | `flash()` in 12 POST-Routes |
| `templates/admin/base_admin.html` | Toast-Container + Auto-Dismiss-JS |
| `templates/admin/dashboard.html` | Pulse + 3 warme Empty States |
| `templates/admin/settings.html` | Friendly Empty mit CTA |
| `templates/status.html` | 2 warme Empty States |
| `templates/partials/*` | Pulse-Klassen auf Service/Incident |
| `templates/base.html` | `prefers-reduced-motion` CSS |

## Test plan

- [ ] CI: py_compile + Docker-Build + Integration-Tests
- [ ] Toasts erscheinen sichtbar oben rechts nach Save/Delete-Actions
- [ ] Toasts verschwinden nach 4s (oder bei X-Click)
- [ ] Page-Reload zeigt KEINE Toasts mehr (single-shot)
- [ ] Aktive Incidents pulsieren in Admin-Liste und auf Public
- [ ] `prefers-reduced-motion: reduce` (Browser-Setting) → keine Animation
- [ ] Empty States in allen Listen modern/freundlich
- [ ] Dark-Mode-Kontrast auf Toasts ist sauber

Refs #45 #48 #49 #51

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_