### PR TITLE
feat: filter dropdowns, source/ref fields, tab nav UX, badge sizes

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -314,6 +314,8 @@ async def create_manual_incident(
     start_datetime: datetime | None = None,
     scheduled_start: datetime | None = None,
     scheduled_end: datetime | None = None,
+    source: str = "manual",
+    external_id: str | None = None,
 ) -> Incident:
     now = datetime.utcnow()
     start = start_datetime or now
@@ -328,7 +330,8 @@ async def create_manual_incident(
         start_datetime=start,
         last_modified=now,
         is_resolved=False,
-        source="manual",
+        source=source or "manual",
+        external_id=external_id or None,
         scheduled_start=scheduled_start,
         scheduled_end=scheduled_end,
     )

--- a/app/database.py
+++ b/app/database.py
@@ -50,6 +50,7 @@ async def init_db() -> None:
             "ALTER TABLE monitored_services ADD COLUMN group_name VARCHAR(64)",
             "ALTER TABLE incident_updates ADD COLUMN notify_subscribers BOOLEAN NOT NULL DEFAULT 0",
             "ALTER TABLE monitored_services ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE incidents ADD COLUMN external_id VARCHAR(128)",
             # subscribers table is created by metadata.create_all above;
             # these stmts only fire if it already existed without the column
         ]:

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -222,6 +222,13 @@ LABELS: dict[str, str] = {
     # Notification send
     "notify.new_incident":            "Neue Störung",
     "notify.update":                  "Status-Update",
+    # Source / reference on incidents
+    "admin.source_label":            "Quelle",
+    "admin.source_microsoft":        "Microsoft (Graph)",
+    "admin.source_manual":           "Manuell",
+    "admin.source_other":            "Sonstige",
+    "admin.external_id_label":       "Referenz / ID",
+    "admin.external_id_placeholder": "z. B. MO1310977",
     # Azure AD settings
     "admin.azure_heading":            "Azure AD App",
     "admin.azure_hint":               "Credentials der Azure-AD-App für Microsoft Graph API und E-Mail-Versand.",

--- a/app/models.py
+++ b/app/models.py
@@ -81,6 +81,7 @@ class Incident(Base):
     is_resolved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_suppressed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="graph")
+    external_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     severity: Mapped[str] = mapped_column(String(32), nullable=False, server_default="")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     end_datetime: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -374,6 +374,8 @@ async def create_incident(
     severity: Annotated[str | None, Form()] = None,
     description: Annotated[str | None, Form()] = None,
     start_datetime: Annotated[str | None, Form()] = None,
+    source: Annotated[str, Form()] = "manual",
+    external_id: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
@@ -385,6 +387,8 @@ async def create_incident(
         severity=severity or "",
         description=description or None,
         start_datetime=_parse_form_dt(start_datetime),
+        source=source or "manual",
+        external_id=external_id.strip() if external_id else None,
     )
     await db.commit()
 
@@ -457,6 +461,8 @@ async def update_incident(
     end_datetime: Annotated[str | None, Form()] = None,
     scheduled_start: Annotated[str | None, Form()] = None,
     scheduled_end: Annotated[str | None, Form()] = None,
+    source: Annotated[str | None, Form()] = None,
+    external_id: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
     user: dict = Depends(require_auth),
 ):
@@ -477,7 +483,10 @@ async def update_incident(
         "description": description or None,
         "is_resolved": new_resolved,
         "end_datetime": parsed_end,
+        "external_id": external_id.strip() if external_id else None,
     }
+    if source:
+        updates["source"] = source
     if scheduled_start is not None or scheduled_end is not None:
         updates["scheduled_start"] = _parse_form_dt(scheduled_start)
         updates["scheduled_end"] = _parse_form_dt(scheduled_end)

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -118,17 +118,13 @@
 {% macro service_filter_pills(items, scope) %}
   {% set svc_list = items | map(attribute='service_name') | list | unique | sort %}
   {% if svc_list | length > 1 %}
-  <div class="flex flex-wrap items-center gap-2 mb-3" data-filter-scope="{{ scope }}">
-    <button type="button" data-filter-svc="" data-active="1"
-            class="text-xs px-2.5 py-1 rounded-full border border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-300 transition-colors">
-      {{ L["admin.filter_all"] }}
-    </button>
-    {% for s in svc_list %}
-    <button type="button" data-filter-svc="{{ s }}"
-            class="text-xs px-2.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 transition-colors">
-      {{ s }}
-    </button>
-    {% endfor %}
+  <div class="flex items-center gap-2 mb-3">
+    <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["admin.filter_state"] }}</span>
+    <select data-filter-svc-select data-filter-scope="{{ scope }}"
+            class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
+      <option value="">{{ L["admin.filter_all"] }}</option>
+      {% for s in svc_list %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
+    </select>
   </div>
   {% endif %}
 {% endmacro %}
@@ -255,32 +251,15 @@
 </section>
 
 <script>
-  // Service-filter pills: each section with [data-filter-section] has its own
-  // [data-filter-scope] pill bar and [data-row data-service=...] rows.
   (function () {
     document.querySelectorAll('[data-filter-section]').forEach((section) => {
-      const buttons = section.querySelectorAll('[data-filter-svc]');
+      const sel = section.querySelector('[data-filter-svc-select]');
       const rows = section.querySelectorAll('[data-row]');
-      function apply(svc) {
-        rows.forEach((r) => {
-          const match = !svc || r.dataset.service === svc;
-          r.classList.toggle('hidden', !match);
-        });
-        buttons.forEach((b) => {
-          const active = (b.dataset.filterSvc || '') === svc;
-          b.classList.toggle('border-blue-300', active);
-          b.classList.toggle('bg-blue-50', active);
-          b.classList.toggle('text-blue-700', active);
-          b.classList.toggle('dark:border-blue-700', active);
-          b.classList.toggle('dark:bg-blue-950/40', active);
-          b.classList.toggle('dark:text-blue-300', active);
-          b.classList.toggle('border-gray-200', !active);
-          b.classList.toggle('dark:border-gray-700', !active);
-          b.classList.toggle('text-gray-600', !active);
-          b.classList.toggle('dark:text-gray-400', !active);
-        });
-      }
-      buttons.forEach((b) => b.addEventListener('click', () => apply(b.dataset.filterSvc || '')));
+      if (!sel) return;
+      sel.addEventListener('change', () => {
+        const svc = sel.value;
+        rows.forEach((r) => r.classList.toggle('hidden', !(!svc || r.dataset.service === svc)));
+      });
     });
   })();
 </script>

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -136,6 +136,28 @@
         </div>
         {% endif %}
 
+        <div class="grid grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ L["admin.source_label"] }}</label>
+            <select name="source"
+                    class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+              <option value="manual"  {% if incident.source == 'manual'  %}selected{% endif %}>{{ L["admin.source_manual"] }}</option>
+              <option value="graph"   {% if incident.source == 'graph'   %}selected{% endif %}>{{ L["admin.source_microsoft"] }}</option>
+              <option value="other"   {% if incident.source not in ('manual','graph') %}selected{% endif %}>{{ L["admin.source_other"] }}</option>
+            </select>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {{ L["admin.external_id_label"] }}
+              <span class="font-normal text-gray-400">(optional)</span>
+            </label>
+            <input type="text" name="external_id"
+                   value="{{ incident.external_id or '' }}"
+                   placeholder="{{ L['admin.external_id_placeholder'] }}"
+                   class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+          </div>
+        </div>
+
         <div class="flex items-center gap-3 pt-1">
           <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
             <input type="checkbox" name="is_resolved" value="on"
@@ -237,8 +259,16 @@
       {% if incident.end_datetime %}
       <p>{{ L["admin.end_datetime"] }}: {{ incident.end_datetime | strftime_de }}</p>
       {% endif %}
-      <p>Quelle: {{ incident.source }}</p>
-      <p class="font-mono truncate">ID: {{ incident.graph_issue_id }}</p>
+      <p>
+        {{ L["admin.source_label"] }}:
+        {% if incident.source == 'graph' %}{{ L["admin.source_microsoft"] }}
+        {% elif incident.source == 'manual' %}{{ L["admin.source_manual"] }}
+        {% else %}{{ incident.source }}{% endif %}
+      </p>
+      {% if incident.external_id %}
+      <p>{{ L["admin.external_id_label"] }}: <span class="font-mono">{{ incident.external_id }}</span></p>
+      {% endif %}
+      <p class="font-mono truncate opacity-60">Graph-ID: {{ incident.graph_issue_id }}</p>
     </div>
   </div>
 

--- a/templates/admin/incident_form.html
+++ b/templates/admin/incident_form.html
@@ -12,7 +12,7 @@
   <form method="post" action="/admin/incidents" class="space-y-4">
 
     <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
         {{ L["admin.title_label"] }}
       </label>
       <input type="text" name="title" required
@@ -21,7 +21,7 @@
     </div>
 
     <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
         {{ L["admin.service_label"] }}
       </label>
       <select name="service_name" required
@@ -34,7 +34,7 @@
 
     <div class="grid grid-cols-2 gap-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
           {{ L["admin.classification_label"] }}
         </label>
         <select name="classification"
@@ -44,7 +44,7 @@
         </select>
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
           {{ L["admin.severity_label"] }}
         </label>
         <select name="severity"
@@ -60,7 +60,7 @@
 
     <div>
       <div class="flex items-center justify-between mb-1">
-        <label for="start_datetime" class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        <label for="start_datetime" class="block text-xs font-medium text-gray-500 dark:text-gray-400">
           {{ L["admin.start_datetime"] }}
         </label>
         <button type="button" id="start-now-btn"
@@ -73,13 +73,36 @@
     </div>
 
     <div>
-      <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+      <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
         {{ L["admin.description_label"] }}
         <span class="font-normal text-gray-400">(optional)</span>
       </label>
       <textarea name="description" rows="3"
                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                 placeholder="Detailbeschreibung der Störung…"></textarea>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          {{ L["admin.source_label"] }}
+        </label>
+        <select name="source"
+                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <option value="manual" selected>{{ L["admin.source_manual"] }}</option>
+          <option value="graph">{{ L["admin.source_microsoft"] }}</option>
+          <option value="other">{{ L["admin.source_other"] }}</option>
+        </select>
+      </div>
+      <div>
+        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
+          {{ L["admin.external_id_label"] }}
+          <span class="font-normal text-gray-400">(optional)</span>
+        </label>
+        <input type="text" name="external_id"
+               placeholder="{{ L['admin.external_id_placeholder'] }}"
+               class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+      </div>
     </div>
 
     <div class="pt-2">

--- a/templates/admin/incidents_all.html
+++ b/templates/admin/incidents_all.html
@@ -34,18 +34,13 @@
 </div>
 
 {% if all_services | length > 1 %}
-<div class="flex flex-wrap items-center gap-2 mb-4">
-  <span class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 shrink-0">{{ L["page.history_filter"] }}</span>
-  <button type="button" data-filter-svc="" data-active="1"
-          class="text-xs px-2.5 py-1 rounded-full border border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-300 transition-colors">
-    {{ L["admin.filter_all"] }}
-  </button>
-  {% for s in all_services %}
-  <button type="button" data-filter-svc="{{ s }}"
-          class="text-xs px-2.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 transition-colors">
-    {{ s }}
-  </button>
-  {% endfor %}
+<div class="flex items-center gap-2 mb-4">
+  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["admin.filter_state"] }}</span>
+  <select id="svc-filter-select"
+          class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
+    <option value="">{{ L["admin.filter_all"] }}</option>
+    {% for s in all_services %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
+  </select>
 </div>
 {% endif %}
 
@@ -117,19 +112,44 @@
 
 <script>
   (function () {
-    const buttons = document.querySelectorAll('[data-filter]');
+    const stateButtons = document.querySelectorAll('[data-filter]');
+    const svcSelect = document.getElementById('svc-filter-select');
     const rows = document.querySelectorAll('[data-incident-row]');
     const emptyMsg = document.querySelector('[data-filter-empty]');
-    function apply(filter) {
+    let activeState = 'all';
+
+    function applyFilters() {
+      const svc = svcSelect ? svcSelect.value : '';
       let visible = 0;
       rows.forEach((row) => {
-        const match = filter === 'all' || row.dataset.state === filter;
-        row.classList.toggle('hidden', !match);
-        if (match) visible++;
+        const stateMatch = activeState === 'all' || row.dataset.state === activeState;
+        const svcMatch = !svc || row.dataset.service === svc;
+        const show = stateMatch && svcMatch;
+        row.classList.toggle('hidden', !show);
+        if (show) visible++;
       });
       if (emptyMsg) emptyMsg.classList.toggle('hidden', visible > 0);
-      buttons.forEach((b) => {
-        const active = b.dataset.filter === filter;
+
+      // Update service select: hide options for services with no visible rows
+      // (regardless of current svc filter, look at state-only visible rows)
+      if (svcSelect) {
+        const visibleSvcs = new Set();
+        rows.forEach((row) => {
+          const stateMatch = activeState === 'all' || row.dataset.state === activeState;
+          if (stateMatch) visibleSvcs.add(row.dataset.service);
+        });
+        Array.from(svcSelect.options).forEach((opt) => {
+          if (!opt.value) return;
+          opt.hidden = !visibleSvcs.has(opt.value);
+        });
+        if (svcSelect.value && !visibleSvcs.has(svcSelect.value)) {
+          svcSelect.value = '';
+        }
+      }
+
+      // Update state button styles
+      stateButtons.forEach((b) => {
+        const active = b.dataset.filter === activeState;
         b.classList.toggle('border-blue-300', active);
         b.classList.toggle('bg-blue-50', active);
         b.classList.toggle('text-blue-700', active);
@@ -142,7 +162,12 @@
         b.classList.toggle('dark:text-gray-400', !active);
       });
     }
-    buttons.forEach((b) => b.addEventListener('click', () => apply(b.dataset.filter)));
+
+    stateButtons.forEach((b) => b.addEventListener('click', () => {
+      activeState = b.dataset.filter;
+      applyFilters();
+    }));
+    if (svcSelect) svcSelect.addEventListener('change', applyFilters);
   })();
 </script>
 {% endblock %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -32,8 +32,8 @@
   {% endif %}
 </div>
 
-{# ── Top tab navigation (anchor scrolling) ──────────────────────────────────── #}
-<nav class="mb-6 bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-x-auto">
+{# ── Top tab navigation (sticky, smooth-scrolls to sections) ────────────────── #}
+<nav id="tab-nav" class="mb-6 bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-x-auto sticky top-2 z-10 transition-shadow">
   <div class="flex items-stretch divide-x divide-gray-100 dark:divide-gray-800 min-w-max">
     {% for href, label_key, icon in [
       ('#overview',     'page.tab_overview',     'overview'),
@@ -106,9 +106,14 @@
 <a id="maintenances" class="block scroll-mt-20"></a>
 {% if maintenances %}
 <section class="mb-8">
-  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
-    {{ L["page.maintenance_heading"] }}
-  </h2>
+  <div class="flex items-center gap-2 mb-3">
+    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {{ L["page.maintenance_heading"] }}
+    </h2>
+    <span class="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 text-xs font-bold rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+      {{ maintenances | length }}
+    </span>
+  </div>
   {% for m in maintenances %}
   <div class="bg-white dark:bg-gray-900 rounded-2xl border-l-4 border-blue-400 border border-gray-100 dark:border-gray-800 px-5 py-4 mb-3 shadow-sm">
     <div class="flex items-start justify-between gap-3">
@@ -164,9 +169,16 @@
 
 <a id="incidents" class="block scroll-mt-20"></a>
 <section class="mb-6">
-  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-3">
-    {{ L["page.incidents_heading_active"] }}
-  </h2>
+  <div class="flex items-center gap-2 mb-3">
+    <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+      {{ L["page.incidents_heading_active"] }}
+    </h2>
+    {% if ns.incidents %}
+    <span class="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 text-xs font-bold rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
+      {{ ns.incidents | length }}
+    </span>
+    {% endif %}
+  </div>
   {% if ns.incidents %}
     {% for incident in ns.incidents %}
       {% include "partials/incident_card.html" %}
@@ -187,7 +199,7 @@
 {# ── Aktuelle Hinweise (same heading style as Aktive Störungen) ───────────── #}
 <a id="advisories" class="block scroll-mt-20"></a>
 <section class="mb-6">
-  <details class="group" {% if ns.advisories %}open{% endif %}>
+  <details class="group">
     <summary class="flex items-center gap-2 cursor-pointer list-none select-none mb-3">
       <svg class="w-4 h-4 text-gray-400 transition-transform group-open:rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
@@ -196,7 +208,7 @@
         {{ L["page.advisories_heading"] }}
       </h2>
       {% if ns.advisories %}
-      <span class="ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[11px] font-semibold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+      <span class="ml-auto inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 text-xs font-bold rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
         {{ ns.advisories | length }}
       </span>
       {% else %}
@@ -226,7 +238,7 @@
       </span>
       <span class="text-xs text-gray-400 dark:text-gray-500">&middot; {{ L["page.history_subheading"] }}</span>
       {% if recent_resolved %}
-      <span class="ml-auto text-xs px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+      <span class="ml-auto inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 text-xs font-bold rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
         {{ recent_resolved | length }}
       </span>
       {% endif %}
@@ -235,21 +247,16 @@
     {% if recent_resolved %}
     {# ── Service filter for history ─────────────────────────────────────── #}
     {% set history_services = recent_resolved | map(attribute='service_name') | list | unique | sort %}
-    <div class="flex flex-wrap items-center gap-2 mb-3" data-history-filter>
-      <span class="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 shrink-0">
-        {{ L["page.history_filter"] }}
-      </span>
-      <button type="button" data-history-filter-btn="" data-active="1"
-              class="text-xs px-2.5 py-1 rounded-full border border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-300 transition-colors">
-        {{ L["page.history_filter_all"] }}
-      </button>
-      {% for svc in history_services %}
-      <button type="button" data-history-filter-btn="{{ svc }}"
-              class="text-xs px-2.5 py-1 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-gray-400 dark:hover:border-gray-500 transition-colors">
-        {{ svc }}
-      </button>
-      {% endfor %}
+    {% if history_services | length > 1 %}
+    <div class="flex items-center gap-2 mb-3">
+      <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["page.history_filter"] }}</span>
+      <select data-history-filter-select
+              class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
+        <option value="">{{ L["page.history_filter_all"] }}</option>
+        {% for svc in history_services %}<option value="{{ svc }}">{{ svc }}</option>{% endfor %}
+      </select>
     </div>
+    {% endif %}
     <div class="space-y-2" data-history-entries>
       {% for incident in recent_resolved %}
       <div id="incident-{{ incident.id }}"
@@ -296,10 +303,12 @@
     </p>
     <script>
       (function () {
-        const buttons = document.querySelectorAll('[data-history-filter-btn]');
+        const sel = document.querySelector('[data-history-filter-select]');
         const entries = document.querySelectorAll('[data-history-entry]');
         const emptyMsg = document.querySelector('[data-history-empty-filter]');
-        function apply(filter) {
+        if (!sel) return;
+        sel.addEventListener('change', () => {
+          const filter = sel.value;
           let visible = 0;
           entries.forEach((el) => {
             const match = !filter || el.dataset.service === filter;
@@ -307,23 +316,6 @@
             if (match) visible++;
           });
           if (emptyMsg) emptyMsg.classList.toggle('hidden', visible > 0);
-          buttons.forEach((b) => {
-            const active = (b.dataset.historyFilterBtn || '') === filter;
-            b.dataset.active = active ? '1' : '';
-            b.classList.toggle('border-blue-300', active);
-            b.classList.toggle('bg-blue-50', active);
-            b.classList.toggle('text-blue-700', active);
-            b.classList.toggle('dark:border-blue-700', active);
-            b.classList.toggle('dark:bg-blue-950/40', active);
-            b.classList.toggle('dark:text-blue-300', active);
-            b.classList.toggle('border-gray-200', !active);
-            b.classList.toggle('dark:border-gray-700', !active);
-            b.classList.toggle('text-gray-600', !active);
-            b.classList.toggle('dark:text-gray-400', !active);
-          });
-        }
-        buttons.forEach((b) => {
-          b.addEventListener('click', () => apply(b.dataset.historyFilterBtn || ''));
         });
       })();
     </script>
@@ -406,6 +398,30 @@
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && !modal.classList.contains('hidden')) close();
     });
+  })();
+</script>
+
+<script>
+  // Smooth scroll for tab nav links + elevated shadow while sticky
+  (function () {
+    const nav = document.getElementById('tab-nav');
+    document.querySelectorAll('#tab-nav a[href^="#"]').forEach((a) => {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        const target = document.querySelector(a.getAttribute('href'));
+        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    });
+    if (nav) {
+      const observer = new IntersectionObserver(
+        ([entry]) => nav.classList.toggle('shadow-md', !entry.isIntersecting),
+        { threshold: 1.0, rootMargin: '-2px 0px 0px 0px' }
+      );
+      // observe a sentinel just above the nav
+      const sentinel = document.createElement('div');
+      nav.parentNode.insertBefore(sentinel, nav);
+      observer.observe(sentinel);
+    }
   })();
 </script>
 


### PR DESCRIPTION
## Summary

**Filter improvements**
- Replace all service filter pill rows with a compact `<select>` dropdown — scales to any number of services without wrapping
- On "Alle Störungen" page: state filter (Aktiv/Behoben) now dynamically hides service options that have no visible rows, fixing the "shows services not active" issue

**Incident Quelle / Referenz**
- New `external_id` column on `Incident` model (additive migration)
- Create and edit forms: Quelle dropdown (Microsoft Graph / Manuell / Sonstige) + Referenz/ID text input (e.g. `MO1310977`)
- Detail view footer shows human-readable source label and external ID
- Lighter gray labels in incident creation form to match settings page style

**Public page tab nav**
- Tab nav is now `sticky top-2` — stays visible while scrolling
- Clicking tabs smooth-scrolls to sections instead of jumping
- Elevated shadow appears when nav is stuck to top

**Section badges**
- Aktive Störungen, Aktuelle Hinweise, Wartungen, Kürzlich behoben: larger, colored count badges (`h-6 px-2 text-xs font-bold`) when entries exist
- Aktuelle Hinweise section: collapsed by default

## Test plan

- [ ] Admin dashboard: service filter dropdowns work per section; selecting a service hides other rows
- [ ] Alle Störungen: switch to "Aktiv" → service select only shows services with active incidents
- [ ] Create incident: Quelle and Referenz/ID fields appear; values saved and shown in detail
- [ ] Public page: click a tab → smooth scroll (not instant jump)
- [ ] Public page: scroll down → tab nav stays stuck at top with shadow
- [ ] Public page: Aktuelle Hinweise starts collapsed; Störungen shows red badge count
- [ ] Badges visible on Wartungen and Verlauf sections

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_