### PR TITLE
Refactor incident form to use shared macros (Plan A · 2/3)

### DIFF
--- a/templates/admin/incident_form.html
+++ b/templates/admin/incident_form.html
@@ -1,175 +1,97 @@
 {% extends "admin/base_admin.html" %}
+{% import "partials/_form_macros.html" as f %}
 
 {% block admin_content %}
 <div class="mb-6 flex items-center gap-2">
-  <a href="/admin/incidents"
-     class="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-200 transition-colors">
-    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
-    </svg>
-  </a>
+  {{ f.back_link("/admin/incidents") }}
   <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ L["admin.new_incident"] }}</h1>
 </div>
 
 <form method="post" action="/admin/incidents" class="max-w-2xl space-y-6">
 
-  {# ── Abschnitt 1: Grunddaten ─────────────────────────────────────── #}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
-    <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-800">
-      <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Grunddaten</h2>
+  {% call f.form_card("Grunddaten") %}
+    <div>
+      {{ f.field_label(L["admin.title_label"]) }}
+      <input type="text" name="title" required autofocus
+             class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+             placeholder="Kurze Beschreibung der Störung…">
     </div>
-    <div class="px-5 py-4 space-y-4">
 
+    <div class="grid grid-cols-2 gap-4">
       <div>
-        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-          {{ L["admin.title_label"] }}
-        </label>
-        <input type="text" name="title" required autofocus
-               class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-               placeholder="Kurze Beschreibung der Störung…">
+        {{ f.field_label(L["admin.service_label"]) }}
+        <select name="service_name" required
+                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+          {% for svc in services %}
+          <option value="{{ svc }}">{{ svc }}</option>
+          {% endfor %}
+        </select>
       </div>
-
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-            {{ L["admin.service_label"] }}
-          </label>
-          <select name="service_name" required
-                  class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-            {% for svc in services %}
-            <option value="{{ svc }}">{{ svc }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-            {{ L["admin.classification_label"] }}
-          </label>
-          <select name="classification"
-                  class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-            <option value="incident">{{ L["incident.type.incident"] }}</option>
-            <option value="advisory">{{ L["incident.type.advisory"] }}</option>
-          </select>
-        </div>
-      </div>
-
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-            {{ L["admin.severity_label"] }}
-            <span class="font-normal text-gray-400">(optional)</span>
-          </label>
-          <select name="severity"
-                  class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-            <option value="">—</option>
-            <option value="critical">{{ L["severity.critical"] }}</option>
-            <option value="high">{{ L["severity.high"] }}</option>
-            <option value="medium">{{ L["severity.medium"] }}</option>
-            <option value="low">{{ L["severity.low"] }}</option>
-          </select>
-        </div>
-      </div>
-
-    </div>
-  </div>
-
-  {# ── Abschnitt 2: Zeitraum ───────────────────────────────────────── #}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
-    <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-800">
-      <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Zeitraum</h2>
-    </div>
-    <div class="px-5 py-4">
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <div class="flex items-center justify-between mb-1">
-            <label for="start_datetime" class="text-xs font-medium text-gray-500 dark:text-gray-400">
-              {{ L["admin.start_datetime"] }}
-            </label>
-            <button type="button" id="start-now-btn"
-                    class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors">
-              {{ L["admin.now"] }}
-            </button>
-          </div>
-          <input type="datetime-local" name="start_datetime" id="start_datetime"
-                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-        </div>
-        <div>
-          <div class="flex items-center justify-between mb-1">
-            <label for="end_datetime" class="text-xs font-medium text-gray-500 dark:text-gray-400">
-              {{ L["admin.end_datetime"] }}
-              <span class="font-normal text-gray-400">(optional)</span>
-            </label>
-            <button type="button" id="end-now-btn"
-                    class="text-xs text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors">
-              {{ L["admin.now"] }}
-            </button>
-          </div>
-          <input type="datetime-local" name="end_datetime" id="end_datetime"
-                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-        </div>
-      </div>
-    </div>
-  </div>
-
-  {# ── Abschnitt 3: Details ────────────────────────────────────────── #}
-  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
-    <div class="px-5 py-3 border-b border-gray-100 dark:border-gray-800">
-      <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">Details</h2>
-    </div>
-    <div class="px-5 py-4 space-y-4">
-
       <div>
-        <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-          {{ L["admin.description_label"] }}
-          <span class="font-normal text-gray-400">(optional)</span>
-        </label>
-        <textarea name="description" rows="3"
-                  class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-                  placeholder="Detailbeschreibung der Störung…"></textarea>
+        {{ f.field_label(L["admin.classification_label"]) }}
+        <select name="classification"
+                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <option value="incident">{{ L["incident.type.incident"] }}</option>
+          <option value="advisory">{{ L["incident.type.advisory"] }}</option>
+        </select>
       </div>
-
-      <div class="grid grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-            {{ L["admin.source_label"] }}
-          </label>
-          <input type="text" name="source" value="manual"
-                 list="source-list"
-                 autocomplete="off"
-                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
-          <datalist id="source-list">
-            {% for src in known_sources %}
-            <option value="{{ src }}">{{ source_labels.get(src, '') }}</option>
-            {% endfor %}
-            {% if 'manual' not in known_sources %}<option value="manual">{{ L["admin.source_manual"] }}</option>{% endif %}
-            {% if 'graph' not in known_sources %}<option value="graph">{{ L["admin.source_microsoft"] }}</option>{% endif %}
-          </datalist>
-        </div>
-        <div>
-          <label class="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">
-            {{ L["admin.external_id_label"] }}
-            <span class="font-normal text-gray-400">(optional)</span>
-          </label>
-          <input type="text" name="external_id"
-                 placeholder="{{ L['admin.external_id_placeholder'] }}"
-                 class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
-        </div>
-      </div>
-
     </div>
-  </div>
 
-  {# ── Submit ──────────────────────────────────────────────────────── #}
-  <div class="flex items-center gap-3">
-    <button type="submit"
-            class="px-5 py-2 rounded-lg bg-gray-900 hover:bg-gray-700 dark:bg-white dark:hover:bg-gray-100 text-white dark:text-gray-900 text-sm font-medium transition-colors">
-      {{ L["admin.create"] }}
-    </button>
-    <a href="/admin/incidents"
-       class="text-sm text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors">
-      Abbrechen
-    </a>
-  </div>
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        {{ f.field_label(L["admin.severity_label"], optional=True) }}
+        <select name="severity"
+                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+          <option value="">—</option>
+          <option value="critical">{{ L["severity.critical"] }}</option>
+          <option value="high">{{ L["severity.high"] }}</option>
+          <option value="medium">{{ L["severity.medium"] }}</option>
+          <option value="low">{{ L["severity.low"] }}</option>
+        </select>
+      </div>
+    </div>
+  {% endcall %}
+
+  {% call f.form_card("Zeitraum") %}
+    <div class="grid grid-cols-2 gap-4">
+      {{ f.datetime_now_field(L["admin.start_datetime"], "start_datetime") }}
+      {{ f.datetime_now_field(L["admin.end_datetime"], "end_datetime", optional=True) }}
+    </div>
+  {% endcall %}
+
+  {% call f.form_card("Details") %}
+    <div>
+      {{ f.field_label(L["admin.description_label"], optional=True) }}
+      <textarea name="description" rows="3"
+                class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                placeholder="Detailbeschreibung der Störung…"></textarea>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4">
+      <div>
+        {{ f.field_label(L["admin.source_label"]) }}
+        <input type="text" name="source" value="manual"
+               list="source-list"
+               autocomplete="off"
+               class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        <datalist id="source-list">
+          {% for src in known_sources %}
+          <option value="{{ src }}">{{ source_labels.get(src, '') }}</option>
+          {% endfor %}
+          {% if 'manual' not in known_sources %}<option value="manual">{{ L["admin.source_manual"] }}</option>{% endif %}
+          {% if 'graph' not in known_sources %}<option value="graph">{{ L["admin.source_microsoft"] }}</option>{% endif %}
+        </datalist>
+      </div>
+      <div>
+        {{ f.field_label(L["admin.external_id_label"], optional=True) }}
+        <input type="text" name="external_id"
+               placeholder="{{ L['admin.external_id_placeholder'] }}"
+               class="w-full rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+      </div>
+    </div>
+  {% endcall %}
+
+  {{ f.action_row(L["admin.create"], "/admin/incidents") }}
 
 </form>
 
@@ -204,21 +126,10 @@
   </div>
 </div>
 
+{{ f.now_buttons_script(prefill_target="start_datetime") }}
+
 <script>
   (function () {
-    const fmtLocal = (d) => {
-      const pad = (n) => String(n).padStart(2, "0");
-      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-    };
-    const startInput = document.getElementById("start_datetime");
-    const startBtn = document.getElementById("start-now-btn");
-    const endInput = document.getElementById("end_datetime");
-    const endBtn = document.getElementById("end-now-btn");
-    const setNow = (el) => () => { el.value = fmtLocal(new Date()); };
-    setNow(startInput)(); // pre-fill start with current time
-    startBtn.addEventListener("click", setNow(startInput));
-    endBtn.addEventListener("click", setNow(endInput));
-
     // Source label modal
     const knownSources = {{ known_sources | tojson }};
     const sourceInput = document.querySelector('[name="source"]');


### PR DESCRIPTION
## Summary

**Plan A · 2/3** — Refactor `incident_form.html` so it uses the same shared macros (`back_link`, `form_card`, `field_label`, `datetime_now_field`, `action_row`, `now_buttons_script`) introduced in PR #88.

**Kein Visual-Change** — Diff zeigt nur Markup-Deduplizierung (-158 / +69 Zeilen). Beide Formulare (Maintenance + Incident) lesen jetzt aus genau denselben Bausteinen → spätere Style-Änderungen passieren an einer Stelle.

Die Source-Label-Modal-Logik (Datalist + AJAX-Label-Anlage) bleibt inline in diesem Template, weil sie incident-form-spezifisch ist und kein Wartungs-Pendant hat.

## Test plan

- [ ] `/admin/incidents/new` öffnet exakt wie vorher — 3 Karten, Severity-Feld, Source-Datalist, "Jetzt"-Buttons bei beiden Datumsfeldern, Start vorbefüllt
- [ ] Neue Quelle eintragen → Modal öffnet wie vorher
- [ ] Form absenden legt Incident korrekt an
- [ ] Dark Mode passt

## Nächstes

**Plan A · 3/3**: `incident_detail.html` Edit-View auf das gleiche Karten-Layout heben und auf die Macros umstellen.

https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq

---
_Generated by [Claude Code](https://claude.ai/code/session_015fshLN8FPYxVfBWnEj1Pqq)_