### PR TITLE
ui(public): simplify incident overview — icons instead of pills, calmer dots

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -164,15 +164,21 @@
             <p id="day-modal-sub" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"></p>
           </div>
         </div>
-        <button type="button" data-day-modal-close aria-label="{{ L['ui.close'] }}"
-                class="shrink-0 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
-          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
-          </svg>
-        </button>
+        <div class="shrink-0 flex items-center gap-2">
+          <span id="day-modal-type-icon" class="hidden"></span>
+          <button type="button" data-day-modal-close aria-label="{{ L['ui.close'] }}"
+                  class="text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 -m-1 p-1 rounded">
+            <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
+            </svg>
+          </button>
+        </div>
       </div>
       <div class="px-5 py-4">
-        <div id="day-modal-status-row" class="inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3"></div>
+        <div class="flex flex-wrap items-center gap-2 mb-3">
+          <div id="day-modal-status-row" class="inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium"></div>
+          <div id="day-modal-severity-row" class="hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"></div>
+        </div>
         <p id="day-modal-body" class="text-sm text-gray-600 dark:text-gray-300 leading-relaxed"></p>
         <div id="day-modal-incidents" class="mt-3 space-y-2"></div>
       </div>
@@ -267,9 +273,35 @@
       const sub = document.getElementById('day-modal-sub');
       const dot = document.getElementById('day-modal-dot');
       const statusRow = document.getElementById('day-modal-status-row');
+      const severityRow = document.getElementById('day-modal-severity-row');
+      const typeIconBox = document.getElementById('day-modal-type-icon');
       const body = document.getElementById('day-modal-body');
       const incidentsBox = document.getElementById('day-modal-incidents');
       const backBtn = document.getElementById('day-modal-back');
+
+      // Heroicons paths for type/phase icons rendered dynamically in the modal.
+      const TYPE_ICON = {
+        incident:    { d: 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.732 0 2.814-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.008v.008H12v-.008z', color: 'text-red-600 dark:text-red-400' },
+        advisory:    { d: 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z', color: 'text-amber-600 dark:text-amber-400' },
+        maintenance: { d: 'M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437', color: 'text-blue-600 dark:text-blue-400' },
+      };
+
+      const SEVERITY_BADGE = {
+        critical: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-400',
+        high:     'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-400',
+        medium:   'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-400',
+        low:      'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-400',
+      };
+
+      function renderTypeIcon(classification, label) {
+        const t = TYPE_ICON[classification];
+        if (!t) { typeIconBox.classList.add('hidden'); typeIconBox.innerHTML = ''; return; }
+        typeIconBox.classList.remove('hidden');
+        typeIconBox.innerHTML = '<svg class="w-5 h-5 ' + t.color + '" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" role="img" aria-label="' + label + '">'
+          + '<title>' + label + '</title>'
+          + '<path stroke-linecap="round" stroke-linejoin="round" d="' + t.d + '"/>'
+          + '</svg>';
+      }
 
       let lastBar = null;
 
@@ -322,8 +354,11 @@
         title.textContent = service;
         sub.textContent = dateLabel;
         dot.className = 'w-2.5 h-2.5 rounded-full shrink-0 ' + style.dot;
-        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3 ' + style.badge;
+        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium ' + style.badge;
         statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + statusLabel;
+        severityRow.classList.add('hidden');
+        typeIconBox.classList.add('hidden');
+        typeIconBox.innerHTML = '';
         body.textContent = style.body;
 
         // Look up incidents covering this date by scanning incident entries
@@ -366,6 +401,9 @@
         modal.classList.add('hidden');
         modal.classList.remove('flex');
         document.body.classList.remove('overflow-hidden');
+        typeIconBox.classList.add('hidden');
+        typeIconBox.innerHTML = '';
+        severityRow.classList.add('hidden');
         lastBar = null;
       }
 
@@ -400,13 +438,24 @@
 
         if (lastBar) backBtn.classList.remove('hidden');
 
-        // Status row: classification · severity · phase
-        const chips = [];
-        if (card.dataset.classification) chips.push(card.dataset.classification);
-        if (card.dataset.severityLabel) chips.push(card.dataset.severityLabel);
-        if (card.dataset.statusLabel) chips.push(card.dataset.statusLabel);
-        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium mb-3 ' + (style.badge || 'bg-gray-100 text-gray-600');
-        statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + chips.join(' · ');
+        // Type icon top-right (next to close button)
+        renderTypeIcon(card.dataset.classificationRaw, card.dataset.classification || '');
+
+        // Status pill: phase only, coloured by phase
+        const phaseLabel = card.dataset.statusLabel || '';
+        statusRow.className = 'inline-flex items-center gap-2 px-2.5 py-1 rounded-full text-xs font-medium ' + (style.badge || 'bg-gray-100 text-gray-600');
+        statusRow.innerHTML = '<span class="w-1.5 h-1.5 rounded-full ' + style.dot + '"></span>' + phaseLabel;
+
+        // Severity badge: separate pill, only when set
+        const sev = card.dataset.severityLabel;
+        const sevRaw = (card.dataset.severityRaw || '').toLowerCase();
+        if (sev) {
+          severityRow.className = 'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ' + (SEVERITY_BADGE[sevRaw] || 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400');
+          severityRow.textContent = sev;
+          severityRow.classList.remove('hidden');
+        } else {
+          severityRow.classList.add('hidden');
+        }
 
         body.innerHTML = '';
         if (card.dataset.since) {

--- a/templates/partials/_icons.html
+++ b/templates/partials/_icons.html
@@ -1,0 +1,42 @@
+{# Icon library for compact status/type indicators.
+   Macros return a coloured Heroicons SVG with a <title> for tooltip + a11y. #}
+
+{% macro type_icon(classification, size='w-4 h-4') -%}
+{%- set _icons = {
+  'incident':    {'d': 'M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.732 0 2.814-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.008v.008H12v-.008z',
+                  'color': 'text-red-600 dark:text-red-400'},
+  'advisory':    {'d': 'M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z',
+                  'color': 'text-amber-600 dark:text-amber-400'},
+  'maintenance': {'d': 'M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437',
+                  'color': 'text-blue-600 dark:text-blue-400'}
+} -%}
+{%- set _i = _icons.get(classification, _icons['incident']) -%}
+<svg class="{{ size }} {{ _i.color }} shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" role="img" aria-label="{{ incident_type_label(classification) }}">
+  <title>{{ incident_type_label(classification) }}</title>
+  <path stroke-linecap="round" stroke-linejoin="round" d="{{ _i.d }}"/>
+</svg>
+{%- endmacro %}
+
+{% macro phase_icon(phase, size='w-4 h-4') -%}
+{%- set _icons = {
+  'active':       {'d': 'M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z',
+                   'color': 'text-yellow-500 dark:text-yellow-400'},
+  'acknowledged': {'d': 'M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.623 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.249-8.25-3.285z',
+                   'color': 'text-orange-500 dark:text-orange-400'},
+  'monitoring':   {'d': 'M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z',
+                   'color': 'text-blue-500 dark:text-blue-400'},
+  'resolved':     {'d': 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+                   'color': 'text-emerald-500 dark:text-emerald-400'},
+  'completed':    {'d': 'M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z',
+                   'color': 'text-emerald-500 dark:text-emerald-400'},
+  'scheduled':    {'d': 'M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z',
+                   'color': 'text-blue-500 dark:text-blue-400'},
+  'in_progress':  {'d': 'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99',
+                   'color': 'text-amber-500 dark:text-amber-400'},
+} -%}
+{%- set _i = _icons.get(phase, _icons['resolved']) -%}
+<svg class="{{ size }} {{ _i.color }} shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" role="img" aria-label="{{ state_label(phase) }}">
+  <title>{{ state_label(phase) }}</title>
+  <path stroke-linecap="round" stroke-linejoin="round" d="{{ _i.d }}"/>
+</svg>
+{%- endmacro %}

--- a/templates/partials/incident_card.html
+++ b/templates/partials/incident_card.html
@@ -1,4 +1,5 @@
 {# Renders one incident card with update timeline. Expects `incident` in scope. #}
+{% from "partials/_icons.html" import type_icon, phase_icon %}
 {% set _upd = [] %}
 {% for u in incident.updates | sort(attribute="post_created_at") %}
   {% set _ = _upd.append({"type": u.update_type, "content": u.content, "at": (u.post_created_at.strftime("%d.%m.%Y %H:%M") if u.post_created_at else ""), "author": (u.author or "")}) %}
@@ -17,6 +18,7 @@
      data-classification="{{ incident_type_label(incident.classification) }}"
      data-classification-raw="{{ incident.classification }}"
      data-severity-label="{{ severity_label(incident.severity) if incident.severity else '' }}"
+     data-severity-raw="{{ incident.severity or '' }}"
      data-since="{{ incident.start_datetime | strftime_de if incident.start_datetime else '' }}"
      data-description="{{ incident.description or '' }}"
      data-updates="{{ _upd | tojson | e }}">
@@ -25,7 +27,7 @@
       <div class="min-w-0">
         {% set _phase = 'resolved' if incident.is_resolved else incident.status %}
         <h3 class="font-medium text-gray-900 dark:text-white leading-snug flex items-center gap-2">
-          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ phase_dot_class(_phase) }} {{ phase_pulse_class(_phase) }}"
+          <span class="w-2.5 h-2.5 rounded-full shrink-0 {{ phase_dot_class(_phase) }}"
                 title="{{ state_label(_phase) }}"></span>
           <span>{{ incident.title }}</span>
         </h3>
@@ -46,15 +48,9 @@
         </div>
         {% endif %}
       </div>
-      <div class="shrink-0 flex flex-col items-end gap-1">
-        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{ incident_type_badge_class(incident.classification) }}">
-          {{ incident_type_label(incident.classification) }}
-        </span>
-        {% if incident.severity %}
-        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{ severity_badge_class(incident.severity) }}">
-          {{ severity_label(incident.severity) }}
-        </span>
-        {% endif %}
+      <div class="shrink-0 flex items-center gap-2">
+        {{ type_icon(incident.classification, size='w-5 h-5') }}
+        {{ phase_icon(_phase, size='w-5 h-5') }}
       </div>
     </div>
 

--- a/templates/status.html
+++ b/templates/status.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "partials/_icons.html" import type_icon, phase_icon %}
 
 {% block content %}
 
@@ -134,9 +135,6 @@
   <div class="bg-white dark:bg-gray-900 rounded-2xl border-l-4 border-blue-400 border border-gray-100 dark:border-gray-800 px-5 py-4 mb-3 shadow-sm">
     <div class="flex items-start justify-between gap-3">
       <div class="min-w-0">
-        <span class="inline-block text-xs font-medium px-2 py-0.5 rounded-full mb-1 {{ incident_type_badge_class('maintenance') }}">
-          {{ L["incident.type.maintenance"] }}
-        </span>
         <h3 class="font-medium text-gray-900 dark:text-white">{{ m.title }}</h3>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ m.service_name }}</p>
         {% if m.description %}
@@ -156,14 +154,9 @@
         </p>
         {% endif %}
       </div>
-      <div class="shrink-0">
-        {% if m.status == "in_progress" %}
-          <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">{{ L["maintenance.in_progress"] }}</span>
-        {% elif m.status == "completed" %}
-          <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300">{{ L["maintenance.completed"] }}</span>
-        {% else %}
-          <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">{{ L["maintenance.scheduled"] }}</span>
-        {% endif %}
+      <div class="shrink-0 flex items-center gap-2">
+        {{ type_icon('maintenance', size='w-5 h-5') }}
+        {{ phase_icon(m.status or 'scheduled', size='w-5 h-5') }}
       </div>
     </div>
   </div>
@@ -303,22 +296,18 @@
            data-classification="{{ incident_type_label(incident.classification) }}"
            data-classification-raw="{{ incident.classification }}"
            data-severity-label="{{ severity_label(incident.severity) if incident.severity else '' }}"
+           data-severity-raw="{{ incident.severity or '' }}"
            data-since="{{ incident.start_datetime | strftime_de if incident.start_datetime else '' }}"
            data-description="{{ incident.description or '' }}"
            class="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-800 border-l-4 border-l-emerald-400 shadow-sm overflow-hidden cursor-pointer hover:shadow-md transition-shadow">
         <div class="flex items-center gap-3 px-3 py-2.5">
           <div class="min-w-0 flex-1 flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full shrink-0 bg-emerald-500"></span>
             <span class="text-sm font-medium text-gray-700 dark:text-gray-300 truncate">{{ incident.title }}</span>
             <span class="hidden sm:inline text-xs text-gray-400 dark:text-gray-500 shrink-0">{{ incident.service_name }}</span>
           </div>
           <div class="flex items-center gap-2 shrink-0">
-            <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium {{ incident_type_badge_class(incident.classification) }}">
-              {{ incident_type_label(incident.classification) }}
-            </span>
-            <span class="text-xs px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 shrink-0">
-              {{ L["incident.resolved"] }}
-            </span>
+            {{ type_icon(incident.classification) }}
+            {{ phase_icon('resolved') }}
             <span class="text-xs text-gray-400 dark:text-gray-500 shrink-0 hidden sm:block"
                   title="{% if incident.start_datetime %}{{ L['ui.start'] }}: {{ incident.start_datetime | strftime_de }}{% endif %}{% if incident.end_datetime %} · {{ L['ui.end'] }}: {{ incident.end_datetime | strftime_de }}{% endif %}">
               {% if incident.start_datetime and incident.end_datetime %}


### PR DESCRIPTION
## Summary
Three changes for the public ticket overview, after feedback that the page felt too colourful:

1. **Detail modal**: the *type* (Incident / Advisory / Maintenance) chip moves to the top-right of the modal header (next to close); the *status* pill in the body now shows the phase only, coloured according to the phase palette (yellow / orange / blue / emerald). Severity gets its own pill next to it when set, instead of being mashed into the status pill.
2. **Active incident cards**: the pulsing phase dot stops pulsing — the coloured left border and the section heading „Aktive Störungen" already convey "something is happening". The dot itself stays (it indicates the phase, which the type-coloured border doesn't). Type/severity text pills replaced by compact icons in the top-right of each card.
3. **Resolved history rows**: text pills for type and "Behoben" replaced by type+phase icons (with `<title>` for tooltip + a11y). Same treatment for maintenance cards.

Each icon carries a `<title>` so the label is visible on hover and to screen readers.

A new `templates/partials/_icons.html` exposes `type_icon(...)` and `phase_icon(...)` macros so all templates share one icon source.

Admin lists are intentionally **out of scope** for this PR — they're filter-heavy dense tables where readable textual pills are still better.

## Test plan
- [ ] `/` — verify active incident cards show type + phase icons in the top right, no pulse animation, dot still present
- [ ] `/` — open an incident card, confirm type icon is top-right of the modal, phase pill colour matches the phase (yellow for investigating, etc.), severity is a separate pill when set
- [ ] `/` — verify history rows render two icons (type + green check) and no text pills
- [ ] `/` — verify maintenance cards show the same icon pattern, status icon reflects scheduled / in_progress / completed
- [ ] DE/EN — hover an icon, verify the tooltip is localised
- [ ] Dark mode — verify icon colours have proper contrast
- [ ] `prefers-reduced-motion: reduce` — no animations remain on active cards anyway

https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK)_