### PR TITLE
feat(config): SECRET_KEY beim ersten Start automatisch generieren

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,11 @@ AZURE_CLIENT_ID=your-app-client-id-here
 AZURE_CLIENT_SECRET=your-client-secret-here
 AZURE_REDIRECT_URI=https://statuspage.example.com/auth/callback
 
-# Sicherheit – zufälligen 32-Byte-Hex-String generieren:
-# python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=change-me-to-a-32-byte-random-hex-string
+# Sicherheit – Session-Schlüssel.
+# Leer lassen: Beim ersten Start wird automatisch ein 32-Byte-Hex-String
+# generiert und unter data/secret_key persistiert (überlebt Neustarts).
+# Eigenen Wert setzen mit:  python -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=
 
 # Einbettungs-Widget API-Key (leer lassen = OIDC erforderlich für /embed)
 EMBED_API_KEY=

--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ AZURE_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 AZURE_CLIENT_SECRET=dein-client-secret
 AZURE_REDIRECT_URI=https://statuspage.example.com/auth/callback
 
-# Zufälligen Schlüssel erzeugen:
+# Leer lassen: wird beim ersten Start automatisch generiert und unter
+# data/secret_key persistiert. Eigenen Wert (optional) erzeugen mit:
 # python -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=...
+SECRET_KEY=
 
 EMBED_API_KEY=ein-langer-zufaelliger-string  # leer lassen = OIDC erforderlich
 MONITORED_SERVICES=Exchange Online,SharePoint Online,Microsoft Teams
@@ -97,7 +98,7 @@ Beim ersten Aufruf wird man zu Entra ID weitergeleitet.
 | `AZURE_CLIENT_ID` | Anwendungs-ID | — |
 | `AZURE_CLIENT_SECRET` | Clientgeheimnis | — |
 | `AZURE_REDIRECT_URI` | OAuth-Callback-URL | `http://localhost:8000/auth/callback` |
-| `SECRET_KEY` | Session-Signaturschlüssel (≥32 Byte Hex) | — |
+| `SECRET_KEY` | Session-Signaturschlüssel (≥32 Byte Hex). Leer = Auto-Generierung beim ersten Start, persistiert in `data/secret_key` | *(auto)* |
 | `EMBED_API_KEY` | Token für Widget-Zugriff ohne Login | *(leer)* |
 | `DATABASE_URL` | SQLAlchemy Async URL | `sqlite+aiosqlite:///./data/statuspage.db` |
 | `MONITORED_SERVICES` | Kommagetrennte Dienstnamen (Graph API exakt) | Exchange Online, SharePoint Online, Microsoft Teams |

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,16 @@
-from pydantic import computed_field
+import logging
+import secrets
+from pathlib import Path
+
+from pydantic import computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Sentinel value from .env.example – treated as "not configured"
+_SECRET_KEY_PLACEHOLDER = "change-me-to-a-32-byte-random-hex-string"
+# Persisted location for the auto-generated key (same writable dir as the DB)
+_SECRET_KEY_FILE = Path("data") / "secret_key"
 
 
 class Settings(BaseSettings):
@@ -11,8 +22,9 @@ class Settings(BaseSettings):
     AZURE_CLIENT_SECRET: str = "your-client-secret"
     AZURE_REDIRECT_URI: str = "http://localhost:8000/auth/callback"
 
-    # Session security
-    SECRET_KEY: str = "change-me-to-a-32-byte-random-hex-string"
+    # Session security – empty/placeholder triggers auto-generation on first run
+    # (persisted to data/secret_key so sessions survive restarts).
+    SECRET_KEY: str = ""
     SESSION_MAX_AGE: int = 3600
 
     # Embed widget API key (empty = OIDC required for /embed)
@@ -51,6 +63,43 @@ class Settings(BaseSettings):
     # Build metadata (injected by Docker build args; empty in local dev)
     BUILD_SHA: str = ""
     BUILD_TIME: str = ""
+
+    @model_validator(mode="after")
+    def _ensure_secret_key(self) -> "Settings":
+        if self.SECRET_KEY and self.SECRET_KEY != _SECRET_KEY_PLACEHOLDER:
+            return self
+
+        try:
+            _SECRET_KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+            if _SECRET_KEY_FILE.is_file():
+                stored = _SECRET_KEY_FILE.read_text(encoding="utf-8").strip()
+                if stored:
+                    self.SECRET_KEY = stored
+                    return self
+            generated = secrets.token_hex(32)
+            _SECRET_KEY_FILE.write_text(generated, encoding="utf-8")
+            try:
+                _SECRET_KEY_FILE.chmod(0o600)
+            except OSError:
+                pass
+            self.SECRET_KEY = generated
+            logger.warning(
+                "SECRET_KEY was not configured – generated a new one and "
+                "persisted it to %s. Set SECRET_KEY in your environment to "
+                "override.",
+                _SECRET_KEY_FILE,
+            )
+        except OSError:
+            # Read-only filesystem etc. – fall back to an ephemeral key so the
+            # app still boots, but warn that sessions won't survive a restart.
+            self.SECRET_KEY = secrets.token_hex(32)
+            logger.warning(
+                "SECRET_KEY was not configured and %s is not writable – "
+                "using an ephemeral key. Sessions will be invalidated on "
+                "every restart.",
+                _SECRET_KEY_FILE,
+            )
+        return self
 
     @property
     def teams_webhook_list(self) -> list[str]:


### PR DESCRIPTION
## Summary

- `SECRET_KEY` muss nicht mehr manuell gesetzt werden. Ist die Variable leer oder steht noch der `.env.example`-Platzhalter (`change-me-to-a-32-byte-random-hex-string`), erzeugt `app/config.py` beim Start einen frischen 32-Byte-Hex-Schlüssel via `secrets.token_hex(32)`.
- Der generierte Schlüssel wird unter `data/secret_key` (gleiches Verzeichnis wie die SQLite-DB) mit `chmod 600` persistiert, damit Sessions Container-Neustarts überleben.
- Ist das Datenverzeichnis nicht beschreibbar, wird ein ephemerer Schlüssel verwendet und eine Warnung geloggt – die App bootet trotzdem.
- Ein in der Umgebung explizit gesetztes `SECRET_KEY` hat weiterhin Vorrang (nichts wird überschrieben).
- `.env.example` und README aktualisiert: `SECRET_KEY=` ist jetzt optional, mit Hinweis auf die Auto-Generierung.

## Test plan

- [x] Frischer Run ohne `SECRET_KEY` → 64-Zeichen-Key generiert, in `data/secret_key` geschrieben
- [x] Zweiter Run lädt denselben Key aus der Datei (Sessions bleiben gültig)
- [x] Explizit gesetzte env-Variable überschreibt Auto-Generierung
- [x] Alter Platzhalterwert aus `.env.example` triggert Regenerierung
- [ ] Manuell prüfen, dass Docker-Compose-Setup beim ersten Start sauber hochfährt


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK)_