### PR TITLE
Shorten resolved-incident display to date + duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Background-agent worktrees (transient, never check in)
+.claude/worktrees/

--- a/app/templates.py
+++ b/app/templates.py
@@ -142,6 +142,30 @@ def _date_de(d, fmt: str = "%d.%m.%Y") -> str:
     return d.strftime(fmt)
 
 
+def _duration_de(start: datetime | None, end: datetime | None) -> str:
+    if start is None or end is None:
+        return ""
+    seconds = int((end - start).total_seconds())
+    if seconds < 0:
+        return ""
+    if seconds < 60:
+        return f"{seconds} Sek"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes} Min"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours} Std"
+    days = hours // 24
+    if days < 7:
+        return "1 Tag" if days == 1 else f"{days} Tage"
+    weeks = days // 7
+    if weeks < 5:
+        return "1 Woche" if weeks == 1 else f"{weeks} Wochen"
+    months = days // 30
+    return "1 Monat" if months == 1 else f"{months} Monate"
+
+
 def _render_md(text: str | None) -> str:
     if not text:
         return ""
@@ -152,3 +176,4 @@ def _render_md(text: str | None) -> str:
 templates.env.filters["strftime_de"] = _strftime_de
 templates.env.filters["date_de"] = _date_de
 templates.env.filters["render_md"] = _render_md
+templates.env.globals["duration_de"] = _duration_de

--- a/templates/admin/incidents_all.html
+++ b/templates/admin/incidents_all.html
@@ -95,7 +95,7 @@
     {% endif %}
     <span class="text-xs text-gray-400 dark:text-gray-500" title="{% if inc.start_datetime %}Start: {{ inc.start_datetime | strftime_de }}{% endif %}{% if inc.end_datetime %} · Ende: {{ inc.end_datetime | strftime_de }}{% endif %}">
       {% if inc.is_resolved and inc.end_datetime and inc.start_datetime %}
-        {{ inc.start_datetime | strftime_de }} → {{ inc.end_datetime | strftime_de }}
+        {{ inc.start_datetime | date_de }} · {{ duration_de(inc.start_datetime, inc.end_datetime) }}
       {% else %}
         {{ (inc.end_datetime or inc.last_modified or inc.start_datetime) | strftime_de }}
       {% endif %}

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -27,8 +27,10 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
           <span class="font-medium">{{ L["incident.affects"] }}:</span> {{ incident.service_name }}
           &nbsp;·&nbsp;
-          {% if incident.is_resolved and incident.end_datetime %}
-            {{ incident.start_datetime | strftime_de }} → {{ incident.end_datetime | strftime_de }}
+          {% if incident.is_resolved and incident.end_datetime and incident.start_datetime %}
+            <span title="{{ incident.start_datetime | strftime_de }} → {{ incident.end_datetime | strftime_de }}">
+              {{ incident.start_datetime | date_de }} · {{ duration_de(incident.start_datetime, incident.end_datetime) }}
+            </span>
           {% else %}
             <span class="font-medium">{{ L["incident.since"] }}:</span> {{ incident.start_datetime | strftime_de }}
           {% endif %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -308,7 +308,7 @@
             <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0 hidden sm:block"
                   title="{% if incident.start_datetime %}Start: {{ incident.start_datetime | strftime_de }}{% endif %}{% if incident.end_datetime %} · Ende: {{ incident.end_datetime | strftime_de }}{% endif %}">
               {% if incident.start_datetime and incident.end_datetime %}
-                {{ incident.start_datetime | strftime_de }} → {{ incident.end_datetime | strftime_de }}
+                {{ incident.start_datetime | date_de }} · {{ duration_de(incident.start_datetime, incident.end_datetime) }}
               {% else %}
                 {{ (incident.end_datetime or incident.last_modified) | strftime_de }}
               {% endif %}


### PR DESCRIPTION
## Summary

Verkürzt die Anzeige für gelöste Incidents — vorher zu lang, jetzt kompakt:

| | Vorher | Nachher |
|---|---|---|
| Anzeige | `13.05.2026 14:30 Uhr → 17.05.2026 18:45 Uhr` | `13.05.2026 · 4 Tage` |

Volle Zeitstempel bleiben per Hover-Tooltip erhalten.

Neues Jinja-Global `duration_de(start, end)` wählt automatisch die passende Einheit:
`Sek / Min / Std / Tag(e) / Woche(n) / Monat(e)`.

Auch ergänzt: `.claude/worktrees/` in `.gitignore` — verhindert, dass Background-Agent-Worktrees aus Versehen committed werden.

## Test plan

- [ ] `/` Public Page: gelöste Incident-Karten zeigen `Start · Dauer` statt voller Range
- [ ] `/` History-Liste: dito
- [ ] `/admin/incidents` Zeile: dito für gelöste, aktive bleiben unverändert
- [ ] Hover-Tooltip zeigt weiterhin beide vollen Zeitstempel
- [ ] Sehr kurze Incidents (Sekunden/Minuten/Stunden) korrekt formatiert

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_