### PR TITLE
Fix graph_client to read Azure credentials from DB

### DIFF
--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -5,28 +5,34 @@ from datetime import datetime, timedelta
 import httpx
 import msal
 
-from app.config import settings
-
 logger = logging.getLogger(__name__)
 
 GRAPH_BASE = "https://graph.microsoft.com/v1.0"
 
 _msal_app: msal.ConfidentialClientApplication | None = None
+_msal_credentials: tuple[str, str, str] | None = None
 
 
-def _get_msal_app() -> msal.ConfidentialClientApplication:
-    global _msal_app
-    if _msal_app is None:
+def _get_msal_app(tenant_id: str, client_id: str, client_secret: str) -> msal.ConfidentialClientApplication:
+    global _msal_app, _msal_credentials
+    creds = (tenant_id, client_id, client_secret)
+    if _msal_app is None or _msal_credentials != creds:
         _msal_app = msal.ConfidentialClientApplication(
-            client_id=settings.AZURE_CLIENT_ID,
-            client_credential=settings.AZURE_CLIENT_SECRET,
-            authority=f"https://login.microsoftonline.com/{settings.AZURE_TENANT_ID}",
+            client_id=client_id,
+            client_credential=client_secret,
+            authority=f"https://login.microsoftonline.com/{tenant_id}",
         )
+        _msal_credentials = creds
     return _msal_app
 
 
 async def _get_access_token() -> str:
-    app = _get_msal_app()
+    from app.app_settings import get_azure_settings  # noqa: PLC0415
+    from app.database import AsyncSessionLocal  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as db:
+        azure_cfg = await get_azure_settings(db)
+    app = _get_msal_app(azure_cfg.tenant_id, azure_cfg.client_id, azure_cfg.client_secret)
     # MSAL token acquisition is synchronous; run in thread to avoid blocking event loop
     result = await asyncio.to_thread(
         app.acquire_token_for_client,


### PR DESCRIPTION
## Summary

- `graph_client.py` always read `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_CLIENT_SECRET` directly from env vars, ignoring any values saved via the Admin UI (`/admin/settings → Azure`)
- This caused token acquisition to fail with a `ValueError` about an invalid authority when the `.env` still contained placeholder values
- `_get_access_token()` now calls `get_azure_settings()` to resolve effective credentials (DB wins over env), consistent with how the rest of the app handles this layering
- The MSAL client is rebuilt automatically whenever credentials change (fingerprint comparison)

## Test plan

- [ ] Enter Azure credentials in Admin UI (`/admin/settings`, Azure-Abschnitt), leave `.env` with placeholder values
- [ ] Restart app — Graph API poll should succeed (check logs for `Health overviews committed`)
- [ ] Change credentials in UI → next poll uses new credentials without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)