### PR TITLE
ci: fix pip-audit CLI flag (--output-format → --format), unblock scheduled audit

### DIFF
--- a/.github/workflows/audit-scheduled.yml
+++ b/.github/workflows/audit-scheduled.yml
@@ -32,11 +32,15 @@ jobs:
           set +e
           pip-audit \
             --requirement requirements.txt \
-            --output-format markdown \
+            --format markdown \
             --progress-spinner off \
-            > audit-report.md 2>&1
+            > audit-report.md 2>audit-error.log
           EXIT_CODE=$?
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          if [ -s audit-error.log ]; then
+            echo "--- pip-audit stderr ---"
+            cat audit-error.log
+          fi
           cat audit-report.md
           exit 0   # never fail the step; we handle findings via issue
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           pip-audit \
             --requirement requirements.txt \
-            --output-format markdown \
+            --format markdown \
             --progress-spinner off \
             | tee audit-report.md
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           pip install pip-audit
           pip-audit \
             --requirement requirements.txt \
-            --output-format markdown \
+            --format markdown \
             --progress-spinner off \
             | tee audit-report.md
 


### PR DESCRIPTION
## Summary
The scheduled `pip-audit` workflow has been opening a noisy GitHub Issue ([#98](https://github.com/nic2045/My-M365-Statuspage/issues/98)) every week with pip-audit's *usage banner* as the "finding". Root cause is a long-standing typo in the CLI flag.

### Diagnosis
- `pip-audit --output-format markdown` is the invocation used in all three workflows.
- `pip-audit` only accepts `-f, --format` — see `pip-audit --help`. There is no `--output-format`.
- Because argparse prefix-matches and the unknown flag's value lands back in argv, pip-audit eventually parses it as the positional `[project_path]`. That collides with `-r/--requirement` (mutually exclusive group) and crashes with:
  ```
  pip-audit: error: argument project_path: not allowed with argument -r/--requirement
  ```
- CI and release pipelines *hid* the failure because they pipe through `tee`, which only forwards stdout — the argparse error went to stderr and was lost. The scheduled audit uses `> file 2>&1`, so it captured the usage banner and obediently filed it as an issue.

Verified locally with pip-audit 2.10.0:
```
pip-audit -r requirements.txt --format markdown --progress-spinner off
No known vulnerabilities found
```

### Changes
- `.github/workflows/audit-scheduled.yml` — `--output-format` → `--format`; split stderr off into a separate `audit-error.log` and surface it in the step log, so future genuine pip-audit errors don't pollute the issue body.
- `.github/workflows/ci.yml` — same flag fix.
- `.github/workflows/release.yml` — same flag fix.

Closes #98.

## Test plan
- [ ] CI's "Security Audit (pip-audit)" job stays green on this PR.
- [ ] Next Monday's scheduled audit run (or a manual `workflow_dispatch`) produces a real markdown report. If there are findings, the issue body shows the vuln table — not pip-audit's usage banner.

https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLJKXj9tpo1WxkuTW78tK)_