### PR TITLE
Show build info chip (version + commit + build time) in DEV mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,11 @@ jobs:
 
       # ── 1. Build ────────────────────────────────────────────────────────────
       - name: Build Docker image
-        run: docker build -t "$IMAGE" .
+        run: |
+          docker build \
+            --build-arg BUILD_SHA="$(git rev-parse --short HEAD)" \
+            --build-arg BUILD_TIME="$(date -u +%Y-%m-%dT%H:%MZ)" \
+            -t "$IMAGE" .
 
       # ── 2. Image size guard (container-structure-test doesn't cover size) ──
       - name: "Image size < 800 MB"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute build metadata
+        id: meta
+        run: |
+          echo "BUILD_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "BUILD_TIME=$(date -u +%Y-%m-%dT%H:%MZ)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -48,6 +54,9 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}
             ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            BUILD_SHA=${{ steps.meta.outputs.BUILD_SHA }}
+            BUILD_TIME=${{ steps.meta.outputs.BUILD_TIME }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,13 @@ RUN mkdir -p /app/data && chown appuser:appuser /app/data
 
 USER appuser
 
+# Build metadata: passed via --build-arg from CI, surfaced as ENV so the app
+# can render them in the dev-only build chip (bottom-right of every page).
+ARG BUILD_SHA=""
+ARG BUILD_TIME=""
+ENV BUILD_SHA=$BUILD_SHA \
+    BUILD_TIME=$BUILD_TIME
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 

--- a/app/config.py
+++ b/app/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     # Public base URL (used in email links)
     BASE_URL: str = "http://localhost:8000"
 
+    # Build metadata (injected by Docker build args; empty in local dev)
+    BUILD_SHA: str = ""
+    BUILD_TIME: str = ""
+
     @property
     def teams_webhook_list(self) -> list[str]:
         return [u.strip() for u in self.TEAMS_WEBHOOK_URLS.split(",") if u.strip()]

--- a/app/templates.py
+++ b/app/templates.py
@@ -20,6 +20,9 @@ templates = Jinja2Templates(directory="templates")
 templates.env.globals["L"] = LABELS
 templates.env.globals["APP_VERSION"] = __version__
 templates.env.globals["APP_TITLE"] = _settings.APP_TITLE
+templates.env.globals["BUILD_SHA"] = _settings.BUILD_SHA
+templates.env.globals["BUILD_TIME"] = _settings.BUILD_TIME
+templates.env.globals["DEBUG"] = _settings.DEBUG
 templates.env.globals["status_bar_class"] = (
     lambda s: STATUS_TAILWIND_BAR.get(s, STATUS_TAILWIND_BAR["unknown"])
 )

--- a/templates/admin/base_admin.html
+++ b/templates/admin/base_admin.html
@@ -126,9 +126,6 @@
 
       </div>
 
-      <p class="hidden lg:block text-[10px] text-gray-400 dark:text-gray-500 text-right pr-3 pb-2 select-none">
-        v{{ APP_VERSION }}
-      </p>
     </nav>
   </aside>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -162,6 +162,14 @@
     <span>Installieren</span>
   </button>
 
+  {# ── Build info chip — only in DEV mode (DEBUG=True); never in production ── #}
+  {% if DEBUG %}
+  <div title="App-Version · Commit · Build-Zeit (UTC)"
+       class="fixed bottom-2 right-2 z-30 text-[10px] font-mono px-2 py-1 rounded-md bg-gray-900/70 text-white/80 backdrop-blur select-text pointer-events-auto">
+    v{{ APP_VERSION }}{% if BUILD_SHA %} · {{ BUILD_SHA }}{% endif %}{% if BUILD_TIME %} · {{ BUILD_TIME }}{% endif %}
+  </div>
+  {% endif %}
+
   <script>
     // Dark mode toggle (persists to localStorage)
     const html = document.documentElement;


### PR DESCRIPTION
## Summary

Adds a small floating chip in the **bottom-right corner of every page** that shows exactly which build is running, so you can verify the version under test at a glance.

**Chip content (ISO 8601, UTC):**
```
v1.4.0 · a1b2c3d · 2026-05-17T22:45Z
```

**Visibility:** gated on `settings.DEBUG` — only appears in dev/local environments, **never** in production, even for admin users.

## Implementation

| File | Change |
|---|---|
| `Dockerfile` | New `ARG BUILD_SHA` / `BUILD_TIME` → `ENV` |
| `.github/workflows/ci.yml` | `docker build` passes both via `--build-arg` |
| `.github/workflows/release.yml` | `docker/build-push-action` `build-args:` block |
| `app/config.py` | `BUILD_SHA: str = ""`, `BUILD_TIME: str = ""` |
| `app/templates.py` | Exposes `BUILD_SHA`, `BUILD_TIME`, `DEBUG` as Jinja globals |
| `templates/base.html` | Renders the chip when `DEBUG` is True |
| `templates/admin/base_admin.html` | Removes the redundant `v{APP_VERSION}` line in the sidebar |

## Test plan

- [ ] Run locally with `DEBUG=true` → chip visible bottom-right on every page (public + admin)
- [ ] Run with default `DEBUG=false` → no chip anywhere
- [ ] Production image built via release.yml → chip suppressed (DEBUG defaults to false), but `BUILD_SHA` and `BUILD_TIME` are still baked in for future use (logs, headers)
- [ ] Local dev without docker (no BUILD_SHA/BUILD_TIME): chip shows just `v1.4.0`

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_