### PR TITLE
feat(i18n): Mehrsprachige UI (DE/EN) mit Browser-Erkennung beim ersten Besuch

### DIFF
--- a/app/app_settings.py
+++ b/app/app_settings.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings as env_settings
+from app.i18n import LABELS_BY_LANG
 from app.models import AppSetting
 
 logger = logging.getLogger(__name__)
@@ -284,3 +285,21 @@ async def verify_smtp_connection(
     except Exception as exc:  # noqa: BLE001
         logger.warning("SMTP verify exception: %s", exc)
         return False, f"Unerwarteter Fehler: {exc}"
+
+
+# ── UI language ───────────────────────────────────────────────────────────────
+
+_LANG_SETTING_KEY = "ui.default_language"
+
+
+async def get_app_default_language(db: AsyncSession) -> str | None:
+    """Admin-configured default language, or None if unset."""
+    rows = await get_all_settings(db)
+    value = rows.get(_LANG_SETTING_KEY)
+    return value if value in LABELS_BY_LANG else None
+
+
+async def save_app_default_language(db: AsyncSession, lang: str) -> None:
+    if lang not in LABELS_BY_LANG:
+        raise ValueError(f"unsupported language: {lang!r}")
+    await set_setting(db, _LANG_SETTING_KEY, lang)

--- a/app/config.py
+++ b/app/config.py
@@ -46,6 +46,10 @@ class Settings(BaseSettings):
     # Dev: bypass Entra ID OIDC – alle Routen ohne Login zugänglich
     DISABLE_AUTH: bool = False
 
+    # UI language fallback when the visitor has no cookie, no Accept-Language
+    # header and no admin-configured default. Supported: "de", "en".
+    DEFAULT_LANGUAGE: str = "de"
+
     # Notifications – Email (SMTP)
     SMTP_HOST: str = ""
     SMTP_PORT: int = 587

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,4 +1,32 @@
-LABELS: dict[str, str] = {
+"""Internationalisation: per-language label dictionaries plus a request-scoped
+language resolver.
+
+The current language is held in a ContextVar that is set once per HTTP request
+by the language middleware (see ``app.main``). Templates access labels via the
+``L`` proxy registered as a Jinja global; Python code can call
+``get_label("key")`` directly or read ``LABELS["key"]`` from the same proxy.
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+import os
+from collections.abc import Iterator, Mapping
+
+logger = logging.getLogger(__name__)
+
+# ── Supported languages ─────────────────────────────────────────────────────
+DEFAULT_LANGUAGE = "de"
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("de", "en")
+
+# Human-readable native names used in the UI selector.
+LANGUAGE_NAMES: dict[str, str] = {
+    "de": "Deutsch",
+    "en": "English",
+}
+
+
+LABELS_DE: dict[str, str] = {
     # Status
     "status.operational":         "In Betrieb",
     "status.degraded":            "Eingeschränkt",
@@ -97,11 +125,7 @@ LABELS: dict[str, str] = {
     "severity.high":              "Hoch",
     "severity.medium":            "Mittel",
     "severity.low":               "Niedrig",
-    # State change timeline entries  (Incident-Phasen)
-    # active        → Investigating  – Problem bekannt, Ursache wird gesucht
-    # acknowledged  → Identified     – Ursache gefunden, Behebung startet
-    # monitoring    → Monitoring     – Fix eingespielt, System wird beobachtet
-    # resolved      → Resolved       – Störung offiziell vorbei
+    # Incident state phases
     "state.active":               "Untersuchung läuft",
     "state.acknowledged":         "Identifiziert",
     "state.monitoring":           "Überwachung",
@@ -267,4 +291,477 @@ LABELS: dict[str, str] = {
     "admin.search.group.subscribers":  "Subscriber",
     "admin.search.no_results":         "Keine Treffer.",
     "admin.search.hint":               "Cmd+K oder Strg+K zum Öffnen",
+    # Language selector
+    "settings.title":                 "Einstellungen",
+    "settings.language_heading":      "Sprache",
+    "settings.language_hint":         "Standardsprache der Oberfläche für neue Besucher. Einzelne Besucher können die Sprache jederzeit per Umschalter ändern.",
+    "settings.language_save":         "Speichern",
+    "settings.language_label":        "Standardsprache",
+    "toast.language_saved":           "Sprache gespeichert.",
+    "ui.switch_language":             "Sprache wechseln",
+    "ui.close":                       "Schließen",
+    "ui.back_to_overview":            "Zurück zur Übersicht",
+    "ui.app_install":                 "App installieren",
+    "ui.app_install_short":           "Installieren",
+    "ui.theme_toggle":                "Farbschema wechseln",
+    "ui.no_title":                    "(ohne Titel)",
+    "ui.related_entries":             "Zugehörige Einträge",
+    "ui.no_details_available":        "Keine weiteren Details verfügbar.",
+    "ui.click_for_details":           "Klicken für Details",
+    "ui.more_click_for_details":      "+{count} weitere – klicken für Details",
+    "ui.day.operational_body":        "Keine Vorfälle an diesem Tag — Dienst lief normal.",
+    "ui.day.degraded_body":           "Eingeschränkte Verfügbarkeit an diesem Tag.",
+    "ui.day.interrupted_body":        "Dienstunterbrechung an diesem Tag.",
+    "ui.day.no_data_body":            "Keine Datenpunkte für diesen Tag verfügbar.",
+    "ui.day.unknown_body":            "Status unbekannt.",
+    # Duration suffixes (used by duration filter)
+    "duration.sec":                   "Sek",
+    "duration.min":                   "Min",
+    "duration.hr":                    "Std",
+    "duration.day_one":               "1 Tag",
+    "duration.day_many":              "{n} Tage",
+    "duration.week_one":              "1 Woche",
+    "duration.week_many":             "{n} Wochen",
+    "duration.month_one":             "1 Monat",
+    "duration.month_many":            "{n} Monate",
+    "datetime.today":                 "heute",
 }
+
+
+LABELS_EN: dict[str, str] = {
+    # Status
+    "status.operational":         "Operational",
+    "status.degraded":            "Degraded",
+    "status.interrupted":         "Outage",
+    "status.unknown":             "Unknown",
+    "status.no_data":             "No data",
+    # Page
+    "page.title":                 "M365 Service Status",
+    "page.all_good":              "All services operational",
+    "page.some_degraded":         "Performance issues",
+    "page.incidents_active":      "Active incidents",
+    "page.uptime_heading":        "Uptime – last 90 days",
+    "page.range.label":           "Range:",
+    "page.range.24h":             "24h",
+    "page.range.7d":              "7 days",
+    "page.range.30d":             "30 days",
+    "page.range.90d":             "90 days",
+    "page.incidents_heading":     "Active incidents & advisories",
+    "page.incidents_heading_active": "Active incidents",
+    "page.advisories_heading":    "Current advisories",
+    "page.advisories_none":       "none",
+    "page.last_updated":          "Last updated",
+    "page.logout":                "Sign out",
+    "page.darkmode":              "Dark",
+    "page.lightmode":             "Light",
+    "page.no_incidents":          "No active incidents reported.",
+    # Incidents
+    "incident.type.incident":     "Incident",
+    "incident.type.advisory":     "Advisory",
+    "incident.affects":           "Affects",
+    "incident.since":             "Since",
+    "incident.until":             "until",
+    "incident.updates":           "Updates",
+    "incident.resolved":          "Resolved",
+    # Embed
+    "embed.active_incidents":     "Active incidents detected",
+    "embed.details":              "Show details",
+    "embed.updated":              "Updated",
+    "embed.all_good":             "All services operational",
+    # Page – Maintenance
+    "page.maintenance_heading":   "Scheduled maintenance",
+    "page.no_maintenances":       "No scheduled maintenance.",
+    # Admin
+    "admin.title":                "Admin",
+    "admin.dashboard":            "Dashboard",
+    "admin.incidents":            "Incidents & advisories",
+    "admin.incidents_only":       "Active incidents",
+    "admin.show_all_incidents":   "Show all incidents",
+    "admin.incidents_all_title":  "All incidents",
+    "admin.incidents_all_sub":    "Active, resolved and ignored entries",
+    "admin.back_to_dashboard":    "Back to dashboard",
+    "admin.filter_state":         "Status:",
+    "admin.filter_all":           "All",
+    "admin.filter_active":        "Active",
+    "admin.filter_resolved":      "Resolved",
+    "admin.filter_empty":         "No entries match this filter.",
+    "admin.advisories":           "Advisories",
+    "admin.services_count_suffix": "services",
+    "empty.admin.advisories":     "No active advisories.",
+    # Admin – Sidebar navigation
+    "admin.nav.dashboard":        "Dashboard",
+    "admin.nav.incidents":        "Incidents",
+    "admin.nav.maintenances":     "Maintenance",
+    "admin.nav.settings":         "Settings",
+    "admin.nav.debug":            "Debug",
+    "admin.nav.public_page":      "Public status page",
+    "admin.nav.toggle":           "Open navigation",
+    "admin.nav.close":            "Close navigation",
+    "admin.nav.own_incidents":    "My incidents",
+    "admin.nav.new_incident":     "New incident",
+    "admin.nav.general_section":    "General",
+    "admin.nav.services_mgmt":      "Service management",
+    "admin.nav.meldungen_section":  "Incidents",
+    "admin.nav.system_section":     "System",
+    "admin.new_incident":         "New incident / advisory",
+    "admin.new_maintenance":      "New maintenance",
+    "admin.maintenances":         "Scheduled maintenance",
+    "admin.create":               "Create",
+    "admin.save":                 "Save",
+    "admin.resolve":              "Mark as resolved",
+    "admin.reopen":               "Reopen",
+    "admin.add_update":           "Add update",
+    "admin.post_placeholder":     "Enter status update…",
+    "admin.service_status":       "Service status",
+    "admin.set_status":           "Set status",
+    "admin.title_label":          "Title",
+    "admin.description_label":    "Description",
+    "admin.severity_label":       "Severity",
+    "admin.start_datetime":       "Start",
+    "admin.now":                  "Now",
+    "admin.notify_subscribers":   "Notify subscribers",
+    "admin.delete":               "Delete",
+    "admin.delete_confirm":       "Really delete this entry?",
+    # Severity levels
+    "severity.critical":          "Critical",
+    "severity.high":              "High",
+    "severity.medium":            "Medium",
+    "severity.low":               "Low",
+    # Incident state phases
+    "state.active":               "Investigating",
+    "state.acknowledged":         "Identified",
+    "state.monitoring":           "Monitoring",
+    "state.resolved":             "Resolved",
+    "state.scheduled":            "Scheduled",
+    "state.in_progress":          "In progress",
+    "state.completed":            "Completed",
+    "admin.service_label":        "Service",
+    "admin.classification_label": "Type",
+    "admin.status_label":         "Status",
+    "admin.end_datetime":         "End (actual)",
+    "admin.scheduled_start":      "Start (scheduled)",
+    "admin.scheduled_end":        "End (scheduled)",
+    "admin.back":                 "Back",
+    "admin.no_incidents":         "No active entries.",
+    "admin.suppress":             "Ignore",
+    "admin.unsuppress":           "Restore",
+    "admin.acknowledge":          "Take ownership",
+    "admin.release":              "Release",
+    "admin.owner":                "Owner",
+    "admin.acknowledged_at":      "Acknowledged at",
+    "toast.acknowledged":         "Taken over",
+    "toast.released":             "Released",
+    "admin.suppressed_heading":   "Ignored entries",
+    "admin.no_suppressed":        "No ignored entries.",
+    "admin.no_maintenances":      "No scheduled maintenance.",
+    # Maintenance status
+    "maintenance.scheduled":      "Scheduled",
+    "maintenance.in_progress":    "In progress",
+    "maintenance.completed":      "Completed",
+    # Incident type
+    "incident.type.maintenance":  "Maintenance",
+    # Incident history (public page)
+    "page.history_heading":       "Recently resolved",
+    "page.history_subheading":    "Last 30 days",
+    "page.history_empty":         "No incidents resolved in the last 30 days.",
+    "page.history_filter":        "Filter:",
+    "page.history_filter_all":    "All",
+    "page.history_filter_empty":  "No entries for this service.",
+    "page.history_show":          "Show incident history",
+    "incident.resolved_at":       "Resolved at",
+    # Service management
+    "admin.service_management":   "Service management",
+    "admin.discover_services":    "Load from Microsoft",
+    "admin.service_enable":       "Enable",
+    "admin.service_disable":      "Disable",
+    "admin.no_known_services":    "No services known yet.",
+    "empty.admin.services":       "No services known yet. Click \"Load from Microsoft\" to import all M365 services.",
+    "empty.admin.services_cta":   "Load from Microsoft",
+    "empty.admin.incidents":      "No active incidents.",
+    "empty.admin.incidents_sub":  "The system is running normally.",
+    "empty.admin.suppressed":     "No ignored entries.",
+    "empty.admin.maintenances":   "No scheduled maintenance.",
+    "empty.admin.maintenances_sub": "Nothing scheduled at the moment.",
+    "empty.public.all_good":      "No active incidents.",
+    "empty.public.all_good_sub":  "All services running normally.",
+    "empty.public.history":       "No incidents resolved in the last 30 days.",
+    "toast.dismiss":              "Dismiss notification",
+    "toast.group_saved":          "Group saved.",
+    "admin.service_backfill_hint": "Loading 90-day history in the background…",
+    "admin.uptime_shown":         "Uptime visible",
+    "admin.uptime_hidden":        "Uptime hidden",
+    "admin.uptime_toggle_hint":   "Show/hide total 90-day uptime on the status page",
+    "page.uptime_90d":            "Overall uptime (90 days)",
+    "page.uptime_suffix":         "available",
+    # Service groups
+    "admin.service_group":            "Group",
+    "admin.service_group_placeholder": "e.g. Microsoft 365",
+    "admin.service_group_save":       "Apply",
+    "admin.service_group_hint":       "Empty = no group (shown under \"Other\")",
+    "page.group_other":               "Other",
+    "page.group_count":               "{count} services",
+    "page.group_count_one":           "1 service",
+    # Subscriber
+    # Top tab nav
+    "page.tab_overview":              "Overview",
+    "page.tab_incidents":             "Incidents",
+    "page.tab_advisories":            "Advisories",
+    "page.tab_maintenances":          "Maintenance",
+    "page.tab_history":               "History",
+    "subscribe.tab":                  "Subscribe",
+    "subscribe.modal_title":          "Subscribe to notifications",
+    "subscribe.modal_sub":            "Get notified by email when an incident occurs or an update is posted.",
+    "subscribe.cancel":               "Cancel",
+    "subscribe.label":                "Notifications",
+    "subscribe.email_placeholder":    "Enter email address",
+    "subscribe.submit":               "Subscribe",
+    "subscribe.hint":                 "You will receive a confirmation email.",
+    "subscribe.pending_title":        "Almost done!",
+    "subscribe.pending_body":         "Please confirm your email address via the link in the confirmation email.",
+    "subscribe.confirmed_title":      "Subscription confirmed",
+    "subscribe.confirmed_body":       "You will now receive notifications about new incidents.",
+    "subscribe.unsubscribed_title":   "Unsubscribed",
+    "subscribe.unsubscribed_body":    "You will not receive any further notifications.",
+    "subscribe.error_title":          "Error",
+    "subscribe.error_body":           "Your link is invalid or has already expired.",
+    "subscribe.back_to_status":       "Back to status page",
+    # Admin – subscriber management
+    "admin.nav.subscribers":          "Subscribers",
+    "admin.subscribers_heading":      "Email subscribers",
+    "admin.subscribers_hint":         "Confirmed subscribers receive notifications when \"Notify subscribers\" is active.",
+    "admin.subscriber_email":         "Email",
+    "admin.subscriber_confirmed":     "Confirmed at",
+    "admin.subscriber_delete":        "Remove",
+    "admin.subscriber_pending":       "Pending",
+    "admin.teams_heading":            "MS Teams webhook",
+    "admin.teams_hint":               "Incoming webhook URLs (comma-separated). Empty = disabled.",
+    "admin.teams_save":               "Save",
+    "toast.subscriber_deleted":       "Subscriber removed.",
+    "toast.service_moved":            "Order updated.",
+    "admin.move_up":                  "Move up",
+    "admin.move_down":                "Move down",
+    "toast.email_saved":              "Email settings saved.",
+    # Email settings
+    "admin.email_heading":            "Email delivery",
+    "admin.email_hint":               "Method used to send confirmation and notification emails.",
+    "admin.email_method":             "Delivery method",
+    "admin.email_method_none":        "Disabled",
+    "admin.email_method_password":    "SMTP (user/password)",
+    "admin.email_method_oauth2":      "Microsoft Graph (OAuth2)",
+    "admin.email_smtp_host":          "SMTP host",
+    "admin.email_smtp_port":          "Port",
+    "admin.email_smtp_user":          "Username",
+    "admin.email_smtp_pass":          "Password",
+    "admin.email_smtp_pass_hint":     "Empty = keep existing password",
+    "admin.email_smtp_from":          "Sender address (From)",
+    "admin.email_smtp_tls":           "Use STARTTLS",
+    "admin.email_graph_from":         "Mailbox (From address in tenant)",
+    "admin.email_graph_hint":         "Reuses the Azure AD app. Requires Mail.Send application permission + admin consent.",
+    "admin.email_save":               "Save",
+    "admin.email_test_heading":       "Test delivery",
+    "admin.email_test_to":            "Recipient",
+    "admin.email_test_send":          "Send test email",
+    "admin.email_status_configured":  "Configured",
+    "admin.email_status_pending":     "Incomplete",
+    "admin.email_status_disabled":    "Disabled",
+    # Notification send
+    "notify.new_incident":            "New incident",
+    "notify.update":                  "Status update",
+    # Source / reference on incidents
+    "admin.source_label":            "Source",
+    "admin.source_microsoft":        "Microsoft (Graph)",
+    "admin.source_manual":           "Manual",
+    "admin.source_other":            "Other",
+    "admin.external_id_label":       "Reference / ID",
+    "admin.external_id_placeholder": "e.g. MO1310977",
+    # Azure AD settings
+    "admin.azure_heading":            "Azure AD app",
+    "admin.azure_hint":               "Credentials of the Azure AD app for Microsoft Graph API and email delivery.",
+    "admin.azure_tenant_label":       "Tenant ID",
+    "admin.azure_client_label":       "Client ID (app ID)",
+    "admin.azure_secret_label":       "Client secret",
+    "admin.azure_secret_hint":        "Empty = keep existing secret",
+    "admin.azure_save":               "Save & test connection",
+    "admin.azure_status_configured":  "Connected",
+    "admin.azure_status_pending":     "Incomplete",
+    "toast.azure_saved":              "Azure AD app saved.",
+    # Admin – global search palette (Cmd+K / Ctrl+K)
+    "admin.search.placeholder":        "Search…",
+    "admin.search.group.incidents":    "Incidents",
+    "admin.search.group.updates":      "Updates",
+    "admin.search.group.services":     "Services",
+    "admin.search.group.subscribers":  "Subscribers",
+    "admin.search.no_results":         "No matches.",
+    "admin.search.hint":               "Cmd+K or Ctrl+K to open",
+    # Language selector
+    "settings.title":                 "Settings",
+    "settings.language_heading":      "Language",
+    "settings.language_hint":         "Default UI language for new visitors. Individual visitors can switch languages at any time via the toggle.",
+    "settings.language_save":         "Save",
+    "settings.language_label":        "Default language",
+    "toast.language_saved":           "Language saved.",
+    "ui.switch_language":             "Switch language",
+    "ui.close":                       "Close",
+    "ui.back_to_overview":            "Back to overview",
+    "ui.app_install":                 "Install app",
+    "ui.app_install_short":           "Install",
+    "ui.theme_toggle":                "Toggle colour scheme",
+    "ui.no_title":                    "(untitled)",
+    "ui.related_entries":             "Related entries",
+    "ui.no_details_available":        "No further details available.",
+    "ui.click_for_details":           "Click for details",
+    "ui.more_click_for_details":      "+{count} more – click for details",
+    "ui.day.operational_body":        "No incidents on this day — service ran normally.",
+    "ui.day.degraded_body":           "Reduced availability on this day.",
+    "ui.day.interrupted_body":        "Service outage on this day.",
+    "ui.day.no_data_body":            "No data points available for this day.",
+    "ui.day.unknown_body":            "Status unknown.",
+    # Duration suffixes (used by duration filter)
+    "duration.sec":                   "sec",
+    "duration.min":                   "min",
+    "duration.hr":                    "h",
+    "duration.day_one":               "1 day",
+    "duration.day_many":              "{n} days",
+    "duration.week_one":              "1 week",
+    "duration.week_many":             "{n} weeks",
+    "duration.month_one":             "1 month",
+    "duration.month_many":            "{n} months",
+    "datetime.today":                 "today",
+}
+
+
+LABELS_BY_LANG: dict[str, dict[str, str]] = {
+    "de": LABELS_DE,
+    "en": LABELS_EN,
+}
+
+
+# ── Per-request current language ────────────────────────────────────────────
+_current_lang: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "current_lang", default=DEFAULT_LANGUAGE
+)
+
+
+def set_current_language(lang: str) -> contextvars.Token:
+    """Set the language for the current request/context. Returns a token usable
+    with ``reset_current_language()``."""
+    if lang not in LABELS_BY_LANG:
+        lang = DEFAULT_LANGUAGE
+    return _current_lang.set(lang)
+
+
+def reset_current_language(token: contextvars.Token) -> None:
+    try:
+        _current_lang.reset(token)
+    except (ValueError, LookupError):
+        pass
+
+
+def get_current_language() -> str:
+    return _current_lang.get()
+
+
+def get_label(key: str) -> str:
+    lang = _current_lang.get()
+    return (
+        LABELS_BY_LANG.get(lang, {}).get(key)
+        or LABELS_DE.get(key)
+        or key
+    )
+
+
+class _LabelProxy(Mapping[str, str]):
+    """Dict-like view that resolves keys against the language active for the
+    current request (set by the language middleware)."""
+
+    def __getitem__(self, key: str) -> str:
+        return get_label(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(LABELS_DE)
+
+    def __len__(self) -> int:
+        return len(LABELS_DE)
+
+    def __contains__(self, key: object) -> bool:
+        return key in LABELS_DE
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        if key in LABELS_DE or key in LABELS_EN:
+            return get_label(key)
+        return default
+
+
+LABELS: _LabelProxy = _LabelProxy()
+
+
+# ── Language negotiation ────────────────────────────────────────────────────
+def parse_accept_language(header: str | None) -> list[str]:
+    """Return supported language codes parsed from an Accept-Language header,
+    ordered by descending q-value. Unsupported languages are dropped."""
+    if not header:
+        return []
+    candidates: list[tuple[float, str]] = []
+    for chunk in header.split(","):
+        parts = chunk.strip().split(";")
+        lang = parts[0].strip().lower()
+        if not lang:
+            continue
+        q = 1.0
+        for p in parts[1:]:
+            p = p.strip()
+            if p.startswith("q="):
+                try:
+                    q = float(p[2:])
+                except ValueError:
+                    q = 0.0
+        primary = lang.split("-")[0]
+        if primary in LABELS_BY_LANG:
+            candidates.append((q, primary))
+    candidates.sort(key=lambda x: -x[0])
+    seen: set[str] = set()
+    out: list[str] = []
+    for _, lang in candidates:
+        if lang not in seen:
+            seen.add(lang)
+            out.append(lang)
+    return out
+
+
+def language_from_os_locale() -> str | None:
+    """Best-effort: derive a supported language from the server's LANG/LC_* env."""
+    for var in ("LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE"):
+        raw = os.environ.get(var, "").strip()
+        if not raw:
+            continue
+        primary = raw.split(".")[0].split("_")[0].lower()
+        if primary in LABELS_BY_LANG:
+            return primary
+    return None
+
+
+def resolve_language(
+    *,
+    cookie: str | None = None,
+    accept_language: str | None = None,
+    app_default: str | None = None,
+) -> str:
+    """Pick the best language for the current visitor.
+
+    Precedence: explicit cookie → Accept-Language header → app-wide default
+    (admin setting) → server OS locale → ``DEFAULT_LANGUAGE``.
+    """
+    if cookie and cookie in LABELS_BY_LANG:
+        return cookie
+
+    for candidate in parse_accept_language(accept_language):
+        return candidate
+
+    if app_default and app_default in LABELS_BY_LANG:
+        return app_default
+
+    from_os = language_from_os_locale()
+    if from_os:
+        return from_os
+
+    return DEFAULT_LANGUAGE

--- a/app/main.py
+++ b/app/main.py
@@ -8,10 +8,19 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from app.auth import LoginRequired
 from app.config import settings
-from app.database import init_db
+from app.database import AsyncSessionLocal, init_db
+from app.i18n import (
+    LABELS_BY_LANG,
+    reset_current_language,
+    resolve_language,
+    set_current_language,
+)
 from app.routers import admin, api, auth_router, embed, status
 from app.routers.subscribers import router as subscribers_router
 from app.scheduler import start_scheduler, stop_scheduler
+
+LANG_COOKIE = "lang"
+LANG_COOKIE_MAX_AGE = 60 * 60 * 24 * 365  # 1 year
 
 logging.basicConfig(
     level=logging.DEBUG if settings.DEBUG else logging.INFO,
@@ -41,6 +50,60 @@ app.add_middleware(
     https_only=not settings.DEBUG,
     same_site="lax",
 )
+
+@app.middleware("http")
+async def language_middleware(request: Request, call_next):
+    """Resolve the visitor's UI language once per request.
+
+    Cookie wins. If no cookie, fall back to the Accept-Language header (the
+    visitor's browser/OS preference), then to the admin-configured default,
+    then to the server's locale, then to DEFAULT_LANGUAGE.
+    """
+    cookie = request.cookies.get(LANG_COOKIE)
+    app_default: str | None = None
+    if not cookie:
+        try:
+            from app.app_settings import (  # noqa: PLC0415
+                get_app_default_language,
+            )
+            async with AsyncSessionLocal() as db:
+                app_default = await get_app_default_language(db)
+        except Exception:  # noqa: BLE001
+            app_default = None
+    lang = resolve_language(
+        cookie=cookie,
+        accept_language=request.headers.get("accept-language"),
+        app_default=app_default or settings.DEFAULT_LANGUAGE,
+    )
+    token = set_current_language(lang)
+    request.state.lang = lang
+    try:
+        response = await call_next(request)
+    finally:
+        reset_current_language(token)
+    return response
+
+
+@app.get("/lang/{code}", include_in_schema=False)
+async def set_language(request: Request, code: str):
+    """Persist the visitor's language choice and redirect back."""
+    if code not in LABELS_BY_LANG:
+        return RedirectResponse(url="/", status_code=303)
+    next_url = request.query_params.get("next") or request.headers.get("referer") or "/"
+    if not next_url.startswith("/"):
+        # Don't allow off-site redirects via the ?next= param.
+        next_url = "/"
+    response = RedirectResponse(url=next_url, status_code=303)
+    response.set_cookie(
+        LANG_COOKIE,
+        code,
+        max_age=LANG_COOKIE_MAX_AGE,
+        httponly=False,
+        samesite="lax",
+        secure=not settings.DEBUG,
+    )
+    return response
+
 
 app.mount("/static", StaticFiles(directory="static"), name="static")
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -9,8 +9,10 @@ from sqlalchemy import select as sa_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.app_settings import (
+    get_app_default_language,
     get_azure_settings,
     get_email_settings,
+    save_app_default_language,
     save_azure_settings,
     save_email_settings,
     verify_azure_connection,
@@ -56,7 +58,7 @@ from app.graph_client import (
     fetch_issues_since,
     fetch_recently_resolved_issues,
 )
-from app.i18n import LABELS
+from app.i18n import LABELS, LABELS_BY_LANG
 from app.models import MonitoredService
 from app.notifications import send_incident_notification, send_teams_notification, send_test_email
 from app.templates import templates
@@ -194,13 +196,14 @@ async def admin_settings(
     user: dict = Depends(require_auth),
     nav: dict = Depends(admin_nav_context),
 ):
-    all_services, known_groups, subscribers, email_cfg, azure_cfg, source_labels = await asyncio.gather(
+    all_services, known_groups, subscribers, email_cfg, azure_cfg, source_labels, app_lang = await asyncio.gather(
         get_all_monitored_services(db),
         get_known_groups(db),
         get_all_subscribers(db),
         get_email_settings(db),
         get_azure_settings(db),
         get_all_source_labels(db),
+        get_app_default_language(db),
     )
     return templates.TemplateResponse(
         request,
@@ -214,10 +217,26 @@ async def admin_settings(
             "email_cfg": email_cfg,
             "azure_cfg": azure_cfg,
             "source_labels": source_labels,
-            "page_title": f"Einstellungen – {settings.APP_TITLE}",
+            "app_default_language": app_lang or settings.DEFAULT_LANGUAGE,
+            "page_title": f"{LABELS['settings.title']} – {settings.APP_TITLE}",
             **nav,
         },
     )
+
+
+@router.post("/settings/language")
+async def admin_save_language(
+    request: Request,
+    default_language: Annotated[str, Form()],
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_auth),
+):
+    if default_language not in LABELS_BY_LANG:
+        raise HTTPException(status_code=400, detail="unsupported language")
+    await save_app_default_language(db, default_language)
+    await db.commit()
+    flash(request, LABELS["toast.language_saved"])
+    return RedirectResponse(url="/admin/settings#language", status_code=303)
 
 
 @router.post("/settings/email")

--- a/app/templates.py
+++ b/app/templates.py
@@ -7,7 +7,13 @@ from fastapi.templating import Jinja2Templates
 
 from app import __version__
 from app.config import settings as _settings
-from app.i18n import LABELS
+from app.i18n import (
+    LABELS,
+    LANGUAGE_NAMES,
+    SUPPORTED_LANGUAGES,
+    get_current_language,
+    get_label,
+)
 from app.models import INCIDENT_BORDER, STATUS_BADGE_CLASSES, STATUS_TAILWIND_BAR
 
 _ALLOWED_MD_TAGS = ["p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "code", "pre", "blockquote"]
@@ -18,6 +24,9 @@ templates = Jinja2Templates(directory="templates")
 
 # ── Globals ───────────────────────────────────────────────────────────────────
 templates.env.globals["L"] = LABELS
+templates.env.globals["current_lang"] = get_current_language
+templates.env.globals["LANGUAGE_NAMES"] = LANGUAGE_NAMES
+templates.env.globals["SUPPORTED_LANGUAGES"] = SUPPORTED_LANGUAGES
 templates.env.globals["APP_VERSION"] = __version__
 templates.env.globals["APP_TITLE"] = _settings.APP_TITLE
 templates.env.globals["BUILD_SHA"] = _settings.BUILD_SHA
@@ -141,40 +150,54 @@ templates.env.globals["group_services"] = _group_services
 
 
 # ── Filters ───────────────────────────────────────────────────────────────────
-def _strftime_de(dt: datetime | None, fmt: str = "%d.%m.%Y %H:%M Uhr") -> str:
+_DATETIME_FORMATS = {
+    "de": "%d.%m.%Y %H:%M Uhr",
+    "en": "%Y-%m-%d %H:%M",
+}
+_DATE_FORMATS = {
+    "de": "%d.%m.%Y",
+    "en": "%Y-%m-%d",
+}
+
+
+def _strftime_localized(dt: datetime | None, fmt: str | None = None) -> str:
     if dt is None:
         return "—"
+    if fmt is None:
+        fmt = _DATETIME_FORMATS.get(get_current_language(), _DATETIME_FORMATS["de"])
     return dt.strftime(fmt)
 
 
-def _date_de(d, fmt: str = "%d.%m.%Y") -> str:
+def _date_localized(d, fmt: str | None = None) -> str:
     if d is None:
         return "—"
+    if fmt is None:
+        fmt = _DATE_FORMATS.get(get_current_language(), _DATE_FORMATS["de"])
     return d.strftime(fmt)
 
 
-def _duration_de(start: datetime | None, end: datetime | None) -> str:
+def _duration_localized(start: datetime | None, end: datetime | None) -> str:
     if start is None or end is None:
         return ""
     seconds = int((end - start).total_seconds())
     if seconds < 0:
         return ""
     if seconds < 60:
-        return f"{seconds} Sek"
+        return f"{seconds} {get_label('duration.sec')}"
     minutes = seconds // 60
     if minutes < 60:
-        return f"{minutes} Min"
+        return f"{minutes} {get_label('duration.min')}"
     hours = minutes // 60
     if hours < 24:
-        return f"{hours} Std"
+        return f"{hours} {get_label('duration.hr')}"
     days = hours // 24
     if days < 7:
-        return "1 Tag" if days == 1 else f"{days} Tage"
+        return get_label("duration.day_one") if days == 1 else get_label("duration.day_many").format(n=days)
     weeks = days // 7
     if weeks < 5:
-        return "1 Woche" if weeks == 1 else f"{weeks} Wochen"
+        return get_label("duration.week_one") if weeks == 1 else get_label("duration.week_many").format(n=weeks)
     months = days // 30
-    return "1 Monat" if months == 1 else f"{months} Monate"
+    return get_label("duration.month_one") if months == 1 else get_label("duration.month_many").format(n=months)
 
 
 def _render_md(text: str | None) -> str:
@@ -184,7 +207,10 @@ def _render_md(text: str | None) -> str:
     return bleach.clean(raw_html, tags=_ALLOWED_MD_TAGS, attributes=_ALLOWED_MD_ATTRS, strip=True)
 
 
-templates.env.filters["strftime_de"] = _strftime_de
-templates.env.filters["date_de"] = _date_de
+templates.env.filters["strftime_de"] = _strftime_localized
+templates.env.filters["date_de"] = _date_localized
+templates.env.filters["localized_datetime"] = _strftime_localized
+templates.env.filters["localized_date"] = _date_localized
 templates.env.filters["render_md"] = _render_md
-templates.env.globals["duration_de"] = _duration_de
+templates.env.globals["duration_de"] = _duration_localized
+templates.env.globals["localized_duration"] = _duration_localized

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -2,8 +2,37 @@
 
 {% block admin_content %}
 <div class="mb-6">
-  <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Einstellungen</h1>
+  <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ L["settings.title"] }}</h1>
 </div>
+
+{# ── Sprache / Language ────────────────────────────────────────────────────── #}
+<a id="language" class="block scroll-mt-20"></a>
+<section class="mb-8">
+  <h2 class="text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1">
+    {{ L["settings.language_heading"] }}
+  </h2>
+  <p class="text-xs text-gray-400 dark:text-gray-500 mb-3">{{ L["settings.language_hint"] }}</p>
+  <form method="post" action="/admin/settings/language"
+        class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm p-5 flex flex-wrap items-end gap-4">
+    <div class="flex-1 min-w-[12rem]">
+      <label for="default_language" class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+        {{ L["settings.language_label"] }}
+      </label>
+      <select id="default_language" name="default_language"
+              class="w-full text-sm px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+        {% for code in SUPPORTED_LANGUAGES %}
+          <option value="{{ code }}" {% if app_default_language == code %}selected{% endif %}>
+            {{ LANGUAGE_NAMES[code] }} ({{ code | upper }})
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+    <button type="submit"
+            class="inline-flex items-center px-4 py-2 rounded-lg bg-brand text-white text-sm font-medium hover:bg-brand-dark transition-colors">
+      {{ L["settings.language_save"] }}
+    </button>
+  </form>
+</section>
 
 {# ── Dienstverwaltung ────────────────────────────────────────────────────────── #}
 <a id="services" class="block scroll-mt-20"></a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de" class="h-full">
+<html lang="{{ current_lang() }}" class="h-full">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -71,10 +71,37 @@
       </div>
 
       <div class="flex items-center gap-3">
+        <!-- Language switcher -->
+        <div class="relative" data-lang-switcher>
+          <button type="button"
+                  data-lang-toggle
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-label="{{ L['ui.switch_language'] }}"
+                  class="inline-flex items-center gap-1 px-2 py-1 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors text-xs font-medium uppercase">
+            <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129"/>
+            </svg>
+            <span>{{ current_lang() | upper }}</span>
+          </button>
+          <ul data-lang-menu role="menu"
+              class="hidden absolute right-0 mt-1 min-w-[8rem] rounded-lg bg-white dark:bg-gray-900 shadow-lg ring-1 ring-black/5 dark:ring-white/10 py-1 z-30">
+            {% for code in SUPPORTED_LANGUAGES %}
+            <li>
+              <a href="/lang/{{ code }}?next={{ request.url.path | urlencode }}"
+                 role="menuitem"
+                 class="block px-3 py-1.5 text-sm {% if current_lang() == code %}font-semibold text-brand dark:text-brand-light{% else %}text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800{% endif %}">
+                {{ LANGUAGE_NAMES[code] }}
+              </a>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
+
         <!-- Dark mode toggle -->
         <button
           id="theme-toggle"
-          aria-label="Farbschema wechseln"
+          aria-label="{{ L['ui.theme_toggle'] }}"
           class="p-1.5 rounded-md text-white/70 hover:text-white hover:bg-white/10 transition-colors"
         >
           <svg id="icon-sun" class="w-4 h-4 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -125,7 +152,7 @@
     <div class="relative bg-white dark:bg-gray-900 rounded-2xl shadow-2xl max-w-md w-full border border-gray-100 dark:border-gray-800 overflow-hidden">
       <div class="px-5 py-4 border-b border-gray-100 dark:border-gray-800 flex items-start justify-between gap-3">
         <div class="min-w-0 flex items-center gap-2">
-          <button id="day-modal-back" type="button" aria-label="Zurück zur Übersicht"
+          <button id="day-modal-back" type="button" aria-label="{{ L['ui.back_to_overview'] }}"
                   class="hidden shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -ml-1 p-1 rounded transition-colors">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/>
@@ -137,7 +164,7 @@
             <p id="day-modal-sub" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"></p>
           </div>
         </div>
-        <button type="button" data-day-modal-close aria-label="Schließen"
+        <button type="button" data-day-modal-close aria-label="{{ L['ui.close'] }}"
                 class="shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
@@ -154,12 +181,12 @@
 
   <!-- PWA install prompt (shown only after browser fires beforeinstallprompt) -->
   <button id="pwa-install-btn"
-          aria-label="App installieren"
+          aria-label="{{ L['ui.app_install'] }}"
           class="hidden fixed bottom-4 right-4 z-40 inline-flex items-center gap-1.5 px-3 py-2 rounded-full bg-brand text-white text-sm font-medium shadow-lg hover:bg-brand-dark transition-colors">
     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v12m0 0l-4-4m4 4l4-4m-8 8h8"/>
     </svg>
-    <span>Installieren</span>
+    <span>{{ L['ui.app_install_short'] }}</span>
   </button>
 
   {# ── Build info chip — only in DEV mode (DEBUG=True); never in production ── #}
@@ -170,6 +197,46 @@
   </div>
   {% endif %}
 
+  <script>
+    // Labels exposed to inline JS so day-modal/tooltip strings stay localised.
+    window.__I18N = {
+      day_op_body: {{ L['ui.day.operational_body'] | tojson }},
+      day_deg_body: {{ L['ui.day.degraded_body'] | tojson }},
+      day_int_body: {{ L['ui.day.interrupted_body'] | tojson }},
+      day_nd_body: {{ L['ui.day.no_data_body'] | tojson }},
+      day_unk_body: {{ L['ui.day.unknown_body'] | tojson }},
+      cls_incident: {{ L['incident.type.incident'] | tojson }},
+      cls_advisory: {{ L['incident.type.advisory'] | tojson }},
+      cls_maintenance: {{ L['incident.type.maintenance'] | tojson }},
+      related: {{ L['ui.related_entries'] | tojson }},
+      since: {{ L['incident.since'] | tojson }},
+      no_title: {{ L['ui.no_title'] | tojson }},
+      no_details: {{ L['ui.no_details_available'] | tojson }},
+      click_for_details: {{ L['ui.click_for_details'] | tojson }},
+      more_click_for_details: {{ L['ui.more_click_for_details'] | tojson }},
+    };
+  </script>
+  <script>
+    // Language switcher dropdown
+    (function () {
+      const wrap = document.querySelector('[data-lang-switcher]');
+      if (!wrap) return;
+      const btn = wrap.querySelector('[data-lang-toggle]');
+      const menu = wrap.querySelector('[data-lang-menu]');
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const open = !menu.classList.contains('hidden');
+        menu.classList.toggle('hidden');
+        btn.setAttribute('aria-expanded', String(!open));
+      });
+      document.addEventListener('click', (e) => {
+        if (!wrap.contains(e.target)) {
+          menu.classList.add('hidden');
+          btn.setAttribute('aria-expanded', 'false');
+        }
+      });
+    })();
+  </script>
   <script>
     // Dark mode toggle (persists to localStorage)
     const html = document.documentElement;
@@ -199,17 +266,17 @@
       let lastBar = null;
 
       const STATUS_STYLE = {
-        operational: { dot: 'bg-emerald-500', badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300', body: 'Keine Vorfälle an diesem Tag — Dienst lief normal.' },
-        degraded:    { dot: 'bg-amber-500',   badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',       body: 'Eingeschränkte Verfügbarkeit an diesem Tag.' },
-        interrupted: { dot: 'bg-red-500',     badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',               body: 'Dienstunterbrechung an diesem Tag.' },
-        no_data:     { dot: 'bg-gray-300',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: 'Keine Datenpunkte für diesen Tag verfügbar.' },
-        unknown:     { dot: 'bg-gray-400',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: 'Status unbekannt.' },
+        operational: { dot: 'bg-emerald-500', badge: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300', body: window.__I18N.day_op_body },
+        degraded:    { dot: 'bg-amber-500',   badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',       body: window.__I18N.day_deg_body },
+        interrupted: { dot: 'bg-red-500',     badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',               body: window.__I18N.day_int_body },
+        no_data:     { dot: 'bg-gray-300',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: window.__I18N.day_nd_body },
+        unknown:     { dot: 'bg-gray-400',    badge: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',              body: window.__I18N.day_unk_body },
       };
 
       const CLASS_STYLE = {
-        incident:    { border: 'border-l-red-400',   badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',     label: 'Störung' },
-        advisory:    { border: 'border-l-amber-400', badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400', label: 'Hinweis' },
-        maintenance: { border: 'border-l-blue-400',  badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400',  label: 'Wartung' },
+        incident:    { border: 'border-l-red-400',   badge: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-400',     label: window.__I18N.cls_incident },
+        advisory:    { border: 'border-l-amber-400', badge: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400', label: window.__I18N.cls_advisory },
+        maintenance: { border: 'border-l-blue-400',  badge: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400',  label: window.__I18N.cls_maintenance },
       };
 
       function open(btn) {
@@ -238,7 +305,7 @@
         if (matching.length > 0) {
           const header = document.createElement('p');
           header.className = 'text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-2';
-          header.textContent = 'Zugehörige Einträge';
+          header.textContent = window.__I18N.related;
           incidentsBox.appendChild(header);
           matching.forEach((inc) => {
             const cs = CLASS_STYLE[inc.classificationRaw] || {};
@@ -284,7 +351,7 @@
           const end = el.dataset.end || new Date().toISOString().slice(0, 10);
           if (start && date >= start && date <= end) {
             out.push({
-              title: el.dataset.title || '(ohne Titel)',
+              title: el.dataset.title || window.__I18N.no_title,
               meta: el.dataset.meta || (el.dataset.statusLabel ? el.dataset.statusLabel + ' · ' + (el.dataset.service || '') : (el.dataset.service || '')),
               classificationRaw: el.dataset.classificationRaw || '',
               element: el,
@@ -319,7 +386,7 @@
         if (card.dataset.since) {
           const p = document.createElement('p');
           p.className = 'text-xs text-gray-500 dark:text-gray-400 mb-2';
-          p.innerHTML = '<span class="font-medium">Seit:</span> ' + card.dataset.since;
+          p.innerHTML = '<span class="font-medium">' + window.__I18N.since + ':</span> ' + card.dataset.since;
           body.appendChild(p);
         }
         if (card.dataset.description) {
@@ -330,7 +397,7 @@
         } else {
           const p = document.createElement('p');
           p.className = 'text-sm text-gray-500 dark:text-gray-400 italic';
-          p.textContent = 'Keine weiteren Details verfügbar.';
+          p.textContent = window.__I18N.no_details;
           body.appendChild(p);
         }
 
@@ -372,10 +439,10 @@
             tIncidents.appendChild(row);
           });
           if (matching.length > 3) {
-            tMore.textContent = '+' + (matching.length - 3) + ' weitere — klicken für Details';
+            tMore.textContent = window.__I18N.more_click_for_details.replace('{count}', String(matching.length - 3));
             tMore.classList.remove('hidden');
           } else {
-            tMore.textContent = 'Klicken für Details';
+            tMore.textContent = window.__I18N.click_for_details;
             tMore.classList.remove('hidden');
           }
         } else {


### PR DESCRIPTION
## Summary

Macht die UI mehrsprachig (Deutsch + Englisch) mit automatischer Erkennung beim ersten Besuch und persistenter Wahl pro Besucher.

### Wie die Sprache bestimmt wird

Erstbesucher: Browser-`Accept-Language` (entspricht der OS-/Browser-Einstellung). Falls weder Cookie noch passender Header: optionaler Admin-Default (`ui.default_language` in der DB → in `/admin/settings#language` einstellbar) → Server-`LANG` → eingebauter Default (`DEFAULT_LANGUAGE` env, default `de`).

Wiederkehrer: Cookie `lang` (1 Jahr gültig). Manueller Wechsel über das neue DE/EN-Dropdown oben rechts in der Nav.

### Was umgebaut wurde

- `app/i18n.py`: zwei Wörterbücher (`LABELS_DE`, `LABELS_EN`, je 274 Keys), `ContextVar`-basierter Sprachzustand, dict-kompatibler `LABELS`-Proxy. Templates mussten nichts umschreiben – `L['key']` funktioniert weiter, liefert aber die Übersetzung der aktiven Request-Sprache.
- `app/main.py`: HTTP-Middleware setzt die Sprache einmal pro Request; neuer `/lang/{code}`-Endpoint setzt den Cookie und leitet sicher zurück (nur same-origin).
- `app/templates.py`: Datums-/Zeit-/Dauer-Filter sprachabhängig (Filternamen `strftime_de` / `date_de` / `duration_de` bleiben kompatibel; zusätzlich `localized_*` Aliase).
- `templates/base.html`: Language-Switcher in der Topbar, `<html lang="…">` dynamisch, hardcodierte deutsche JS-Strings (Day-Modal, Tooltip, PWA-Install) hängen jetzt an einem `window.__I18N`-Block.
- `templates/admin/settings.html` + `app/routers/admin.py`: neue Section „Sprache" mit Select + POST-Route `/admin/settings/language`.
- `app/app_settings.py`: `get_app_default_language` / `save_app_default_language` als DB-Override.

### Was nicht in diesem PR ist

- Code-Kommentare/Docstrings/Variablen sind weiterhin teilweise auf Deutsch – kommt in einem Folge-PR, da das pure Übersetzungsarbeit ohne Verhaltensänderung ist und besser separat reviewt wird.
- Vereinzelte deutsche Strings in Tooltips/Titles innerhalb einzelner Templates (z.B. `title="Start: …"` in `status.html`) sind noch ungelöst – fallen in den Folge-PR.

## Test plan

Lokal mit `TestClient` verifiziert:
- [x] `Accept-Language: de` → `<html lang="de">`, deutsche Labels gerendert
- [x] `Accept-Language: en` → `<html lang="en">`, englische Labels (`Operational`, etc.)
- [x] Cookie `lang=en` überschreibt `Accept-Language: de`
- [x] `GET /lang/de` setzt Cookie `lang=de` und redirected (303)
- [x] `GET /lang/fr` (nicht unterstützt) redirected ohne Cookie
- [x] `POST /admin/settings/language` mit `default_language=en` speichert in DB; ein neuer Besucher ohne Cookie und mit unsupported Header (`fr,it`) bekommt jetzt EN
- [x] Datums-/Dauer-Filter: DE → "15.01.2024 09:30 Uhr", "5 Tage"; EN → "2024-01-15 09:30", "5 days"
- [x] Beide Label-Dicts haben identische Key-Mengen (kein Missing-Translation)
- [x] `ruff check app/` clean
- [ ] Manuelle Cross-Browser-Sichtprüfung (Statuspage + Admin) in DE und EN

Closes: keine Issue-Referenz, separater Branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK)_