### PR TITLE
fix: sync impactDescription and preserve post HTML from Graph API

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -17,7 +17,8 @@ from app.schemas import (
     StatusPageSchema,
 )
 
-ALLOWED_HTML_TAGS = ["p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "span"]
+ALLOWED_HTML_TAGS = ["p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "span",
+                     "h1", "h2", "h3", "h4", "div", "table", "thead", "tbody", "tr", "td", "th"]
 ALLOWED_HTML_ATTRS = {"a": ["href", "title"]}
 
 _STATUS_SEVERITY = {"operational": 0, "unknown": 1, "degraded": 2, "interrupted": 3}

--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -84,7 +84,7 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
     base_url = (
         f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
         f"?$filter=service eq '{service_name}' and startDateTime ge {since}"
-        f"&$select=id,service,title,classification,status,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity"
+        f"&$select=id,service,title,classification,status,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity,impactDescription"
         f"&$top=100"
     )
     all_issues: list[dict] = []

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -144,6 +144,8 @@ async def sync_issue_as_incident(db, issue: dict) -> None:
     existing_incident = existing.scalar_one_or_none()
     old_status = existing_incident.status if existing_incident else None
 
+    impact_desc = issue.get("impactDescription") or None
+
     fields: dict = {
         "title": issue.get("title", ""),
         "service_name": issue.get("service", ""),
@@ -154,6 +156,10 @@ async def sync_issue_as_incident(db, issue: dict) -> None:
         "is_resolved": issue.get("isResolved", False),
         "severity": severity,
     }
+    # Only set description from impactDescription when the incident has none yet,
+    # preserving any description an admin has written manually.
+    if impact_desc and not (existing_incident and existing_incident.description):
+        fields["description"] = impact_desc
     if classification == "maintenance":
         fields["scheduled_start"] = _parse_dt(issue.get("startDateTime"))
         fields["scheduled_end"] = _parse_dt(issue.get("endDateTime"))


### PR DESCRIPTION
## Problem

M365 status messages contain rich structured content — User impact, More info, Scope of impact, Root cause, Next steps, and timestamped updates. None of this was showing up in tickets.

## Root causes

1. **`impactDescription` never stored** — The Graph API issue object has an `impactDescription` field (plain text summary of the impact). `sync_issue_as_incident()` read it from the API response but never put it in the `description` field. New tickets always had an empty description.

2. **Backfill query missing `impactDescription`** — `fetch_issues_since()` uses an explicit `$select` that didn't include `impactDescription`, so even if we added handling it would be null for backfilled incidents.

3. **Post HTML structure stripped** — Microsoft formats update posts as HTML using `<div>`, `<h1>`–`<h4>`, `<table>` to separate sections (User impact, Scope, Root cause, etc.). The `ALLOWED_HTML_TAGS` in `crud.py` was restricted to inline tags only, so the structural HTML was stripped by bleach — leaving the sections' text jumbled together without headings or dividers.

## Fixes

- `scheduler.py`: populate `description` from `impactDescription` for new incidents (and existing ones with null description). Admin-written descriptions are preserved.
- `graph_client.py`: add `impactDescription` to `fetch_issues_since` `$select`.
- `crud.py`: extend `ALLOWED_HTML_TAGS` with `h1`–`h4`, `div`, `table`/`tr`/`td`/`th` so Microsoft's HTML post structure survives sanitization.

## Test plan

- [ ] After next poll, new Graph incidents should have a non-empty description from `impactDescription`
- [ ] Incident update posts should show structured sections (User impact, Root cause, etc.) with visible headings/dividers
- [ ] Existing manually-written descriptions must not be overwritten

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_