### PR TITLE
fix: navbar always shows APP_TITLE, not the page-specific title

### DIFF
--- a/app/templates.py
+++ b/app/templates.py
@@ -16,8 +16,11 @@ _md = mistune.create_markdown(escape=False)
 templates = Jinja2Templates(directory="templates")
 
 # ── Globals ───────────────────────────────────────────────────────────────────
+from app.config import settings as _settings
+
 templates.env.globals["L"] = LABELS
 templates.env.globals["APP_VERSION"] = __version__
+templates.env.globals["APP_TITLE"] = _settings.APP_TITLE
 templates.env.globals["status_bar_class"] = (
     lambda s: STATUS_TAILWIND_BAR.get(s, STATUS_TAILWIND_BAR["unknown"])
 )

--- a/app/templates.py
+++ b/app/templates.py
@@ -6,6 +6,7 @@ import mistune
 from fastapi.templating import Jinja2Templates
 
 from app import __version__
+from app.config import settings as _settings
 from app.i18n import LABELS
 from app.models import INCIDENT_BORDER, STATUS_BADGE_CLASSES, STATUS_TAILWIND_BAR
 
@@ -16,8 +17,6 @@ _md = mistune.create_markdown(escape=False)
 templates = Jinja2Templates(directory="templates")
 
 # ── Globals ───────────────────────────────────────────────────────────────────
-from app.config import settings as _settings
-
 templates.env.globals["L"] = LABELS
 templates.env.globals["APP_VERSION"] = __version__
 templates.env.globals["APP_TITLE"] = _settings.APP_TITLE

--- a/templates/base.html
+++ b/templates/base.html
@@ -66,7 +66,7 @@
           <rect x="13" y="13" width="10" height="10" rx="1.5" fill="#ffba08"/>
         </svg>
         <span class="font-medium text-white tracking-tight">
-          {{ page_title | default("M365 Dienststatus") }}
+          {{ APP_TITLE }}
         </span>
       </div>
 


### PR DESCRIPTION
## Problem

When opening a ticket in the admin area, the top navbar showed the incident title (e.g. "Exchange Online - Outage") instead of "M365 Dienststatus". The `page_title` template variable was used in two places: the browser `<title>` tag (correct) and the navbar brand text (wrong).

## Fix

- Added `APP_TITLE` as a Jinja2 global in `app/templates.py` (loaded once from `settings.APP_TITLE`)
- `base.html` navbar now uses `{{ APP_TITLE }}` — always stable
- `page_title` still drives the browser `<title>` tab as before

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_