### PR TITLE
Fix SMTP 550 5.3.5 by setting envelope sender to authenticated user

### DIFF
--- a/app/notifications.py
+++ b/app/notifications.py
@@ -33,8 +33,15 @@ async def _send_via_smtp(cfg: EmailSettings, to: str, subject: str, html_body: s
         import aiosmtplib
 
         msg = _build_email(cfg, to, subject, html_body, text_body)
+        # On Office 365 (and many providers) the SMTP envelope MAIL FROM must
+        # match the authenticated user, even when the visible From: header is
+        # a "Send As" address. Pass sender explicitly so aiosmtplib does not
+        # fall back to deriving it from the From: header.
+        envelope_sender = cfg.smtp_user or cfg.smtp_from or None
         await aiosmtplib.send(
             msg,
+            sender=envelope_sender,
+            recipients=[to],
             hostname=cfg.smtp_host,
             port=cfg.smtp_port,
             username=cfg.smtp_user or None,


### PR DESCRIPTION
## Summary

Test-email sending failed with:

```
aiosmtplib.errors.SMTPSenderRefused: (550, "5.3.5 Email sender's username is invalid", 'noreply@pyur.com')
```

Office 365's SMTP submission endpoint requires the **envelope** `MAIL FROM` to match the authenticated SMTP user, even when the visible `From:` header is a "Send As" address. `aiosmtplib.send(message)` was deriving the envelope sender from the message's `From:` header (the configured `smtp_from`, e.g. `noreply@pyur.com`), which is typically different from `smtp_user`, so O365 rejected the submission.

## Fix

In `app/notifications.py::_send_via_smtp`, pass `sender` and `recipients` explicitly to `aiosmtplib.send`, using `smtp_user` as the envelope sender. The `From:` header in the MIME message is left unchanged so the recipient still sees the configured display address.

## Test plan

- [ ] Configure SMTP with `smtp_user` ≠ `smtp_from` (Send-As scenario) and trigger a test email from `/admin/settings`.
- [ ] Confirm Office 365 accepts the message and the recipient sees the configured `From:` address.
- [ ] Configure SMTP with `smtp_user` == `smtp_from` and confirm sending still works.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYtVuRVpHvu8HpwnSPiQkV)_