### PR TITLE
feat: source field free-text with datalist autocomplete + Zur Statusseite link

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -441,6 +441,16 @@ async def get_suppressed_incidents(db: AsyncSession) -> list[Incident]:
     return list(result.scalars().all())
 
 
+async def get_distinct_sources(db: AsyncSession) -> list[str]:
+    result = await db.execute(
+        select(Incident.source)
+        .where(Incident.source.is_not(None), Incident.source != "")
+        .distinct()
+        .order_by(Incident.source)
+    )
+    return [row[0] for row in result.fetchall()]
+
+
 def _service_sort_clause():
     """Sort: group (NULL last) → admin-set sort_order → service_name."""
     from sqlalchemy import case

--- a/app/models.py
+++ b/app/models.py
@@ -80,7 +80,7 @@ class Incident(Base):
     last_modified: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     is_resolved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     is_suppressed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
-    source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="graph")
+    source: Mapped[str] = mapped_column(String(100), nullable=False, server_default="graph")
     external_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     severity: Mapped[str] = mapped_column(String(32), nullable=False, server_default="")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -29,6 +29,7 @@ from app.crud import (
     get_all_monitored_services,
     get_all_subscribers,
     get_confirmed_subscribers,
+    get_distinct_sources,
     get_enabled_services,
     get_enabled_services_with_status,
     get_incident_by_id,
@@ -372,13 +373,17 @@ async def new_incident_form(
     user: dict = Depends(require_auth),
     nav: dict = Depends(admin_nav_context),
 ):
-    enabled_services = await get_enabled_services(db)
+    enabled_services, known_sources = await asyncio.gather(
+        get_enabled_services(db),
+        get_distinct_sources(db),
+    )
     return templates.TemplateResponse(
         request,
         "admin/incident_form.html",
         {
             "user": user,
             "services": enabled_services,
+            "known_sources": known_sources,
             "page_title": "Neue Störung / Hinweis",
             **nav,
         },
@@ -454,7 +459,10 @@ async def incident_detail(
     incident = await get_incident_by_id(db, incident_id)
     if incident is None:
         raise HTTPException(status_code=404, detail="Nicht gefunden")
-    enabled_services = await get_enabled_services(db)
+    enabled_services, known_sources = await asyncio.gather(
+        get_enabled_services(db),
+        get_distinct_sources(db),
+    )
     return templates.TemplateResponse(
         request,
         "admin/incident_detail.html",
@@ -462,6 +470,7 @@ async def incident_detail(
             "user": user,
             "incident": incident,
             "services": enabled_services,
+            "known_sources": known_sources,
             "phase_segments": _compute_phase_segments(incident),
             "page_title": incident.title,
             **nav,

--- a/templates/admin/incident_detail.html
+++ b/templates/admin/incident_detail.html
@@ -139,12 +139,18 @@
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ L["admin.source_label"] }}</label>
-            <select name="source"
-                    class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-              <option value="manual"  {% if incident.source == 'manual'  %}selected{% endif %}>{{ L["admin.source_manual"] }}</option>
-              <option value="graph"   {% if incident.source == 'graph'   %}selected{% endif %}>{{ L["admin.source_microsoft"] }}</option>
-              <option value="other"   {% if incident.source not in ('manual','graph') %}selected{% endif %}>{{ L["admin.source_other"] }}</option>
-            </select>
+            <input type="text" name="source"
+                   value="{{ incident.source or 'manual' }}"
+                   list="source-list"
+                   autocomplete="off"
+                   class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            <datalist id="source-list">
+              {% for src in known_sources %}
+              <option value="{{ src }}">{% if src == 'manual' %}{{ L["admin.source_manual"] }}{% elif src == 'graph' %}{{ L["admin.source_microsoft"] }}{% endif %}</option>
+              {% endfor %}
+              {% if 'manual' not in known_sources %}<option value="manual">{{ L["admin.source_manual"] }}</option>{% endif %}
+              {% if 'graph' not in known_sources %}<option value="graph">{{ L["admin.source_microsoft"] }}</option>{% endif %}
+            </datalist>
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/templates/admin/incident_form.html
+++ b/templates/admin/incident_form.html
@@ -87,12 +87,17 @@
         <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
           {{ L["admin.source_label"] }}
         </label>
-        <select name="source"
-                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-          <option value="manual" selected>{{ L["admin.source_manual"] }}</option>
-          <option value="graph">{{ L["admin.source_microsoft"] }}</option>
-          <option value="other">{{ L["admin.source_other"] }}</option>
-        </select>
+        <input type="text" name="source" value="manual"
+               list="source-list"
+               autocomplete="off"
+               class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        <datalist id="source-list">
+          {% for src in known_sources %}
+          <option value="{{ src }}">{% if src == 'manual' %}{{ L["admin.source_manual"] }}{% elif src == 'graph' %}{{ L["admin.source_microsoft"] }}{% endif %}</option>
+          {% endfor %}
+          {% if 'manual' not in known_sources %}<option value="manual">{{ L["admin.source_manual"] }}</option>{% endif %}
+          {% if 'graph' not in known_sources %}<option value="graph">{{ L["admin.source_microsoft"] }}</option>{% endif %}
+        </datalist>
       </div>
       <div>
         <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">


### PR DESCRIPTION
## Summary

- **Source field free-text**: Replaces the fixed `<select>` dropdown for "Quelle" with a plain `<input type="text">` backed by a native `<datalist>`. The datalist is populated from all distinct source values already stored in the DB — so previously saved entries appear as tab-completable / mouse-selectable suggestions. New free-text entries (e.g. "BMC Helix", "Jira") are saved as-is. Standard entries ("manual", "graph") are always included as fallback options.
- **"Zur Statusseite" link**: Added a persistent link in the top-right of the admin content area (all pages) via `base_admin.html`. Styled identically to the "Zum Dashboard" back-link, with an external-link icon.
- `String(32)` → `String(100)` on `Incident.source` for free-text entries (SQLite doesn't enforce the old limit, but the model now reflects intent).

## Test plan

- [ ] Open Admin → Neue Meldung: "Quelle" field shows "manual" pre-filled, dropdown suggests "manual" and "graph" on click/focus
- [ ] Type a new value (e.g. "Jira") and save — reopen the form, "Jira" now appears in suggestions
- [ ] Open an existing incident edit form — source field pre-filled with stored value, datalist shows all known sources
- [ ] Every admin page shows "Zur Statusseite ↗" link in top-right, clicking navigates to `/`

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_