### PR TITLE
Show start → end range for resolved incidents

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -25,6 +25,7 @@ LABELS: dict[str, str] = {
     "incident.type.advisory":     "Hinweis",
     "incident.affects":           "Betrifft",
     "incident.since":             "Seit",
+    "incident.until":             "bis",
     "incident.updates":           "Updates",
     "incident.resolved":          "Behoben",
     # Embed

--- a/templates/admin/incidents_all.html
+++ b/templates/admin/incidents_all.html
@@ -93,8 +93,12 @@
       {{ L["incident.resolved"] }}
     </span>
     {% endif %}
-    <span class="text-xs text-gray-400 dark:text-gray-500">
-      {{ (inc.end_datetime or inc.last_modified or inc.start_datetime) | strftime_de }}
+    <span class="text-xs text-gray-400 dark:text-gray-500" title="{% if inc.start_datetime %}Start: {{ inc.start_datetime | strftime_de }}{% endif %}{% if inc.end_datetime %} · Ende: {{ inc.end_datetime | strftime_de }}{% endif %}">
+      {% if inc.is_resolved and inc.end_datetime and inc.start_datetime %}
+        {{ inc.start_datetime | strftime_de }} → {{ inc.end_datetime | strftime_de }}
+      {% else %}
+        {{ (inc.end_datetime or inc.last_modified or inc.start_datetime) | strftime_de }}
+      {% endif %}
     </span>
   </div>
 </a>

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -27,7 +27,11 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           <span class="font-medium">{{ L["incident.affects"] }}:</span> {{ incident.service_name }}
           &nbsp;·&nbsp;
-          <span class="font-medium">{{ L["incident.since"] }}:</span> {{ incident.start_datetime | strftime_de }}
+          {% if incident.is_resolved and incident.end_datetime %}
+            {{ incident.start_datetime | strftime_de }} → {{ incident.end_datetime | strftime_de }}
+          {% else %}
+            <span class="font-medium">{{ L["incident.since"] }}:</span> {{ incident.start_datetime | strftime_de }}
+          {% endif %}
         </p>
         {% if incident.description %}
         <div class="text-sm text-gray-600 dark:text-gray-300 mt-2 prose prose-sm dark:prose-invert max-w-none [&_a]:text-blue-600 [&_a]:underline">

--- a/templates/status.html
+++ b/templates/status.html
@@ -305,8 +305,13 @@
             <span class="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 shrink-0">
               {{ L["incident.resolved"] }}
             </span>
-            <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0 hidden sm:block">
-              {{ (incident.end_datetime or incident.last_modified) | strftime_de }}
+            <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0 hidden sm:block"
+                  title="{% if incident.start_datetime %}Start: {{ incident.start_datetime | strftime_de }}{% endif %}{% if incident.end_datetime %} · Ende: {{ incident.end_datetime | strftime_de }}{% endif %}">
+              {% if incident.start_datetime and incident.end_datetime %}
+                {{ incident.start_datetime | strftime_de }} → {{ incident.end_datetime | strftime_de }}
+              {% else %}
+                {{ (incident.end_datetime or incident.last_modified) | strftime_de }}
+              {% endif %}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Folge-PR zu #77 (end_datetime aus Graph speichern). Jetzt wird die gespeicherte Endzeit auch **sichtbar** angezeigt — bisher wurde nur EIN Datum pro Incident gezeigt (das letzte modifizierte), obwohl Start + Ende beide bekannt sind.

**Geänderte Anzeigen** (nur für **gelöste** Incidents, aktive bleiben wie bisher):

| Ort | Vorher | Nachher |
|---|---|---|
| Public Incident-Card | `Seit: 13.05` | `13.05 → 17.05` |
| Public History-Liste | `17.05` | `13.05 → 17.05` |
| `/admin/incidents` Zeile | `17.05` | `13.05 → 17.05` + Tooltip |

Aktive Incidents bleiben mit `Seit: <Start>` — das ist hier semantisch korrekt, weil sie noch laufen.

Hover-Tooltip in der Admin-Zeile zeigt zusätzlich `Start: dd.mm.yyyy hh:mm Uhr · Ende: …` für maximale Klarheit.

## Test plan

- [ ] `/` mit gelösten M365-Incidents: jede Card und History-Zeile zeigt `Start → Ende`
- [ ] Aktive Incidents zeigen weiterhin nur `Seit: <Start>`
- [ ] `/admin/incidents`: Zeile zeigt Bereich für gelöste, Hover-Tooltip beide Werte
- [ ] Bei fehlendem `end_datetime` (z. B. ältere M365-Incidents) wird auf bestehendes Verhalten zurückgefallen

## Hinweis zu Altdaten

Bestehende M365-Incidents, die vor PR #77 gelöst wurden, haben kein `end_datetime`. Der Graph-Poller backfilled automatisch alles, was in den letzten **30 Tagen** gelöst wurde (Phase 3 in `poll_graph_api`). Ältere bleiben mit der bisherigen Anzeige (`last_modified`).

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_