### PR TITLE
Store end_datetime from Graph API for all incident types

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -86,6 +86,9 @@ async def upsert_incident(
             # Don't overwrite severity if admin has set it manually
             if k == "severity" and incident.source == "manual":
                 continue
+            # Preserve admin-set end_datetime if Graph API has no value yet
+            if k == "end_datetime" and v is None and incident.end_datetime is not None:
+                continue
             setattr(incident, k, v)
         await db.flush()
     return incident

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -152,6 +152,7 @@ async def sync_issue_as_incident(db, issue: dict) -> None:
         "classification": classification,
         "status": new_status,
         "start_datetime": _parse_dt(issue.get("startDateTime")),
+        "end_datetime": _parse_dt(issue.get("endDateTime")),
         "last_modified": _parse_dt(issue.get("lastModifiedDateTime")),
         "is_resolved": issue.get("isResolved", False),
         "severity": severity,


### PR DESCRIPTION
## Summary

- **Graph poller now stores `end_datetime`** for all incident types, not just maintenance — resolving M365 incidents now show a populated end time in the admin detail form
- **Protects admin-entered values**: if the admin manually sets an `end_datetime` but Graph API polls with null (incident not yet resolved), the manual value is preserved — same pattern already used for `description`

## Why

Previously when viewing an M365-imported incident in the admin detail form, the "Ende" field was always empty because the Graph poller only stored `endDateTime` for maintenance-classified incidents. Admins could enter a value but it could be cleared on the next poll if Graph returned null.

## Test plan

- [ ] Resolve an M365 incident via Graph API → `end_datetime` is populated in admin detail form
- [ ] Manually set `end_datetime` on an M365 incident → value survives the next Graph poll (when Graph still returns no endDateTime)
- [ ] Maintenance incidents still store `scheduled_start` / `scheduled_end` as before

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_