### PR TITLE
feat: modal back-nav, multi-select service filters, tab-nav UX fixes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,12 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Release batch reason (optional)"
+        required: false
+        default: ""
 
 permissions:
   contents: write

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -119,12 +119,26 @@
   {% set svc_list = items | map(attribute='service_name') | list | unique | sort %}
   {% if svc_list | length > 1 %}
   <div class="flex items-center gap-2 mb-3">
-    <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["admin.filter_state"] }}</span>
-    <select data-filter-svc-select data-filter-scope="{{ scope }}"
-            class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
-      <option value="">{{ L["admin.filter_all"] }}</option>
-      {% for s in svc_list %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
-    </select>
+    <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">Service</span>
+    <div class="relative" data-multiselect data-filter-scope="{{ scope }}">
+      <button type="button" data-ms-toggle
+              class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none cursor-pointer flex items-center gap-1.5 transition-colors max-w-[220px]">
+        <span data-ms-label class="truncate">{{ L["admin.filter_all"] }}</span>
+        <svg class="w-3 h-3 shrink-0 text-gray-400 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div data-ms-panel
+           class="hidden absolute top-full mt-1 left-0 z-20 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1 min-w-[180px] max-h-56 overflow-y-auto">
+        {% for s in svc_list %}
+        <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer text-xs text-gray-700 dark:text-gray-200">
+          <input type="checkbox" data-ms-option value="{{ s }}"
+                 class="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-0">
+          <span class="truncate">{{ s }}</span>
+        </label>
+        {% endfor %}
+      </div>
+    </div>
   </div>
   {% endif %}
 {% endmacro %}
@@ -252,13 +266,34 @@
 
 <script>
   (function () {
-    document.querySelectorAll('[data-filter-section]').forEach((section) => {
-      const sel = section.querySelector('[data-filter-svc-select]');
-      const rows = section.querySelectorAll('[data-row]');
-      if (!sel) return;
-      sel.addEventListener('change', () => {
-        const svc = sel.value;
-        rows.forEach((r) => r.classList.toggle('hidden', !(!svc || r.dataset.service === svc)));
+    document.querySelectorAll('[data-multiselect]').forEach((ms) => {
+      const toggle = ms.querySelector('[data-ms-toggle]');
+      const panel = ms.querySelector('[data-ms-panel]');
+      const label = ms.querySelector('[data-ms-label]');
+      const opts = ms.querySelectorAll('[data-ms-option]');
+      const section = ms.closest('[data-filter-section]');
+      const rows = section ? section.querySelectorAll('[data-row]') : [];
+
+      function getSelected() {
+        return Array.from(opts).filter(o => o.checked).map(o => o.value);
+      }
+      function applyFilter(selected) {
+        rows.forEach((r) => r.classList.toggle('hidden', selected.length > 0 && !selected.includes(r.dataset.service)));
+        if (selected.length === 0) label.textContent = label.dataset.all || 'Alle';
+        else if (selected.length <= 2) label.textContent = selected.join(', ');
+        else label.textContent = selected.length + ' ausgewählt';
+        toggle.classList.toggle('border-blue-400', selected.length > 0);
+        toggle.classList.toggle('text-blue-700', selected.length > 0);
+        toggle.classList.toggle('dark:border-blue-600', selected.length > 0);
+        toggle.classList.toggle('dark:text-blue-300', selected.length > 0);
+      }
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        panel.classList.toggle('hidden');
+      });
+      opts.forEach(o => o.addEventListener('change', () => applyFilter(getSelected())));
+      document.addEventListener('click', (e) => {
+        if (!ms.contains(e.target)) panel.classList.add('hidden');
       });
     });
   })();

--- a/templates/admin/incidents_all.html
+++ b/templates/admin/incidents_all.html
@@ -35,12 +35,26 @@
 
 {% if all_services | length > 1 %}
 <div class="flex items-center gap-2 mb-4">
-  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["admin.filter_state"] }}</span>
-  <select id="svc-filter-select"
-          class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
-    <option value="">{{ L["admin.filter_all"] }}</option>
-    {% for s in all_services %}<option value="{{ s }}">{{ s }}</option>{% endfor %}
-  </select>
+  <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">Service</span>
+  <div class="relative" id="svc-ms">
+    <button type="button" id="svc-ms-toggle"
+            class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none cursor-pointer flex items-center gap-1.5 transition-colors max-w-[220px]">
+      <span id="svc-ms-label" class="truncate">{{ L["admin.filter_all"] }}</span>
+      <svg class="w-3 h-3 shrink-0 text-gray-400 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+      </svg>
+    </button>
+    <div id="svc-ms-panel"
+         class="hidden absolute top-full mt-1 left-0 z-20 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1 min-w-[180px] max-h-56 overflow-y-auto">
+      {% for s in all_services %}
+      <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer text-xs text-gray-700 dark:text-gray-200">
+        <input type="checkbox" value="{{ s }}" data-svc-ms-opt
+               class="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-0">
+        <span class="truncate">{{ s }}</span>
+      </label>
+      {% endfor %}
+    </div>
+  </div>
 </div>
 {% endif %}
 
@@ -113,38 +127,56 @@
 <script>
   (function () {
     const stateButtons = document.querySelectorAll('[data-filter]');
-    const svcSelect = document.getElementById('svc-filter-select');
     const rows = document.querySelectorAll('[data-incident-row]');
     const emptyMsg = document.querySelector('[data-filter-empty]');
+    const svcMs = document.getElementById('svc-ms');
+    const svcMsToggle = document.getElementById('svc-ms-toggle');
+    const svcMsPanel = document.getElementById('svc-ms-panel');
+    const svcMsLabel = document.getElementById('svc-ms-label');
+    const svcOpts = svcMs ? svcMs.querySelectorAll('[data-svc-ms-opt]') : [];
     let activeState = 'all';
 
+    function getSelectedSvcs() {
+      return Array.from(svcOpts).filter(o => o.checked).map(o => o.value);
+    }
+
+    function updateSvcLabel(selected) {
+      if (!svcMsLabel) return;
+      if (selected.length === 0) svcMsLabel.textContent = '{{ L["admin.filter_all"] }}';
+      else if (selected.length <= 2) svcMsLabel.textContent = selected.join(', ');
+      else svcMsLabel.textContent = selected.length + ' ausgewählt';
+      if (svcMsToggle) {
+        svcMsToggle.classList.toggle('border-blue-400', selected.length > 0);
+        svcMsToggle.classList.toggle('text-blue-700', selected.length > 0);
+        svcMsToggle.classList.toggle('dark:border-blue-600', selected.length > 0);
+        svcMsToggle.classList.toggle('dark:text-blue-300', selected.length > 0);
+      }
+    }
+
     function applyFilters() {
-      const svc = svcSelect ? svcSelect.value : '';
+      const selectedSvcs = getSelectedSvcs();
       let visible = 0;
       rows.forEach((row) => {
         const stateMatch = activeState === 'all' || row.dataset.state === activeState;
-        const svcMatch = !svc || row.dataset.service === svc;
+        const svcMatch = selectedSvcs.length === 0 || selectedSvcs.includes(row.dataset.service);
         const show = stateMatch && svcMatch;
         row.classList.toggle('hidden', !show);
         if (show) visible++;
       });
       if (emptyMsg) emptyMsg.classList.toggle('hidden', visible > 0);
 
-      // Update service select: hide options for services with no visible rows
-      // (regardless of current svc filter, look at state-only visible rows)
-      if (svcSelect) {
+      // Hide service options for services with no state-matching rows
+      if (svcMs) {
         const visibleSvcs = new Set();
         rows.forEach((row) => {
           const stateMatch = activeState === 'all' || row.dataset.state === activeState;
           if (stateMatch) visibleSvcs.add(row.dataset.service);
         });
-        Array.from(svcSelect.options).forEach((opt) => {
-          if (!opt.value) return;
-          opt.hidden = !visibleSvcs.has(opt.value);
+        svcOpts.forEach((opt) => {
+          const li = opt.closest('label');
+          if (li) li.classList.toggle('hidden', !visibleSvcs.has(opt.value));
+          if (!visibleSvcs.has(opt.value)) opt.checked = false;
         });
-        if (svcSelect.value && !visibleSvcs.has(svcSelect.value)) {
-          svcSelect.value = '';
-        }
       }
 
       // Update state button styles
@@ -167,7 +199,19 @@
       activeState = b.dataset.filter;
       applyFilters();
     }));
-    if (svcSelect) svcSelect.addEventListener('change', applyFilters);
+    if (svcMsToggle) {
+      svcMsToggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        svcMsPanel.classList.toggle('hidden');
+      });
+    }
+    svcOpts.forEach((o) => o.addEventListener('change', () => {
+      updateSvcLabel(getSelectedSvcs());
+      applyFilters();
+    }));
+    document.addEventListener('click', (e) => {
+      if (svcMs && !svcMs.contains(e.target)) svcMsPanel?.classList.add('hidden');
+    });
   })();
 </script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -123,15 +123,21 @@
     <div data-day-modal-backdrop class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
     <div class="relative bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full border border-gray-100 dark:border-gray-800 overflow-hidden">
       <div class="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-start justify-between gap-3">
-        <div class="min-w-0 flex items-center gap-3">
-          <span id="day-modal-dot" class="w-3 h-3 rounded-full shrink-0"></span>
-          <div>
-            <h3 id="day-modal-title" class="text-base font-semibold text-gray-900 dark:text-white"></h3>
+        <div class="min-w-0 flex items-center gap-2">
+          <button id="day-modal-back" type="button" aria-label="Zurück zur Übersicht"
+                  class="hidden shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -ml-1 p-1 rounded transition-colors">
+            <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
+            </svg>
+          </button>
+          <span id="day-modal-dot" class="w-2.5 h-2.5 rounded-full shrink-0"></span>
+          <div class="min-w-0">
+            <h3 id="day-modal-title" class="text-sm font-semibold text-gray-900 dark:text-white leading-tight"></h3>
             <p id="day-modal-sub" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"></p>
           </div>
         </div>
         <button type="button" data-day-modal-close aria-label="Schließen"
-                class="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
+                class="shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
           </svg>
@@ -140,7 +146,7 @@
       <div class="px-5 py-4">
         <div id="day-modal-status-row" class="inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3"></div>
         <p id="day-modal-body" class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed"></p>
-        <div id="day-modal-incidents" class="mt-4 space-y-2"></div>
+        <div id="day-modal-incidents" class="mt-3 space-y-2"></div>
       </div>
     </div>
   </div>
@@ -179,6 +185,9 @@
       const statusRow = document.getElementById('day-modal-status-row');
       const body = document.getElementById('day-modal-body');
       const incidentsBox = document.getElementById('day-modal-incidents');
+      const backBtn = document.getElementById('day-modal-back');
+
+      let lastBar = null;
 
       const STATUS_STYLE = {
         operational: { dot: 'bg-emerald-500', badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300', body: 'Keine Vorfälle an diesem Tag — Dienst lief normal.' },
@@ -188,7 +197,16 @@
         unknown:     { dot: 'bg-gray-400',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: 'Status unbekannt.' },
       };
 
+      const CLASS_STYLE = {
+        incident:    { border: 'border-l-red-400',   badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',     label: 'Störung' },
+        advisory:    { border: 'border-l-amber-400', badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400', label: 'Hinweis' },
+        maintenance: { border: 'border-l-blue-400',  badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400',  label: 'Wartung' },
+      };
+
       function open(btn) {
+        lastBar = btn;
+        backBtn.classList.add('hidden');
+
         const date = btn.dataset.date;
         const dateLabel = btn.dataset.dateLabel;
         const status = btn.dataset.status;
@@ -198,7 +216,7 @@
 
         title.textContent = service;
         sub.textContent = dateLabel;
-        dot.className = 'w-3 h-3 rounded-full shrink-0 ' + style.dot;
+        dot.className = 'w-2.5 h-2.5 rounded-full shrink-0 ' + style.dot;
         statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3 ' + style.badge;
         statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + statusLabel;
         body.textContent = style.body;
@@ -214,16 +232,23 @@
           header.textContent = 'Zugehörige Einträge';
           incidentsBox.appendChild(header);
           matching.forEach((inc) => {
-            const btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'w-full text-left block px-3 py-2 rounded-lg border border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors';
-            btn.innerHTML = '<span class="text-sm font-medium text-gray-800 dark:text-gray-200">' + inc.title + '</span>'
+            const cs = CLASS_STYLE[inc.classificationRaw] || {};
+            const row = document.createElement('button');
+            row.type = 'button';
+            row.className = 'w-full text-left block pl-3 pr-3 py-2 rounded-lg border border-gray-100 dark:border-gray-800 border-l-4 '
+              + (cs.border || 'border-l-gray-300')
+              + ' hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors';
+            let badgeHtml = '';
+            if (cs.badge) {
+              badgeHtml = '<span class="inline-flex items-center px-1.5 py-0 rounded text-[10px] font-medium ' + cs.badge + ' ml-1.5">' + (cs.label || inc.classificationRaw) + '</span>';
+            }
+            row.innerHTML = '<span class="text-sm font-medium text-gray-800 dark:text-gray-200">' + inc.title + badgeHtml + '</span>'
               + '<span class="block text-xs text-gray-400 dark:text-gray-500 mt-0.5">' + inc.meta + '</span>';
-            btn.addEventListener('click', (ev) => {
+            row.addEventListener('click', (ev) => {
               ev.preventDefault();
               if (inc.element) openIncidentCard(inc.element);
             });
-            incidentsBox.appendChild(btn);
+            incidentsBox.appendChild(row);
           });
         }
 
@@ -236,10 +261,11 @@
         modal.classList.add('hidden');
         modal.classList.remove('flex');
         document.body.classList.remove('overflow-hidden');
+        lastBar = null;
       }
 
       // Find incident entries on the page whose [start..end] date range covers `date`
-      // Returns [{title, href, meta}]. Uses [data-incident-entry] attributes.
+      // Returns [{title, meta, classificationRaw, element}]. Uses [data-incident-entry] attributes.
       function findIncidentsCoveringDate(service, date) {
         const all = document.querySelectorAll('[data-incident-entry]');
         const out = [];
@@ -250,8 +276,8 @@
           if (start && date >= start && date <= end) {
             out.push({
               title: el.dataset.title || '(ohne Titel)',
-              href: el.dataset.href || '#',
-              meta: el.dataset.meta || (el.dataset.classification ? el.dataset.classification + ' · ' + (el.dataset.service || '') : ''),
+              meta: el.dataset.meta || (el.dataset.statusLabel ? el.dataset.statusLabel + ' · ' + (el.dataset.service || '') : (el.dataset.service || '')),
+              classificationRaw: el.dataset.classificationRaw || '',
               element: el,
             });
           }
@@ -265,7 +291,12 @@
 
         title.textContent = card.dataset.title || '';
         sub.textContent = card.dataset.service || '';
-        dot.className = 'w-3 h-3 rounded-full shrink-0 ' + style.dot;
+        dot.className = 'w-2.5 h-2.5 rounded-full shrink-0 ' + style.dot;
+
+        // Show back button only when we drilled in from a day overview
+        if (lastBar) {
+          backBtn.classList.remove('hidden');
+        }
 
         // Status row: combine classification + severity + state
         const chips = [];
@@ -299,6 +330,10 @@
         modal.classList.add('flex');
         document.body.classList.add('overflow-hidden');
       }
+
+      backBtn.addEventListener('click', () => {
+        if (lastBar) open(lastBar);
+      });
 
       // ── Bar hover tooltip ────────────────────────────────────────────────
       const tooltip = document.getElementById('bar-tooltip');

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -11,6 +11,7 @@
      data-status="{{ 'resolved' if incident.is_resolved else incident.status }}"
      data-status-label="{{ state_label('resolved' if incident.is_resolved else incident.status) }}"
      data-classification="{{ incident_type_label(incident.classification) }}"
+     data-classification-raw="{{ incident.classification }}"
      data-severity-label="{{ severity_label(incident.severity) if incident.severity else '' }}"
      data-since="{{ incident.start_datetime | strftime_de if incident.start_datetime else '' }}"
      data-description="{{ incident.description or '' }}">

--- a/templates/status.html
+++ b/templates/status.html
@@ -33,7 +33,7 @@
 </div>
 
 {# ── Top tab navigation (sticky, smooth-scrolls to sections) ────────────────── #}
-<nav id="tab-nav" class="mb-6 bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-x-auto sticky top-2 z-10 transition-shadow">
+<nav id="tab-nav" class="mb-6 bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-x-auto sticky top-14 z-10 transition-shadow">
   <div class="flex items-stretch divide-x divide-gray-100 dark:divide-gray-800 min-w-max">
     {% for href, label_key, icon in [
       ('#overview',     'page.tab_overview',     'overview'),
@@ -250,11 +250,25 @@
     {% if history_services | length > 1 %}
     <div class="flex items-center gap-2 mb-3">
       <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ L["page.history_filter"] }}</span>
-      <select data-history-filter-select
-              class="text-xs px-2 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 focus:outline-none focus:ring-1 focus:ring-blue-400 cursor-pointer">
-        <option value="">{{ L["page.history_filter_all"] }}</option>
-        {% for svc in history_services %}<option value="{{ svc }}">{{ svc }}</option>{% endfor %}
-      </select>
+      <div class="relative" id="history-ms">
+        <button type="button" id="history-ms-toggle"
+                class="text-xs px-2.5 py-1 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none cursor-pointer flex items-center gap-1.5 transition-colors max-w-[200px]">
+          <span id="history-ms-label" class="truncate">{{ L["page.history_filter_all"] }}</span>
+          <svg class="w-3 h-3 shrink-0 text-gray-400 flex-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/>
+          </svg>
+        </button>
+        <div id="history-ms-panel"
+             class="hidden absolute top-full mt-1 left-0 z-20 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-1 min-w-[180px] max-h-56 overflow-y-auto">
+          {% for svc in history_services %}
+          <label class="flex items-center gap-2 px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800 cursor-pointer text-xs text-gray-700 dark:text-gray-200">
+            <input type="checkbox" value="{{ svc }}" data-hms-opt
+                   class="w-3.5 h-3.5 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700 text-blue-600 focus:ring-blue-500 focus:ring-offset-0">
+            <span class="truncate">{{ svc }}</span>
+          </label>
+          {% endfor %}
+        </div>
+      </div>
     </div>
     {% endif %}
     <div class="space-y-2" data-history-entries>
@@ -271,6 +285,7 @@
            data-status="resolved"
            data-status-label="{{ L['incident.resolved'] }}"
            data-classification="{{ incident_type_label(incident.classification) }}"
+           data-classification-raw="{{ incident.classification }}"
            data-severity-label="{{ severity_label(incident.severity) if incident.severity else '' }}"
            data-since="{{ incident.start_datetime | strftime_de if incident.start_datetime else '' }}"
            data-description="{{ incident.description or '' }}"
@@ -303,19 +318,42 @@
     </p>
     <script>
       (function () {
-        const sel = document.querySelector('[data-history-filter-select]');
+        const ms = document.getElementById('history-ms');
+        if (!ms) return;
+        const toggle = document.getElementById('history-ms-toggle');
+        const panel = document.getElementById('history-ms-panel');
+        const label = document.getElementById('history-ms-label');
+        const opts = ms.querySelectorAll('[data-hms-opt]');
         const entries = document.querySelectorAll('[data-history-entry]');
         const emptyMsg = document.querySelector('[data-history-empty-filter]');
-        if (!sel) return;
-        sel.addEventListener('change', () => {
-          const filter = sel.value;
+
+        function applyFilter(selected) {
           let visible = 0;
           entries.forEach((el) => {
-            const match = !filter || el.dataset.service === filter;
+            const match = selected.length === 0 || selected.includes(el.dataset.service);
             el.classList.toggle('hidden', !match);
             if (match) visible++;
           });
           if (emptyMsg) emptyMsg.classList.toggle('hidden', visible > 0);
+          // Update label
+          if (selected.length === 0) label.textContent = '{{ L["page.history_filter_all"] }}';
+          else if (selected.length <= 2) label.textContent = selected.join(', ');
+          else label.textContent = selected.length + ' ausgewählt';
+          toggle.classList.toggle('border-blue-400', selected.length > 0);
+          toggle.classList.toggle('text-blue-700', selected.length > 0);
+          toggle.classList.toggle('dark:border-blue-600', selected.length > 0);
+          toggle.classList.toggle('dark:text-blue-300', selected.length > 0);
+        }
+
+        toggle.addEventListener('click', (e) => {
+          e.stopPropagation();
+          panel.classList.toggle('hidden');
+        });
+        opts.forEach((o) => o.addEventListener('change', () => {
+          applyFilter(Array.from(opts).filter(x => x.checked).map(x => x.value));
+        }));
+        document.addEventListener('click', (e) => {
+          if (!ms.contains(e.target)) panel.classList.add('hidden');
         });
       })();
     </script>
@@ -409,7 +447,15 @@
       a.addEventListener('click', (e) => {
         e.preventDefault();
         const target = document.querySelector(a.getAttribute('href'));
-        if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        if (target) {
+          // Open any collapsed <details> in the section immediately after the anchor
+          const nextSection = target.nextElementSibling;
+          if (nextSection) {
+            const det = nextSection.querySelector('details');
+            if (det) det.open = true;
+          }
+          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       });
     });
     if (nav) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Day-modal back navigation**: Clicking a service bar opens the day overview. Clicking an incident entry inside now shows a back button (‹) that returns to the day overview. Incident rows are color-coded by classification (Störung = red left border, Hinweis = amber, Wartung = blue) with an inline badge label.
- **Multi-select service filter**: All three service filter locations (admin dashboard, admin incidents-all, public history) now use a custom checkbox dropdown instead of a single `<select>`. Multiple services can be selected simultaneously; label updates to show names or "N ausgewählt".
- **Tab nav sticky position**: Changed `top-2` → `top-14` so the tab bar docks below the brand navbar instead of overlapping it when scrolled.
- **Tab nav → auto-expand sections**: Clicking a tab nav link (Hinweise, Verlauf) now automatically opens collapsed `<details>` sections before smooth-scrolling to them.
- **Release-please**: Switched from auto-trigger on `push: main` to `workflow_dispatch` so releases are only created when manually triggered, enabling work to be batched.

## Test plan

- [ ] Click a 90-day uptime bar → day overview opens
- [ ] Click an incident in the day overview → detail opens, back button visible
- [ ] Click back → returns to day overview
- [ ] Service filter dropdown: select multiple services → only matching rows shown
- [ ] Deselect all → all rows shown again
- [ ] Advisories tab in public page: click "Hinweise" → section scrolls and auto-expands
- [ ] History tab: click "Verlauf" → section scrolls and auto-expands
- [ ] Scroll past banner → tab nav sticks below brand navbar, not under it

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_