### PR TITLE
feat: dashboard redesign + click-to-detail overlay + split incidents/advisories

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -276,7 +276,10 @@ async def get_scheduled_maintenances(db: AsyncSession) -> list[Incident]:
 async def get_all_incidents(
     db: AsyncSession,
     include_resolved: bool = False,
+    classification: str | None = None,
 ) -> list[Incident]:
+    """Return non-maintenance incidents. Pass classification='incident' for
+    real disruptions only, 'advisory' for informational items."""
     stmt = (
         select(Incident)
         .options(selectinload(Incident.updates))
@@ -285,6 +288,8 @@ async def get_all_incidents(
     )
     if not include_resolved:
         stmt = stmt.where(Incident.is_resolved.is_(False))
+    if classification is not None:
+        stmt = stmt.where(Incident.classification == classification)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -443,6 +448,36 @@ async def get_enabled_services(db: AsyncSession) -> list[str]:
         .order_by(group_sort, MonitoredService.service_name)
     )
     return [row[0] for row in result.fetchall()]
+
+
+async def get_enabled_services_with_status(db: AsyncSession) -> list[dict]:
+    """Same order as get_enabled_services, enriched with current status + group.
+
+    Used by the admin dashboard to render status-aware quick-action tiles.
+    """
+    from sqlalchemy import case
+    group_sort = case(
+        (MonitoredService.group_name.is_(None), "￿"),
+        else_=MonitoredService.group_name,
+    )
+    result = await db.execute(
+        select(
+            MonitoredService.service_name,
+            MonitoredService.group_name,
+        )
+        .where(MonitoredService.is_enabled.is_(True))
+        .order_by(group_sort, MonitoredService.service_name)
+    )
+    rows = result.fetchall()
+    enriched: list[dict] = []
+    for name, group in rows:
+        status = await get_service_current_status(db, name)
+        enriched.append({
+            "service_name": name,
+            "group_name": group,
+            "current_status": status,
+        })
+    return enriched
 
 
 async def get_all_monitored_services(db: AsyncSession) -> list[MonitoredService]:

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -25,7 +25,7 @@ async def admin_nav_context(
 
     incidents_q = select(func.count(Incident.id)).where(
         Incident.is_resolved.is_(False),
-        Incident.classification != "maintenance",
+        Incident.classification == "incident",
         Incident.is_suppressed.is_(False),
     )
     maintenances_q = select(func.count(Incident.id)).where(

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -36,6 +36,10 @@ LABELS: dict[str, str] = {
     "admin.title":                "Admin",
     "admin.dashboard":            "Dashboard",
     "admin.incidents":            "Störungen & Hinweise",
+    "admin.incidents_only":       "Aktive Störungen",
+    "admin.advisories":           "Hinweise",
+    "admin.services_count_suffix": "Dienste",
+    "empty.admin.advisories":     "Keine aktiven Hinweise.",
     # Admin – Sidebar navigation
     "admin.nav.dashboard":        "Dashboard",
     "admin.nav.incidents":        "Störungen",

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -22,6 +22,7 @@ from app.crud import (
     get_all_subscribers,
     get_confirmed_subscribers,
     get_enabled_services,
+    get_enabled_services_with_status,
     get_incident_by_id,
     get_known_groups,
     get_resolved_incidents,
@@ -151,21 +152,27 @@ async def admin_dashboard(
     user: dict = Depends(require_auth),
     nav: dict = Depends(admin_nav_context),
 ):
-    incidents = await get_all_incidents(db, include_resolved=False)
+    incidents = await get_all_incidents(
+        db, include_resolved=False, classification="incident"
+    )
+    advisories = await get_all_incidents(
+        db, include_resolved=False, classification="advisory"
+    )
     resolved = await get_resolved_incidents(db, limit=10)
     suppressed = await get_suppressed_incidents(db)
     maintenances = await get_scheduled_maintenances(db)
-    enabled_services = await get_enabled_services(db)
+    services_with_status = await get_enabled_services_with_status(db)
     return templates.TemplateResponse(
         request,
         "admin/dashboard.html",
         {
             "user": user,
             "incidents": incidents,
+            "advisories": advisories,
             "resolved_incidents": resolved,
             "suppressed_incidents": suppressed,
             "maintenances": maintenances,
-            "services": enabled_services,
+            "services": services_with_status,
             "page_title": f"Admin – {settings.APP_TITLE}",
             **nav,
         },

--- a/app/templates.py
+++ b/app/templates.py
@@ -75,10 +75,11 @@ templates.env.globals["phase_dot_class"] = (
 def _group_services(services, fallback_label: str):
     """Bucket services by group_name (None → fallback_label), preserving the
     incoming order. Used by status.html instead of Jinja's groupby, which
-    cannot sort mixed None/str keys."""
+    cannot sort mixed None/str keys. Accepts both ORM objects and dicts."""
     buckets: dict[str, list] = {}
     for s in services:
-        key = s.group_name or fallback_label
+        group = s.get("group_name") if isinstance(s, dict) else getattr(s, "group_name", None)
+        key = group or fallback_label
         buckets.setdefault(key, []).append(s)
     return list(buckets.items())
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -22,68 +22,136 @@
 </div>
 
 {# ── Dienststatus überschreiben ──────────────────────────────────────────────── #}
+{% set status_meta = {
+  'operational': {'dot': 'bg-emerald-500', 'label': L['status.operational'], 'ring': 'ring-emerald-500/30', 'text': 'text-emerald-700 dark:text-emerald-400', 'bg': 'bg-emerald-50 dark:bg-emerald-950/30'},
+  'degraded':    {'dot': 'bg-amber-500',   'label': L['status.degraded'],    'ring': 'ring-amber-500/30',   'text': 'text-amber-700 dark:text-amber-400',     'bg': 'bg-amber-50 dark:bg-amber-950/30'},
+  'interrupted': {'dot': 'bg-red-500',     'label': L['status.interrupted'], 'ring': 'ring-red-500/30',     'text': 'text-red-700 dark:text-red-400',         'bg': 'bg-red-50 dark:bg-red-950/30'},
+  'unknown':     {'dot': 'bg-gray-400',    'label': L['status.unknown'],     'ring': 'ring-gray-400/30',    'text': 'text-gray-600 dark:text-gray-400',       'bg': 'bg-gray-50 dark:bg-gray-900'},
+} %}
 <section class="mb-8">
-  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
-    {{ L["admin.service_status"] }}
-  </h2>
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
-    {% for service in services %}
-    <form method="post" action="/admin/services/{{ service | urlencode }}/status"
-          class="flex items-center justify-between px-5 py-3 gap-4">
-      <span class="font-medium text-sm text-gray-800 dark:text-gray-200">{{ service }}</span>
-      <div class="flex items-center gap-2">
-        <select name="status"
-                class="text-sm rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500">
-          <option value="operational">{{ L["status.operational"] }}</option>
-          <option value="degraded">{{ L["status.degraded"] }}</option>
-          <option value="interrupted">{{ L["status.interrupted"] }}</option>
-          <option value="unknown">{{ L["status.unknown"] }}</option>
-        </select>
-        <button type="submit"
-                class="px-3 py-1.5 rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-sm font-medium text-gray-700 dark:text-gray-300 transition-colors">
-          {{ L["admin.set_status"] }}
-        </button>
-      </div>
-    </form>
-    {% endfor %}
+  <div class="flex items-baseline justify-between mb-3">
+    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {{ L["admin.service_status"] }}
+    </h2>
+    <span class="text-[11px] text-gray-400 dark:text-gray-500">{{ services | length }} {{ L["admin.services_count_suffix"] }}</span>
   </div>
+
+  {% set grouped = group_services(services, L['page.group_other']) %}
+  {% set show_headers = grouped | length > 1 %}
+
+  {% for group_label, group_services in grouped %}
+    {% set svc_list = group_services | list %}
+    {% if show_headers %}
+    <div class="flex items-baseline justify-between mt-5 mb-2 first:mt-0">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">{{ group_label }}</h3>
+      <span class="text-[11px] text-gray-400 dark:text-gray-500">
+        {% if svc_list | length == 1 %}{{ L['page.group_count_one'] }}{% else %}{{ L['page.group_count'].format(count=svc_list | length) }}{% endif %}
+      </span>
+    </div>
+    {% endif %}
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+      {% for svc in svc_list %}
+        {% set cur = svc.current_status %}
+        {% set meta = status_meta.get(cur, status_meta['unknown']) %}
+        <div class="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-800 shadow-sm p-3 flex items-center gap-3">
+          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ meta.dot }} ring-4 {{ meta.ring }}"
+                title="{{ meta.label }}"></span>
+          <div class="flex-1 min-w-0">
+            <p class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate">{{ svc.service_name }}</p>
+            <p class="text-[11px] {{ meta.text }} font-medium uppercase tracking-wide">{{ meta.label }}</p>
+          </div>
+          <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/status"
+                class="flex items-center gap-1 shrink-0">
+            {% for key in ['operational', 'degraded', 'interrupted'] %}
+              {% set is_current = (cur == key) %}
+              {% set bm = status_meta[key] %}
+              <button type="submit" name="status" value="{{ key }}"
+                      title="{{ bm.label }}"
+                      class="w-8 h-8 rounded-lg flex items-center justify-center transition-all
+                        {% if is_current %}{{ bm.bg }} {{ bm.text }} ring-1 ring-current/20
+                        {% else %}text-gray-300 dark:text-gray-600 hover:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800{% endif %}">
+                {% if key == 'operational' %}
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                {% elif key == 'degraded' %}
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.732 0 2.814-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.008v.008H12v-.008z"/></svg>
+                {% else %}
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                {% endif %}
+              </button>
+            {% endfor %}
+          </form>
+        </div>
+      {% endfor %}
+    </div>
+  {% endfor %}
 </section>
 
-{# ── Aktive Störungen & Hinweise ─────────────────────────────────────────────── #}
+{# ── Aktive Störungen ────────────────────────────────────────────────────────── #}
+{% macro incident_row(inc) %}
+<div class="flex items-center justify-between px-5 py-3 group">
+  <a href="/admin/incidents/{{ inc.id }}" class="flex-1 flex items-center gap-0 hover:opacity-80 transition-opacity min-w-0">
+    {% set _phase = 'resolved' if inc.is_resolved else inc.status %}
+    <span class="w-2.5 h-2.5 rounded-full mr-2 shrink-0 {{ phase_dot_class(_phase) }}"
+          title="{{ state_label(_phase) }}"></span>
+    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
+      {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
+      {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
+      {{ incident_type_label(inc.classification) }}
+    </span>
+    {% if inc.severity %}
+    <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5 {{ severity_badge_class(inc.severity) }}">{{ severity_label(inc.severity) }}</span>
+    {% endif %}
+    <span class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate">{{ inc.title }}</span>
+    <span class="text-sm text-gray-400 dark:text-gray-500 ml-2 shrink-0">· {{ inc.service_name }}</span>
+  </a>
+  <form method="post" action="/admin/incidents/{{ inc.id }}/suppress" class="ml-3 shrink-0">
+    <button type="submit"
+            class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+      {{ L["admin.suppress"] }}
+    </button>
+  </form>
+</div>
+{% endmacro %}
+
 <section id="incidents" class="mb-8 scroll-mt-20">
   <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
-    {{ L["admin.incidents"] }}
+    {{ L["admin.incidents_only"] }}
   </h2>
   {% if incidents %}
   <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
-    {% for inc in incidents %}
-    <div class="flex items-center justify-between px-5 py-3 group">
-      <a href="/admin/incidents/{{ inc.id }}" class="flex-1 flex items-center gap-0 hover:opacity-80 transition-opacity min-w-0">
-        <span class="w-2.5 h-2.5 rounded-full mr-2 shrink-0 {{ phase_dot_class('resolved' if inc.is_resolved else inc.status) }}"
-              title="{{ state_label('resolved' if inc.is_resolved else inc.status) }}"></span>
-        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5
-          {% if inc.classification == 'advisory' %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400
-          {% else %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400{% endif %}">
-          {{ incident_type_label(inc.classification) }}
-        </span>
-        {% if inc.severity %}
-        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mr-1.5 {{ severity_badge_class(inc.severity) }}">{{ severity_label(inc.severity) }}</span>
-        {% endif %}
-        <span class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate">{{ inc.title }}</span>
-        <span class="text-sm text-gray-400 dark:text-gray-500 ml-2 shrink-0">· {{ inc.service_name }}</span>
-      </a>
-      <form method="post" action="/admin/incidents/{{ inc.id }}/suppress" class="ml-3 shrink-0">
-        <button type="submit"
-                class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 hover:text-gray-700 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
-          {{ L["admin.suppress"] }}
-        </button>
-      </form>
-    </div>
-    {% endfor %}
+    {% for inc in incidents %}{{ incident_row(inc) }}{% endfor %}
   </div>
   {% else %}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-500 dark:text-gray-400 shadow-sm">
-    {{ L["admin.no_incidents"] }}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-6 shadow-sm">
+    <div class="flex items-center gap-3">
+      <div class="w-8 h-8 rounded-full bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center text-emerald-600 dark:text-emerald-400 shrink-0">
+        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+      </div>
+      <div>
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ L["empty.admin.incidents"] }}</p>
+        <p class="text-xs text-gray-500 dark:text-gray-400">{{ L["empty.admin.incidents_sub"] }}</p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+</section>
+
+{# ── Hinweise (Advisories) ───────────────────────────────────────────────────── #}
+<section id="advisories" class="mb-8 scroll-mt-20">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
+    {{ L["admin.advisories"] }}
+  </h2>
+  {% if advisories %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 divide-y divide-gray-100 dark:divide-gray-800 shadow-sm overflow-hidden">
+    {% for inc in advisories %}{{ incident_row(inc) }}{% endfor %}
+  </div>
+  {% else %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-4 text-sm text-gray-400 dark:text-gray-500 shadow-sm flex items-center gap-2">
+    <svg class="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"/>
+    </svg>
+    <span>{{ L["empty.admin.advisories"] }}</span>
   </div>
   {% endif %}
 </section>

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -32,7 +32,7 @@
     </form>
     {% endif %}
     <form method="post" action="/admin/incidents/{{ incident.id }}/delete"
-          onsubmit="return confirm('{{ L[&quot;admin.delete_confirm&quot;] }}');">
+          onsubmit="return confirm('{{ L['admin.delete_confirm'] }}');">
       <button type="submit" class="text-xs px-2.5 py-1 rounded-lg border border-red-300 text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20 transition-colors">
         {{ L["admin.delete"] }}
       </button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -107,6 +107,34 @@
     {% block content %}{% endblock %}
   </main>
 
+  <!-- ── Day-detail modal: opened by clicking a 90-day uptime bar ───────────── -->
+  <div id="day-modal" role="dialog" aria-modal="true" aria-labelledby="day-modal-title"
+       class="fixed inset-0 z-50 hidden items-center justify-center p-4">
+    <div data-day-modal-backdrop class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
+    <div class="relative bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full border border-gray-100 dark:border-gray-800 overflow-hidden">
+      <div class="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-start justify-between gap-3">
+        <div class="min-w-0 flex items-center gap-3">
+          <span id="day-modal-dot" class="w-3 h-3 rounded-full shrink-0"></span>
+          <div>
+            <h3 id="day-modal-title" class="text-base font-semibold text-gray-900 dark:text-white"></h3>
+            <p id="day-modal-sub" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"></p>
+          </div>
+        </div>
+        <button type="button" data-day-modal-close aria-label="Schließen"
+                class="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
+          </svg>
+        </button>
+      </div>
+      <div class="px-5 py-4">
+        <div id="day-modal-status-row" class="inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3"></div>
+        <p id="day-modal-body" class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed"></p>
+        <div id="day-modal-incidents" class="mt-4 space-y-2"></div>
+      </div>
+    </div>
+  </div>
+
   <!-- PWA install prompt (shown only after browser fires beforeinstallprompt) -->
   <button id="pwa-install-btn"
           aria-label="App installieren"
@@ -128,6 +156,162 @@
       html.classList.toggle('dark');
       localStorage.setItem('theme', html.classList.contains('dark') ? 'dark' : 'light');
     });
+  </script>
+
+  <script>
+    // Day-detail modal: opens when a 90-day uptime bar is clicked
+    (function () {
+      const modal = document.getElementById('day-modal');
+      if (!modal) return;
+      const title = document.getElementById('day-modal-title');
+      const sub = document.getElementById('day-modal-sub');
+      const dot = document.getElementById('day-modal-dot');
+      const statusRow = document.getElementById('day-modal-status-row');
+      const body = document.getElementById('day-modal-body');
+      const incidentsBox = document.getElementById('day-modal-incidents');
+
+      const STATUS_STYLE = {
+        operational: { dot: 'bg-emerald-500', badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300', body: 'Keine Vorfälle an diesem Tag — Dienst lief normal.' },
+        degraded:    { dot: 'bg-amber-500',   badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',       body: 'Eingeschränkte Verfügbarkeit an diesem Tag.' },
+        interrupted: { dot: 'bg-red-500',     badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',               body: 'Dienstunterbrechung an diesem Tag.' },
+        no_data:     { dot: 'bg-gray-300',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: 'Keine Datenpunkte für diesen Tag verfügbar.' },
+        unknown:     { dot: 'bg-gray-400',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: 'Status unbekannt.' },
+      };
+
+      function open(btn) {
+        const date = btn.dataset.date;
+        const dateLabel = btn.dataset.dateLabel;
+        const status = btn.dataset.status;
+        const statusLabel = btn.dataset.statusLabel;
+        const service = btn.dataset.service;
+        const style = STATUS_STYLE[status] || STATUS_STYLE.unknown;
+
+        title.textContent = service;
+        sub.textContent = dateLabel;
+        dot.className = 'w-3 h-3 rounded-full shrink-0 ' + style.dot;
+        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3 ' + style.badge;
+        statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + statusLabel;
+        body.textContent = style.body;
+
+        // Look up incidents covering this date by scanning history entries
+        // (each entry has a data-incident block we can pattern-match against).
+        incidentsBox.innerHTML = '';
+        const matching = findIncidentsCoveringDate(service, date);
+        if (matching.length === 0) {
+          incidentsBox.innerHTML = '';
+        } else {
+          const header = document.createElement('p');
+          header.className = 'text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2';
+          header.textContent = 'Zugehörige Einträge';
+          incidentsBox.appendChild(header);
+          matching.forEach((inc) => {
+            const link = document.createElement('a');
+            link.href = inc.href;
+            link.className = 'block px-3 py-2 rounded-lg border border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors';
+            link.innerHTML = '<span class="text-sm font-medium text-gray-800 dark:text-gray-200">' + inc.title + '</span>'
+              + '<span class="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">' + inc.meta + '</span>';
+            incidentsBox.appendChild(link);
+          });
+        }
+
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+        document.body.classList.add('overflow-hidden');
+      }
+
+      function close() {
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+        document.body.classList.remove('overflow-hidden');
+      }
+
+      // Find incident entries on the page whose [start..end] date range covers `date`
+      // Returns [{title, href, meta}]. Uses [data-incident-entry] attributes.
+      function findIncidentsCoveringDate(service, date) {
+        const all = document.querySelectorAll('[data-incident-entry]');
+        const out = [];
+        all.forEach((el) => {
+          if (el.dataset.service && el.dataset.service !== service) return;
+          const start = el.dataset.start;
+          const end = el.dataset.end || new Date().toISOString().slice(0, 10);
+          if (start && date >= start && date <= end) {
+            out.push({
+              title: el.dataset.title || '(ohne Titel)',
+              href: el.dataset.href || '#',
+              meta: el.dataset.meta || '',
+            });
+          }
+        });
+        return out;
+      }
+
+      function openIncidentCard(card) {
+        const status = card.dataset.status || 'unknown';
+        const style = STATUS_STYLE[status] || STATUS_STYLE.unknown;
+
+        title.textContent = card.dataset.title || '';
+        sub.textContent = card.dataset.service || '';
+        dot.className = 'w-3 h-3 rounded-full shrink-0 ' + style.dot;
+
+        // Status row: combine classification + severity + state
+        const chips = [];
+        if (card.dataset.classification) chips.push(card.dataset.classification);
+        if (card.dataset.severityLabel) chips.push(card.dataset.severityLabel);
+        if (card.dataset.statusLabel) chips.push(card.dataset.statusLabel);
+        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3 ' + style.badge;
+        statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + chips.join(' · ');
+
+        body.innerHTML = '';
+        if (card.dataset.since) {
+          const p = document.createElement('p');
+          p.className = 'text-xs text-gray-500 dark:text-gray-400 mb-2';
+          p.innerHTML = '<span class="font-medium">Seit:</span> ' + card.dataset.since;
+          body.appendChild(p);
+        }
+        if (card.dataset.description) {
+          const desc = document.createElement('p');
+          desc.className = 'text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-line';
+          desc.textContent = card.dataset.description;
+          body.appendChild(desc);
+        } else {
+          const p = document.createElement('p');
+          p.className = 'text-sm text-gray-500 dark:text-gray-400 italic';
+          p.textContent = 'Keine weiteren Details verfügbar.';
+          body.appendChild(p);
+        }
+
+        incidentsBox.innerHTML = '';
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+        document.body.classList.add('overflow-hidden');
+      }
+
+      document.addEventListener('click', (e) => {
+        // Day bars take priority over incident cards (they're inside service cards)
+        const bar = e.target.closest('[data-day-bar]');
+        if (bar) {
+          e.preventDefault();
+          open(bar);
+          return;
+        }
+        const card = e.target.closest('[data-incident-card]');
+        if (card && !e.target.closest('a, button, summary, details')) {
+          openIncidentCard(card);
+          return;
+        }
+        if (e.target.closest('[data-day-modal-close], [data-day-modal-backdrop]')) {
+          close();
+        }
+      });
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !modal.classList.contains('hidden')) close();
+        // Space/Enter on focused incident card opens modal
+        if ((e.key === 'Enter' || e.key === ' ') && document.activeElement?.matches('[data-incident-card]')) {
+          e.preventDefault();
+          openIncidentCard(document.activeElement);
+        }
+      });
+    })();
   </script>
 
   <script>

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -1,5 +1,19 @@
 {# Renders one incident card with update timeline. Expects `incident` in scope. #}
-<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 border-l-4 {{ incident_border_class(incident.classification) }} shadow-sm mb-4 overflow-hidden">
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 border-l-4 {{ incident_border_class(incident.classification) }} shadow-sm mb-4 overflow-hidden cursor-pointer hover:shadow-md transition-shadow"
+     role="button"
+     tabindex="0"
+     data-incident-entry
+     data-incident-card
+     data-service="{{ incident.service_name }}"
+     data-start="{{ incident.start_datetime.date().isoformat() if incident.start_datetime else '' }}"
+     data-end="{{ (incident.end_datetime.date().isoformat() if incident.end_datetime else '') }}"
+     data-title="{{ incident.title }}"
+     data-status="{{ 'resolved' if incident.is_resolved else incident.status }}"
+     data-status-label="{{ state_label('resolved' if incident.is_resolved else incident.status) }}"
+     data-classification="{{ incident_type_label(incident.classification) }}"
+     data-severity-label="{{ severity_label(incident.severity) if incident.severity else '' }}"
+     data-since="{{ incident.start_datetime | strftime_de if incident.start_datetime else '' }}"
+     data-description="{{ incident.description or '' }}">
   <div class="p-4">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">

--- a/templates/partials/service_row.html
+++ b/templates/partials/service_row.html
@@ -1,5 +1,7 @@
 {# Renders one service card. Expects `service` (ServiceStatusSchema) in scope. #}
-<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-3 shadow-sm">
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-3 shadow-sm"
+     data-service-card
+     data-service="{{ service.service_name }}">
   <div class="flex items-center justify-between">
     <span class="font-medium text-gray-800 dark:text-gray-100">{{ service.service_name }}</span>
     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ status_badge_class(service.current_status) }}">

--- a/templates/partials/uptime_bar.html
+++ b/templates/partials/uptime_bar.html
@@ -1,11 +1,17 @@
 {# Renders 90 colored day bars. Expects `service` in scope. #}
 <div class="flex gap-px w-full mt-2" aria-label="90-Tage Verfügbarkeit">
   {% for day in service.uptime_days %}
-  <div
-    class="h-7 flex-1 rounded-sm bar-tooltip transition-opacity {{ status_bar_class(day.status) }}"
+  <button type="button"
+    data-day-bar
+    data-date="{{ day.date.isoformat() }}"
+    data-date-label="{{ day.date | date_de }}"
+    data-status="{{ day.status }}"
+    data-status-label="{{ status_label(day.status) }}"
+    data-service="{{ service.service_name }}"
+    class="h-7 flex-1 rounded-sm bar-tooltip transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-blue-500/40 cursor-pointer {{ status_bar_class(day.status) }}"
     title="{{ day.date | date_de }}: {{ status_label(day.status) }}"
     aria-label="{{ day.date | date_de }}: {{ status_label(day.status) }}"
-  ></div>
+  ></button>
   {% endfor %}
 </div>
 <div class="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mt-1">

--- a/templates/status.html
+++ b/templates/status.html
@@ -148,7 +148,15 @@
     {% if recent_resolved %}
     <div class="space-y-2">
       {% for incident in recent_resolved %}
-      <details class="group/item bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+      <details class="group/item bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden"
+               id="incident-{{ incident.id }}"
+               data-incident-entry
+               data-service="{{ incident.service_name }}"
+               data-start="{{ incident.start_datetime.date().isoformat() if incident.start_datetime else '' }}"
+               data-end="{{ (incident.end_datetime.date().isoformat() if incident.end_datetime else (incident.last_modified.date().isoformat() if incident.last_modified else '')) }}"
+               data-title="{{ incident.title }}"
+               data-href="#incident-{{ incident.id }}"
+               data-meta="{{ incident_type_label(incident.classification) }} · {{ incident.service_name }}">
         <summary class="flex items-center gap-3 px-4 py-3 cursor-pointer list-none select-none hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
           <svg class="w-3.5 h-3.5 text-gray-300 dark:text-gray-600 shrink-0 transition-transform group-open/item:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>


### PR DESCRIPTION
## Summary

QA-Feedback aus dem letzten Sprint umgesetzt:

1. **Dienststatus-Section neu** (OneUptime-Style)
   - Card-Grid statt langer Select-Liste
   - Status-Dot mit Ring, Label und 3 Quick-Action-Buttons je Service
   - Aktiver Status visuell hervorgehoben (Hintergrund + Border)
   - Gruppierung nach `group_name` (analog öffentlicher Seite)

2. **Störungen ≠ Hinweise**
   - Dashboard-Section "Störungen & Hinweise" → getrennt in:
     - **Aktive Störungen** (`classification == "incident"`)
     - **Hinweise** (`classification == "advisory"`)
   - Sidebar-Counter zählt jetzt ebenfalls nur echte Incidents
   - Verhindert dass beratende Advisories als kritisch wirken

3. **Internal Server Error auf `/admin/incidents/{id}` behoben**
   - Bug: `L[&quot;admin.delete_confirm&quot;]` benutzte HTML-Entities
     innerhalb einer Jinja-Expression → `TemplateSyntaxError`
   - Fix: single-quote `L['admin.delete_confirm']`

4. **Klick-auf-Balken Overlay**
   - 90-Tage-Balken sind jetzt klickbar (`<button>` statt `<div>`)
   - Click öffnet zentrales Modal mit:
     - Service-Name + Datum als Titel
     - Status-Pill (operational/degraded/interrupted)
     - Erklärung was an diesem Tag passiert ist
     - Liste der Incidents die diesen Tag abdecken (mit Link zum History-Anchor)
   - Tastatur-Support: Escape schließt, Space/Enter aktiviert
   - Modal lebt in `base.html` und wird für beide Use-Cases wiederverwendet

5. **Klick-auf-Störung im Public Bereich**
   - Aktive Incident-Karten sind klickbar (cursor-pointer, role=button)
   - Click öffnet das gleiche Modal mit Titel, Klassifikation, Severity,
     Phase, Start-Datum und Beschreibung

## What's new

| Datei | Änderung |
|---|---|
| `templates/admin/dashboard.html` | Komplette Neugestaltung Dienststatus + Split Incidents/Hinweise |
| `templates/admin/incident_detail.html` | 500-Bug-Fix (`&quot;` → `'`) |
| `templates/partials/uptime_bar.html` | `<div>` → `<button data-day-bar>` mit Datum/Status-Attrs |
| `templates/partials/incident_card.html` | `data-incident-card` + alle Attrs für Modal |
| `templates/partials/service_row.html` | `data-service-card` wrapper |
| `templates/base.html` | Day-Detail-Modal + JS (Click-Handler + Lookup) |
| `templates/status.html` | History-Einträge erhalten `data-incident-entry` |
| `app/crud.py` | `get_enabled_services_with_status()` + `classification`-Filter in `get_all_incidents()` |
| `app/dependencies.py` | Sidebar-Counter nur Incidents (nicht Advisories) |
| `app/templates.py` | `group_services()` Helper akzeptiert Dicts & ORM-Objekte |
| `app/routers/admin.py` | Dashboard-View liefert getrennte `incidents` / `advisories` |
| `app/i18n.py` | Neue Keys: `admin.incidents_only`, `admin.advisories`, `empty.admin.advisories`, `admin.services_count_suffix` |

## Test plan

- [ ] `/admin` → Dienststatus zeigt Cards in Grid, Status-Buttons werden bei Klick aktiv
- [ ] `/admin` → Aktive Störungen und Hinweise sind separate Sections
- [ ] Sidebar-Counter "Störungen" zeigt nur Incidents, keine Advisories
- [ ] `/admin/incidents/{id}` lädt ohne 500
- [ ] Klick auf 90-Tage-Balken → Modal öffnet sich, Status-Pill stimmt
- [ ] Klick auf Balken im Zeitraum eines History-Incidents → Incident wird im Modal verlinkt
- [ ] Klick auf aktive Incident-Karte (public) → Modal mit Details
- [ ] Escape schließt Modal
- [ ] Mobile: Modal scrollt, Backdrop-Click schließt

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_