### PR TITLE
Pulse service-status dots on admin dashboard

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -55,7 +55,7 @@
         {% set cur = svc.current_status %}
         {% set meta = status_meta.get(cur, status_meta['unknown']) %}
         <div class="px-4 py-3 flex items-center gap-3">
-          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ meta.dot }} ring-4 {{ meta.ring }}"
+          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ meta.dot }} ring-4 {{ meta.ring }} {{ status_pulse_class(cur) }}"
                 title="{{ meta.label }}"></span>
           <div class="flex-1 min-w-0">
             <a href="/#svc-{{ svc.service_name | lower | replace(' ', '-') | replace('/', '-') | replace('_', '-') }}"


### PR DESCRIPTION
## Summary

Closes #45

- Public statuspage already pulses degraded/interrupted service dots via `status_pulse_class()`
- Admin dashboard service-status dots did not pulse — added the same helper so behavior is consistent across both views
- Tailwind `animate-pulse` is automatically suppressed under `prefers-reduced-motion` (global rule already in `base.html`)

## Test plan

- [ ] Open `/admin` with a service in `degraded` or `interrupted` status — dot pulses
- [ ] Same service on `/` (public page) also pulses (already worked)
- [ ] Operational dots stay static
- [ ] OS-level "Reduce motion" disables the pulse

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_