### PR TITLE
Fix sticky nav bar and link service names to public status page

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -58,7 +58,9 @@
           <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ meta.dot }} ring-4 {{ meta.ring }}"
                 title="{{ meta.label }}"></span>
           <div class="flex-1 min-w-0">
-            <p class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate">{{ svc.service_name }}</p>
+            <a href="/#svc-{{ svc.service_name | lower | replace(' ', '-') | replace('/', '-') | replace('_', '-') }}"
+               target="_blank"
+               class="font-medium text-sm text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400 transition-colors">{{ svc.service_name }}</a>
             <p class="text-[11px] {{ meta.text }} font-medium uppercase tracking-wide">{{ meta.label }}</p>
           </div>
           <form method="post" action="/admin/services/{{ svc.service_name | urlencode }}/status"

--- a/templates/base.html
+++ b/templates/base.html
@@ -55,7 +55,7 @@
 <body class="h-full bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100 font-sans antialiased transition-colors duration-200">
 
   <!-- Navigation -->
-  <nav class="bg-brand dark:bg-brand-dark border-b border-brand-dark sticky top-0 z-10">
+  <nav class="bg-brand dark:bg-brand-dark border-b border-brand-dark fixed top-0 left-0 right-0 z-10 w-full">
     <div class="max-w-4xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
       <div class="flex items-center gap-2">
         <!-- M365 four-square icon -->
@@ -102,6 +102,7 @@
     </div>
   </nav>
 
+  <div class="h-14"></div>
   <!-- Main content -->
   <main class="{% block container_class %}max-w-4xl{% endblock %} mx-auto px-4 sm:px-6 py-8">
     {% block content %}{% endblock %}

--- a/templates/partials/service_row.html
+++ b/templates/partials/service_row.html
@@ -1,5 +1,6 @@
 {# Renders one service card. Expects `service` (ServiceStatusSchema) in scope. #}
 <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 p-4 mb-3 shadow-sm"
+     id="svc-{{ service.service_name | lower | replace(' ', '-') | replace('/', '-') | replace('_', '-') }}"
      data-service-card
      data-service="{{ service.service_name }}">
   <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- **Fixed nav bar**: switched from `sticky` to `fixed` positioning — the top blue M365 header now stays visible on all admin pages while scrolling, with a `h-14` spacer so content is not hidden behind it
- **Clickable service names**: in the admin dashboard "M365 Dienststatus" grid, each service name is now a link that opens the public status page at the corresponding anchor (`/#svc-...`)
- **Anchor IDs**: added `id="svc-..."` to each service card in `service_row.html` so the admin links land on the right card

## Test plan

- [ ] Scroll down on any admin page — top nav bar stays fixed
- [ ] Click a service name in admin dashboard — public status page opens in new tab and scrolls to the matching service card
- [ ] Verify dark mode and mobile layout still look correct

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_