### PR TITLE
Friendlier empty states for admin incidents and maintenances

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -143,6 +143,7 @@ LABELS: dict[str, str] = {
     "empty.admin.incidents_sub":  "Das System läuft normal.",
     "empty.admin.suppressed":     "Keine ignorierten Meldungen.",
     "empty.admin.maintenances":   "Keine geplanten Wartungen.",
+    "empty.admin.maintenances_sub": "Es stehen aktuell keine Arbeiten an.",
     "empty.public.all_good":      "Keine aktiven Störungen.",
     "empty.public.all_good_sub":  "Alle Dienste laufen normal.",
     "empty.public.history":       "Keine behobenen Störungen in den letzten 30 Tagen.",

--- a/templates/admin/incidents_all.html
+++ b/templates/admin/incidents_all.html
@@ -125,8 +125,14 @@
   </p>
 </section>
 {% else %}
-<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-8 shadow-sm text-center">
-  <p class="text-sm text-gray-500 dark:text-gray-400">{{ L["admin.no_incidents"] }}</p>
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-8 shadow-sm">
+  <div class="flex flex-col items-center text-center gap-2">
+    <div class="w-10 h-10 rounded-full bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center text-emerald-600 dark:text-emerald-400">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ L["empty.admin.incidents"] }}</p>
+    <p class="text-xs text-gray-500 dark:text-gray-400">{{ L["empty.admin.incidents_sub"] }}</p>
+  </div>
 </div>
 {% endif %}
 

--- a/templates/admin/maintenances_all.html
+++ b/templates/admin/maintenances_all.html
@@ -103,8 +103,16 @@
   {{ L["admin.filter_empty"] }}
 </p>
 {% else %}
-<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-8 shadow-sm text-center">
-  <p class="text-sm text-gray-500 dark:text-gray-400">{{ L["admin.no_maintenances"] }}</p>
+<div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-5 py-8 shadow-sm">
+  <div class="flex flex-col items-center text-center gap-2">
+    <div class="w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center text-blue-600 dark:text-blue-400">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437"/>
+      </svg>
+    </div>
+    <p class="text-sm font-medium text-gray-700 dark:text-gray-200">{{ L["empty.admin.maintenances"] }}</p>
+    <p class="text-xs text-gray-500 dark:text-gray-400">{{ L["empty.admin.maintenances_sub"] }}</p>
+  </div>
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary

Partial work toward #49 — friendlier empty states for admin lists.

- `/admin/incidents` and `/admin/incidents?source=manual` (own incidents) and `/admin/incidents` (all) — replaces plain text empty state with the styled pattern: emerald check icon + main line + sub line, matching what the public statuspage already does for "no incidents"
- `/admin/maintenances` — same pattern, with a blue wrench icon
- Uses existing `empty.admin.incidents` / `_sub` labels, adds `empty.admin.maintenances_sub` for consistency

Not addressed in this PR (out of scope, can be follow-ups):
- Subscriber list empty state
- Templates feature (doesn't exist yet — see #37)

## Test plan

- [ ] `/admin/incidents` with no incidents — friendly card with green check icon shown
- [ ] `/admin/maintenances` with no maintenances — friendly card with blue wrench icon shown
- [ ] Dark mode renders correctly
- [ ] Existing populated lists unchanged

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_