### PR TITLE
Cmd+K global search in admin

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, timedelta
 from typing import Any
 
 import bleach
-from sqlalchemy import desc, select
+from sqlalchemy import desc, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -808,3 +808,127 @@ async def get_confirmed_subscribers(db: AsyncSession) -> list[Subscriber]:
         .order_by(Subscriber.email)
     )
     return list(result.scalars().all())
+
+
+async def search_global(db: AsyncSession, q: str) -> dict:
+    """Run a multi-table LIKE search and group hits for the admin Cmd+K palette.
+
+    Returns a dict shaped for direct JSON serialisation:
+    ``{"groups": [{"label": str, "items": [{"label", "href", "sub"}, ...]}, ...]}``.
+    Empty / very short queries return an empty result set so we don't flood
+    the palette while the user is still typing the first character.
+    """
+    query = (q or "").strip()
+    if len(query) < 2:
+        return {"groups": []}
+
+    pattern = f"%{query}%"
+    per_group = 5
+    total_cap = 20
+
+    incidents_res = await db.execute(
+        select(Incident)
+        .where(
+            Incident.classification != "maintenance",
+            or_(
+                Incident.title.like(pattern),
+                Incident.description.like(pattern),
+                Incident.service_name.like(pattern),
+            ),
+        )
+        .order_by(desc(Incident.last_modified))
+        .limit(per_group)
+    )
+    incidents = list(incidents_res.scalars().all())
+
+    updates_res = await db.execute(
+        select(IncidentUpdate)
+        .where(IncidentUpdate.content.like(pattern))
+        .order_by(desc(IncidentUpdate.post_created_at))
+        .limit(per_group)
+    )
+    updates = list(updates_res.scalars().all())
+
+    services_res = await db.execute(
+        select(MonitoredService)
+        .where(MonitoredService.service_name.like(pattern))
+        .order_by(MonitoredService.service_name)
+        .limit(per_group)
+    )
+    services = list(services_res.scalars().all())
+
+    subscribers_res = await db.execute(
+        select(Subscriber)
+        .where(Subscriber.email.like(pattern))
+        .order_by(Subscriber.email)
+        .limit(per_group)
+    )
+    subscribers = list(subscribers_res.scalars().all())
+
+    groups: list[dict] = []
+    if incidents:
+        groups.append({
+            "label": "admin.search.group.incidents",
+            "items": [
+                {
+                    "label": inc.title,
+                    "href": f"/admin/incidents/{inc.id}",
+                    "sub": inc.service_name or "",
+                }
+                for inc in incidents
+            ],
+        })
+    if updates:
+        # Need parent incidents to build hrefs; fetch in one go to avoid N+1
+        parent_ids = sorted({u.incident_id for u in updates})
+        parents_res = await db.execute(
+            select(Incident).where(Incident.id.in_(parent_ids))
+        )
+        parents = {i.id: i for i in parents_res.scalars().all()}
+        items: list[dict] = []
+        for upd in updates:
+            parent = parents.get(upd.incident_id)
+            snippet = upd.content[:120] + ("…" if len(upd.content) > 120 else "")
+            items.append({
+                "label": snippet,
+                "href": f"/admin/incidents/{upd.incident_id}",
+                "sub": parent.title if parent else "",
+            })
+        groups.append({"label": "admin.search.group.updates", "items": items})
+    if services:
+        groups.append({
+            "label": "admin.search.group.services",
+            "items": [
+                {
+                    "label": svc.service_name,
+                    "href": "/admin/settings#services",
+                    "sub": svc.group_name or "",
+                }
+                for svc in services
+            ],
+        })
+    if subscribers:
+        groups.append({
+            "label": "admin.search.group.subscribers",
+            "items": [
+                {
+                    "label": sub.email,
+                    "href": "/admin/settings#subscribers",
+                    "sub": "" if sub.confirmed_at else "admin.subscriber_pending",
+                }
+                for sub in subscribers
+            ],
+        })
+
+    # Enforce global cap by trimming groups in order
+    remaining = total_cap
+    capped: list[dict] = []
+    for g in groups:
+        if remaining <= 0:
+            break
+        items = g["items"][:remaining]
+        if items:
+            capped.append({"label": g["label"], "items": items})
+            remaining -= len(items)
+
+    return {"groups": capped}

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -247,4 +247,12 @@ LABELS: dict[str, str] = {
     "admin.azure_status_configured":  "Verbunden",
     "admin.azure_status_pending":     "Unvollständig",
     "toast.azure_saved":              "Azure AD App gespeichert.",
+    # Admin – global search palette (Cmd+K / Ctrl+K)
+    "admin.search.placeholder":        "Suchen…",
+    "admin.search.group.incidents":    "Störungen",
+    "admin.search.group.updates":      "Updates",
+    "admin.search.group.services":     "Dienste",
+    "admin.search.group.subscribers":  "Subscriber",
+    "admin.search.no_results":         "Keine Treffer.",
+    "admin.search.hint":               "Cmd+K oder Strg+K zum Öffnen",
 }

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -38,6 +38,7 @@ from app.crud import (
     get_incident_by_id,
     get_known_groups,
     move_service,
+    search_global,
     set_service_enabled,
     set_service_group,
     set_service_status_manual,
@@ -174,6 +175,16 @@ async def admin_dashboard(
             **nav,
         },
     )
+
+
+@router.get("/search")
+async def admin_search(
+    q: str = "",
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    """JSON endpoint backing the Cmd+K palette in the admin area."""
+    return JSONResponse(await search_global(db, q))
 
 
 @router.get("/settings")

--- a/templates/admin/base_admin.html
+++ b/templates/admin/base_admin.html
@@ -193,6 +193,30 @@
 </div>
 {% endif %}
 
+{# ── Global Cmd+K / Ctrl+K search palette ───────────────────────────────── #}
+<div id="admin-search-modal"
+     class="hidden fixed inset-0 z-50 flex items-start justify-center p-4 pt-[10vh]"
+     role="dialog" aria-modal="true" aria-label="{{ L['admin.search.placeholder'] }}">
+  <div class="absolute inset-0 bg-black/40 backdrop-blur-sm" id="admin-search-backdrop"></div>
+  <div class="relative bg-white dark:bg-gray-900 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 w-full max-w-xl overflow-hidden">
+    <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-100 dark:border-gray-800">
+      <svg class="w-5 h-5 text-gray-400 dark:text-gray-500 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M11 18a7 7 0 100-14 7 7 0 000 14z"/>
+      </svg>
+      <input type="text" id="admin-search-input"
+             autocomplete="off"
+             placeholder="{{ L['admin.search.placeholder'] }}"
+             class="flex-1 bg-transparent text-sm text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none" />
+      <kbd class="hidden sm:inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">Esc</kbd>
+    </div>
+    <div id="admin-search-results" class="max-h-[60vh] overflow-y-auto py-2"></div>
+    <div class="px-4 py-2 border-t border-gray-100 dark:border-gray-800 text-[11px] text-gray-400 dark:text-gray-500 flex items-center justify-between">
+      <span>{{ L['admin.search.hint'] }}</span>
+      <span class="hidden sm:inline">&uarr; &darr; &crarr;</span>
+    </div>
+  </div>
+</div>
+
 {% endblock %}
 
 {% block scripts %}
@@ -232,6 +256,154 @@
   closeBtn && closeBtn.addEventListener('click', close);
   overlay.addEventListener('click', close);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape') close(); });
+})();
+</script>
+<script>
+(function () {
+  const modal     = document.getElementById('admin-search-modal');
+  const backdrop  = document.getElementById('admin-search-backdrop');
+  const input     = document.getElementById('admin-search-input');
+  const resultsEl = document.getElementById('admin-search-results');
+  if (!modal || !input || !resultsEl) return;
+
+  const LABELS = {
+    'admin.search.group.incidents':   {{ L['admin.search.group.incidents']   | tojson }},
+    'admin.search.group.updates':     {{ L['admin.search.group.updates']     | tojson }},
+    'admin.search.group.services':    {{ L['admin.search.group.services']    | tojson }},
+    'admin.search.group.subscribers': {{ L['admin.search.group.subscribers'] | tojson }},
+    'admin.search.no_results':        {{ L['admin.search.no_results']        | tojson }},
+    'admin.subscriber_pending':       {{ L['admin.subscriber_pending']       | tojson }},
+  };
+  const tr = (k) => LABELS[k] || k;
+
+  let items = [];
+  let active = -1;
+  let debounce = null;
+  let lastQuery = '';
+
+  function openModal() {
+    modal.classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+    setTimeout(() => { input.focus(); input.select(); }, 30);
+    if (input.value.trim().length >= 2) runSearch(input.value);
+    else renderEmpty();
+  }
+  function closeModal() {
+    modal.classList.add('hidden');
+    document.body.classList.remove('overflow-hidden');
+    items = []; active = -1;
+  }
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, (c) => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    }[c]));
+  }
+
+  function renderEmpty() {
+    resultsEl.innerHTML = '';
+    items = []; active = -1;
+  }
+
+  function renderNoResults() {
+    resultsEl.innerHTML =
+      '<div class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">'
+      + escapeHtml(tr('admin.search.no_results')) + '</div>';
+    items = []; active = -1;
+  }
+
+  function renderGroups(groups) {
+    if (!groups || !groups.length) { renderNoResults(); return; }
+    items = [];
+    const parts = [];
+    groups.forEach((g) => {
+      parts.push(
+        '<div class="px-4 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">'
+        + escapeHtml(tr(g.label)) + '</div>'
+      );
+      g.items.forEach((it) => {
+        const idx = items.length;
+        items.push(it);
+        const sub = it.sub ? (tr(it.sub) || it.sub) : '';
+        parts.push(
+          '<a href="' + escapeHtml(it.href) + '" data-idx="' + idx + '"'
+          + ' class="block px-4 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors">'
+          + '<div class="text-gray-900 dark:text-white truncate">' + escapeHtml(it.label) + '</div>'
+          + (sub ? '<div class="text-xs text-gray-500 dark:text-gray-400 truncate">' + escapeHtml(sub) + '</div>' : '')
+          + '</a>'
+        );
+      });
+    });
+    resultsEl.innerHTML = parts.join('');
+    active = items.length ? 0 : -1;
+    updateActive();
+  }
+
+  function updateActive() {
+    resultsEl.querySelectorAll('a[data-idx]').forEach((el) => {
+      const i = Number(el.dataset.idx);
+      if (i === active) {
+        el.classList.add('bg-blue-50', 'dark:bg-blue-950/40');
+        el.scrollIntoView({ block: 'nearest' });
+      } else {
+        el.classList.remove('bg-blue-50', 'dark:bg-blue-950/40');
+      }
+    });
+  }
+
+  async function runSearch(q) {
+    const trimmed = q.trim();
+    if (trimmed.length < 2) { renderEmpty(); return; }
+    if (trimmed === lastQuery) return;
+    lastQuery = trimmed;
+    try {
+      const resp = await fetch('/admin/search?q=' + encodeURIComponent(trimmed), {
+        credentials: 'same-origin',
+        headers: { 'Accept': 'application/json' },
+      });
+      if (!resp.ok) { renderNoResults(); return; }
+      const data = await resp.json();
+      renderGroups(data.groups || []);
+    } catch (_e) {
+      renderNoResults();
+    }
+  }
+
+  input.addEventListener('input', () => {
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => runSearch(input.value), 120);
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (items.length) { active = (active + 1) % items.length; updateActive(); }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (items.length) { active = (active - 1 + items.length) % items.length; updateActive(); }
+    } else if (e.key === 'Enter') {
+      if (active >= 0 && items[active]) {
+        e.preventDefault();
+        window.location.href = items[active].href;
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeModal();
+    }
+  });
+
+  backdrop.addEventListener('click', closeModal);
+
+  document.addEventListener('keydown', (e) => {
+    const isShortcut = (e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey);
+    if (isShortcut) {
+      e.preventDefault();
+      if (modal.classList.contains('hidden')) openModal();
+      else closeModal();
+    } else if (e.key === 'Escape' && !modal.classList.contains('hidden')) {
+      closeModal();
+    }
+  });
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
Closes #41

## Summary

Globale Suche im Admin per **Cmd+K / Ctrl+K**. Modal-Palette mit gruppierten Ergebnissen über alle relevanten Tabellen.

**Durchsucht** (LIKE `%q%`, ODER-verknüpft, max 5 pro Gruppe / 20 gesamt):
- `Incident.title`, `.description`, `.service_name`
- `IncidentUpdate.content` (Snippet trägt den Parent-Incident-Titel als `sub`)
- `MonitoredService.service_name`
- `Subscriber.email`

**Ergebnisse gruppiert nach Typ:** Störungen · Updates · Dienste · Subscriber

**UX:**
- Cmd+K (Mac) / Ctrl+K (Win/Linux) öffnet das Modal von jeder Admin-Seite
- ↑/↓ navigiert, Enter springt zum Treffer, Esc schließt
- 120 ms Debounce beim Tippen
- Backdrop-Click schließt
- Modal sperrt body-scroll während offen, restored beim Schließen
- < 2 Zeichen → leere Resultliste

## Geänderte Dateien

- `app/crud.py` — neuer `search_global(db, q)` Helper; `or_` zum Import ergänzt
- `app/routers/admin.py` — `GET /admin/search` (auth via `require_auth`)
- `app/i18n.py` — 7 neue `admin.search.*` Labels (Deutsch)
- `templates/admin/base_admin.html` — Modal-Markup + inline JS

## Entscheidungen

- `require_auth` statt `LoginRequired` (LoginRequired ist die Exception, require_auth der Dependency-Callable den bestehende Admin-Routes verwenden)
- Group/Sub-Labels werden vom Backend als Label-Keys (`admin.search.group.incidents`) geliefert und im Frontend aufgelöst — i18n bleibt zentral
- Update-Snippets auf 120 Zeichen mit Ellipsis getrimmt
- Keine extra Sidebar-Entry "Suchen" hinzugefügt (Sidebar ist eng, Shortcut reicht)

## Test plan

- [ ] Cmd+K (oder Ctrl+K) auf jeder `/admin/*`-Seite öffnet das Modal
- [ ] Tippen → Resultate nach 120 ms
- [ ] Treffer in jeder Gruppe (Incident, Update, Dienst, Subscriber) funktioniert
- [ ] Pfeil/Enter Navigation
- [ ] Esc / Backdrop-Click schließen
- [ ] Dark Mode passt
- [ ] Logged-out User bekommt 401/Redirect bei `/admin/search`

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_