### PR TITLE
Keep mobile admin sidebar below the fixed nav bar

### DIFF
--- a/templates/admin/base_admin.html
+++ b/templates/admin/base_admin.html
@@ -58,13 +58,13 @@
 
   {# ── Mobile drawer overlay ─────────────────────────────────────── #}
   <div id="admin-sidebar-overlay"
-       class="fixed inset-0 bg-black/40 z-20 lg:hidden hidden"
+       class="fixed inset-0 top-14 bg-black/40 z-20 lg:hidden hidden"
        aria-hidden="true"></div>
 
   {# ── Sidebar (left, sticky on desktop, drawer on mobile) ──────── #}
   <aside id="admin-sidebar"
-         class="fixed lg:sticky top-0 lg:top-20 left-0 z-30
-                w-60 lg:w-52 h-screen lg:h-auto shrink-0
+         class="fixed lg:sticky top-14 lg:top-20 left-0 z-30
+                w-60 lg:w-52 h-[calc(100vh-3.5rem)] lg:h-auto shrink-0
                 bg-white dark:bg-gray-900 lg:bg-transparent dark:lg:bg-transparent
                 border-r border-gray-200 dark:border-gray-800 lg:border-0
                 -translate-x-full lg:translate-x-0 transition-transform duration-200">


### PR DESCRIPTION
## Summary

- Mobile admin sidebar drawer now starts at `top-14` (56 px = nav height) instead of `top-0`, so it no longer slides over the blue header bar
- The dark overlay behind the drawer is also constrained to `top-14` so the nav bar stays fully visible and clickable while the sidebar is open
- Desktop sticky sidebar is unchanged (`lg:top-20`)

## Test plan

- [ ] Open admin on a mobile viewport, tap the hamburger toggle — sidebar slides in below the nav bar, nav remains visible
- [ ] Click overlay or close button — sidebar closes correctly
- [ ] Desktop layout unchanged — sidebar sticks below nav as before

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_