### PR TITLE
Security sprint: admin authorization, CSRF, security headers & hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,22 @@ SECRET_KEY=
 # Einbettungs-Widget API-Key (leer lassen = OIDC erforderlich für /embed)
 EMBED_API_KEY=
 
+# Admin-Berechtigung – primär über eine Entra-ID App-Rolle.
+# Setup im Azure-Portal:
+#   1. App-Registrierung → "App-Rollen" → Rolle anlegen, z.B.
+#      Anzeigename "Admin", Wert "Admin", erlaubte Mitgliedstypen "Benutzer/Gruppen".
+#   2. Enterprise-Anwendung → "Benutzer und Gruppen" → Benutzer ODER eine
+#      Security-Gruppe der Rolle "Admin" zuweisen.
+# Das Token trägt die Rolle dann im Claim `roles`. ADMIN_ROLE = geforderter Wert.
+ADMIN_ROLE=Admin
+
+# Optionale zusätzliche Allowlist (mit der Rolle ODER-verknüpft):
+# kommagetrennte E-Mail-Adressen/UPNs. Leer lassen, wenn nur App-Rollen genutzt
+# werden. Sind Allowlist UND `roles`-Claim leer = jeder authentifizierte
+# Tenant-Benutzer ist Admin (Legacy-Verhalten, beim Start wird gewarnt).
+# Beispiel: ADMIN_EMAILS=admin@example.com,it-team@example.com
+ADMIN_EMAILS=
+
 # Datenbank
 DATABASE_URL=sqlite+aiosqlite:///./data/statuspage.db
 

--- a/README.en.md
+++ b/README.en.md
@@ -95,6 +95,24 @@ On first visit you will be redirected to Entra ID.
 
 ---
 
+## Admin authorization (app role)
+
+By default **every** authenticated tenant user can access `/admin` (legacy behaviour; a warning is logged at startup). For production, restrict the admin area via an **Entra ID app role** — conveniently driven by a security group:
+
+1. **App registration → App roles → Create app role:**
+   - Display name: `Admin`
+   - Value: `Admin`  *(must match `ADMIN_ROLE`, default `Admin`)*
+   - Allowed member types: **Users/Groups**
+2. **Enterprise application → Users and groups → Add:**
+   - Assign a user **or a security group** to the `Admin` role.
+3. Done. Anyone with the role (directly or via the group) receives the `roles: ["Admin"]` claim in their token and gains `/admin` access. To onboard new admins, just add them to the group.
+
+> **App role over a groups claim:** the `roles` claim is always present in the token (no "group overage" beyond 200 groups, no extra Graph lookup) and uses readable names instead of group GUIDs. A role can still be assigned to a group, so group membership drives access.
+
+Alternatively or in addition, set an email allowlist (`ADMIN_EMAILS`, OR-combined with the role). Note: since the public status page also requires login, non-admins can still **view** the page — the allowlist/role only gates `/admin`.
+
+---
+
 ## Configuration reference
 
 | Variable | Description | Default |
@@ -105,6 +123,8 @@ On first visit you will be redirected to Entra ID.
 | `AZURE_REDIRECT_URI` | OAuth callback URL | `http://localhost:8000/auth/callback` |
 | `SECRET_KEY` | Session signing key (≥32 byte hex). Empty = auto-generated on first start, persisted to `data/secret_key` | *(auto)* |
 | `EMBED_API_KEY` | Token for widget access without login | *(empty)* |
+| `ADMIN_ROLE` | Required app-role value for `/admin` access (`roles` claim) | `Admin` |
+| `ADMIN_EMAILS` | Optional email/UPN allowlist (OR-combined with `ADMIN_ROLE`) | *(empty)* |
 | `DATABASE_URL` | SQLAlchemy async URL | `sqlite+aiosqlite:///./data/statuspage.db` |
 | `MONITORED_SERVICES` | Comma-separated service names (must match Graph API names exactly) | Exchange Online, SharePoint Online, Microsoft Teams |
 | `POLL_INTERVAL_MINUTES` | Polling interval in minutes | `10` |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ Beim ersten Aufruf wird man zu Entra ID weitergeleitet.
 
 ---
 
+## Admin-Berechtigung (App-Rolle)
+
+Standardmäßig hat **jeder** authentifizierte Tenant-Benutzer Zugriff auf `/admin` (Legacy-Verhalten; beim Start wird gewarnt). Für Produktion solltest du den Admin-Bereich über eine **Entra-ID App-Rolle** einschränken — bequem steuerbar per Security-Gruppe:
+
+1. **App-Registrierung → App-Rollen → Rolle erstellen:**
+   - Anzeigename: `Admin`
+   - Wert: `Admin`  *(muss `ADMIN_ROLE` entsprechen, Standard `Admin`)*
+   - Erlaubte Mitgliedstypen: **Benutzer/Gruppen**
+2. **Enterprise-Anwendung → Benutzer und Gruppen → Hinzufügen:**
+   - Einen Benutzer **oder eine Security-Gruppe** der Rolle `Admin` zuweisen.
+3. Fertig. Wer die Rolle (direkt oder über die Gruppe) hat, bekommt im Token den Claim `roles: ["Admin"]` und damit `/admin`-Zugriff. Neue Admins fügst du anschließend nur noch der Gruppe hinzu.
+
+> **App-Rolle statt Gruppen-Claim:** Der `roles`-Claim ist immer im Token (kein „group overage" ab >200 Gruppen, kein zusätzlicher Graph-Lookup) und nutzt lesbare Namen statt Gruppen-GUIDs. Eine Rolle lässt sich trotzdem einer Gruppe zuweisen — so steuert die Gruppenmitgliedschaft den Zugriff.
+
+Alternativ oder ergänzend kannst du eine E-Mail-Allowlist setzen (`ADMIN_EMAILS`, ODER-verknüpft mit der Rolle). Hinweis: Da auch die öffentliche Statusseite Login erfordert, dürfen Nicht-Admins die Seite weiterhin **ansehen** — die Allowlist/Rolle gilt nur für `/admin`.
+
+---
+
 ## Konfigurationsreferenz
 
 | Variable | Beschreibung | Standard |
@@ -102,6 +120,8 @@ Beim ersten Aufruf wird man zu Entra ID weitergeleitet.
 | `AZURE_REDIRECT_URI` | OAuth-Callback-URL | `http://localhost:8000/auth/callback` |
 | `SECRET_KEY` | Session-Signaturschlüssel (≥32 Byte Hex). Leer = Auto-Generierung beim ersten Start, persistiert in `data/secret_key` | *(auto)* |
 | `EMBED_API_KEY` | Token für Widget-Zugriff ohne Login | *(leer)* |
+| `ADMIN_ROLE` | Geforderter App-Rollen-Wert für `/admin`-Zugriff (`roles`-Claim) | `Admin` |
+| `ADMIN_EMAILS` | Optionale E-Mail-/UPN-Allowlist (ODER-verknüpft mit `ADMIN_ROLE`) | *(leer)* |
 | `DATABASE_URL` | SQLAlchemy Async URL | `sqlite+aiosqlite:///./data/statuspage.db` |
 | `MONITORED_SERVICES` | Kommagetrennte Dienstnamen (Graph API exakt) | Exchange Online, SharePoint Online, Microsoft Teams |
 | `POLL_INTERVAL_MINUTES` | Abfrageintervall in Minuten | `10` |

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,12 @@
+import logging
+
 from authlib.integrations.starlette_client import OAuth
+from fastapi import HTTPException
 from starlette.requests import Request
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
 
 oauth = OAuth()
 oauth.register(
@@ -35,3 +40,47 @@ async def require_auth(request: Request) -> dict:
     if user is None:
         raise LoginRequired(next_path=str(request.url.path))
     return user
+
+
+def _user_identifier(user: dict) -> str:
+    return (user.get("email") or user.get("preferred_username") or "").strip().lower()
+
+
+def _user_roles(user: dict) -> list[str]:
+    """App roles from the token's `roles` claim, lower-cased."""
+    roles = user.get("roles")
+    return [str(r).strip().lower() for r in roles] if isinstance(roles, list) else []
+
+
+async def require_admin(request: Request) -> dict:
+    """Authenticated *and* authorized for the admin area.
+
+    Authorization is granted when the user carries the configured Entra ID
+    app role (ADMIN_ROLE) or is on the optional ADMIN_EMAILS allowlist.
+
+    Legacy fallback: if no allowlist is configured *and* the token carries no
+    `roles` claim at all (i.e. app roles have not been set up yet), every
+    authenticated user is allowed so upgrades don't lock admins out. A warning
+    is emitted at startup in that case.
+    """
+    user = await require_auth(request)
+    if settings.DISABLE_AUTH:
+        return user
+
+    allowlist = settings.admin_emails_list
+    required_role = settings.ADMIN_ROLE.strip().lower()
+    roles = _user_roles(user)
+
+    if required_role and required_role in roles:
+        return user
+    if allowlist and _user_identifier(user) in allowlist:
+        return user
+    # No authorization rules in effect anywhere → legacy allow-all.
+    if not allowlist and not roles:
+        return user
+
+    logger.warning(
+        "Admin access denied for %r (roles=%r, required_role=%r)",
+        _user_identifier(user), roles, required_role,
+    )
+    raise HTTPException(status_code=403, detail="Kein Admin-Zugriff für dieses Konto.")

--- a/app/config.py
+++ b/app/config.py
@@ -46,6 +46,17 @@ class Settings(BaseSettings):
     # Dev: bypass Entra ID OIDC – all routes accessible without login
     DISABLE_AUTH: bool = False
 
+    # Admin authorization.
+    # Primary mechanism: an Entra ID app role. Assign the role (or a security
+    # group) to the app in "Enterprise applications → Users and groups"; the
+    # token then carries it in the `roles` claim. ADMIN_ROLE is the role value
+    # to require (the appRole "value" defined in the app manifest).
+    ADMIN_ROLE: str = "Admin"
+    # Optional additional allowlist of emails/UPNs (OR-combined with the role).
+    # Both empty *and* no role claim in the token = every authenticated tenant
+    # user is admin (legacy behaviour) – a warning is logged on startup.
+    ADMIN_EMAILS: str = ""
+
     # UI language fallback when the visitor has no cookie, no Accept-Language
     # header and no admin-configured default. Supported: "de", "en".
     DEFAULT_LANGUAGE: str = "de"
@@ -108,6 +119,10 @@ class Settings(BaseSettings):
     @property
     def teams_webhook_list(self) -> list[str]:
         return [u.strip() for u in self.TEAMS_WEBHOOK_URLS.split(",") if u.strip()]
+
+    @property
+    def admin_emails_list(self) -> list[str]:
+        return [e.strip().lower() for e in self.ADMIN_EMAILS.split(",") if e.strip()]
 
     @computed_field
     @property

--- a/app/crud.py
+++ b/app/crud.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime, timedelta
 from typing import Any
 
-import bleach
+import nh3
 from sqlalchemy import desc, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,15 +24,15 @@ from app.schemas import (
     StatusPageSchema,
 )
 
-ALLOWED_HTML_TAGS = ["p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "span",
-                     "h1", "h2", "h3", "h4", "div", "table", "thead", "tbody", "tr", "td", "th"]
-ALLOWED_HTML_ATTRS = {"a": ["href", "title"]}
+ALLOWED_HTML_TAGS = {"p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "span",
+                     "h1", "h2", "h3", "h4", "div", "table", "thead", "tbody", "tr", "td", "th"}
+ALLOWED_HTML_ATTRS = {"a": {"href", "title"}}
 
 _STATUS_SEVERITY = {"operational": 0, "unknown": 1, "degraded": 2, "interrupted": 3}
 
 
 def _sanitize_html(raw: str) -> str:
-    return bleach.clean(raw, tags=ALLOWED_HTML_TAGS, attributes=ALLOWED_HTML_ATTRS, strip=True)
+    return nh3.clean(raw, tags=ALLOWED_HTML_TAGS, attributes=ALLOWED_HTML_ATTRS)
 
 
 def _parse_dt(value: str | None) -> datetime | None:

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,3 +1,4 @@
+import secrets
 from collections.abc import AsyncGenerator
 
 from fastapi import Depends, HTTPException, Query
@@ -59,7 +60,7 @@ async def require_embed_access(
     """
     if settings.DISABLE_AUTH:
         return
-    if settings.EMBED_API_KEY and token == settings.EMBED_API_KEY:
+    if settings.EMBED_API_KEY and token and secrets.compare_digest(token, settings.EMBED_API_KEY):
         return
     user = await get_current_user(request)
     if user is None:

--- a/app/graph_client.py
+++ b/app/graph_client.py
@@ -87,9 +87,11 @@ async def fetch_issues_since(service_name: str, days: int = 90) -> list[dict]:
     """Fetch all issues (including resolved) for a service over the past N days, for backfill."""
     token = await _get_access_token()
     since = (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%dT00:00:00Z")
+    # Escape single quotes per OData rules (doubled) to prevent $filter injection.
+    safe_service = service_name.replace("'", "''")
     base_url = (
         f"{GRAPH_BASE}/admin/serviceAnnouncement/issues"
-        f"?$filter=service eq '{service_name}' and startDateTime ge {since}"
+        f"?$filter=service eq '{safe_service}' and startDateTime ge {since}"
         f"&$select=id,service,title,classification,status,startDateTime,endDateTime,lastModifiedDateTime,isResolved,severity,impactDescription"
         f"&$top=100"
     )

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
 import logging
 from contextlib import asynccontextmanager
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, Request
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -27,13 +28,33 @@ logging.basicConfig(
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
+    if settings.DISABLE_AUTH:
+        logger.warning(
+            "DISABLE_AUTH is enabled – ALL routes are accessible without login. "
+            "This must never be used in production."
+        )
+    if not settings.admin_emails_list and not settings.DISABLE_AUTH:
+        logger.warning(
+            "No ADMIN_EMAILS allowlist configured. Restrict the admin area by "
+            "assigning the '%s' app role (or a security group) to this app in "
+            "Entra ID, or by setting ADMIN_EMAILS. Until a role-bearing token "
+            "is seen, every authenticated tenant user has full admin access.",
+            settings.ADMIN_ROLE,
+        )
     await init_db()
     start_scheduler()
     yield
     stop_scheduler()
+
+
+# Methods that must not mutate state and are therefore exempt from the CSRF
+# origin check.
+_CSRF_SAFE_METHODS = {"GET", "HEAD", "OPTIONS", "TRACE"}
 
 
 app = FastAPI(
@@ -50,6 +71,52 @@ app.add_middleware(
     https_only=not settings.DEBUG,
     same_site="lax",
 )
+
+# Content-Security-Policy: 'unsafe-inline' is required for the inline scripts/
+# styles and the Tailwind CDN in base.html. The real wins here are
+# frame-ancestors (anti-clickjacking), form-action, object-src and base-uri.
+_CSP = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; "
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "font-src 'self' https://fonts.gstatic.com; "
+    "img-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'self'; "
+    "base-uri 'self'; "
+    "form-action 'self'; "
+    "object-src 'none'"
+)
+
+
+@app.middleware("http")
+async def csrf_protect(request: Request, call_next):
+    """Origin/Referer-based CSRF defense for state-changing requests.
+
+    Combined with the SameSite=lax session cookie this blocks cross-site
+    form submissions. The host of the Origin (or, as a fallback, Referer)
+    header must match the request's Host header.
+    """
+    if request.method not in _CSRF_SAFE_METHODS and not settings.DISABLE_AUTH:
+        host = request.headers.get("host")
+        source = request.headers.get("origin") or request.headers.get("referer")
+        if not source or urlparse(source).netloc != host:
+            return JSONResponse({"detail": "CSRF validation failed"}, status_code=403)
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    # /embed is intentionally framable from any origin (it sets its own CSP),
+    # so don't impose frame restrictions there.
+    if not request.url.path.startswith("/embed"):
+        response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+        response.headers.setdefault("Content-Security-Policy", _CSP)
+    return response
+
 
 @app.middleware("http")
 async def language_middleware(request: Request, call_next):

--- a/app/notifications.py
+++ b/app/notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from html import escape as _esc
 
 import httpx
 
@@ -155,9 +156,10 @@ async def send_test_email(to: str) -> tuple[bool, str]:
 
 async def send_confirmation_email(email: str, confirm_url: str) -> bool:
     subject = "Statuspage – E-Mail-Adresse bestätigen"
+    safe_url = _esc(confirm_url, quote=True)
     html = f"""
 <p>Bitte bestätige deine E-Mail-Adresse, um Benachrichtigungen zu erhalten:</p>
-<p><a href="{confirm_url}">{confirm_url}</a></p>
+<p><a href="{safe_url}">{_esc(confirm_url)}</a></p>
 <p>Falls du dich nicht angemeldet hast, ignoriere diese E-Mail.</p>
 """
     text = f"Bitte bestätige deine E-Mail-Adresse:\n{confirm_url}\n"
@@ -174,14 +176,19 @@ async def send_incident_notification(
     unsubscribe_urls: dict[str, str],
 ) -> None:
     """Send incident notification to a list of confirmed subscriber emails."""
+    e_subject = _esc(subject)
+    e_service = _esc(service_name)
+    e_title = _esc(incident_title)
+    e_desc = _esc(description) if description else ""
+    e_status_url = _esc(status_url, quote=True)
     for email in subscribers:
-        unsub_url = unsubscribe_urls.get(email, "")
+        unsub_url = _esc(unsubscribe_urls.get(email, ""), quote=True)
         html = f"""
-<h2 style="margin:0 0 8px">M365 Dienststatus – {subject}</h2>
-<p><strong>Dienst:</strong> {service_name}</p>
-<p><strong>Meldung:</strong> {incident_title}</p>
-{f'<p>{description}</p>' if description else ''}
-<p><a href="{status_url}">Statusseite öffnen</a></p>
+<h2 style="margin:0 0 8px">M365 Dienststatus – {e_subject}</h2>
+<p><strong>Dienst:</strong> {e_service}</p>
+<p><strong>Meldung:</strong> {e_title}</p>
+{f'<p>{e_desc}</p>' if e_desc else ''}
+<p><a href="{e_status_url}">Statusseite öffnen</a></p>
 <hr style="margin:16px 0">
 <p style="font-size:12px;color:#666">
   <a href="{unsub_url}">Abmelden</a>

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -18,7 +18,7 @@ from app.app_settings import (
     verify_azure_connection,
     verify_smtp_connection,
 )
-from app.auth import require_auth
+from app.auth import require_admin
 from app.config import settings
 from app.crud import (
     add_incident_post,
@@ -163,7 +163,7 @@ def _schedule_delayed_poll(delay: float = 8.0) -> None:
 async def admin_dashboard(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     services_with_status = await get_enabled_services_with_status(db)
@@ -183,7 +183,7 @@ async def admin_dashboard(
 async def admin_search(
     q: str = "",
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """JSON endpoint backing the Cmd+K palette in the admin area."""
     return JSONResponse(await search_global(db, q))
@@ -193,7 +193,7 @@ async def admin_search(
 async def admin_settings(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     all_services, known_groups, subscribers, email_cfg, azure_cfg, source_labels, app_lang = await asyncio.gather(
@@ -229,7 +229,7 @@ async def admin_save_language(
     request: Request,
     default_language: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     if default_language not in LABELS_BY_LANG:
         raise HTTPException(status_code=400, detail="unsupported language")
@@ -251,7 +251,7 @@ async def admin_save_email_settings(
     smtp_tls: Annotated[str | None, Form()] = None,
     graph_from_address: Annotated[str, Form()] = "",
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     if auth_method not in {"none", "password", "graph_oauth2"}:
         auth_method = "none"
@@ -293,7 +293,7 @@ async def admin_send_test_email(
     request: Request,
     to: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     ok, message = await send_test_email(to.strip())
     flash(request, message, "success" if ok else "error")
@@ -307,7 +307,7 @@ async def admin_save_azure_settings(
     client_id: Annotated[str, Form()] = "",
     client_secret: Annotated[str, Form()] = "",
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await save_azure_settings(
         db,
@@ -332,7 +332,7 @@ async def api_save_source_label(
     source: Annotated[str, Form()],
     label: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     src = source.strip()
     lbl = label.strip()
@@ -348,7 +348,7 @@ async def settings_save_source_label(
     source: Annotated[str, Form()],
     label: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     src = source.strip()
     lbl = label.strip()
@@ -363,7 +363,7 @@ async def settings_delete_source_label(
     request: Request,
     source: str,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await delete_source_label(db, source)
     flash(request, "Label entfernt.")
@@ -375,7 +375,7 @@ async def admin_delete_subscriber(
     request: Request,
     subscriber_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await delete_subscriber(db, subscriber_id)
     await db.commit()
@@ -389,7 +389,7 @@ async def admin_incidents_all(
     source: str | None = None,
     classification: str | None = None,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     """List ALL incidents (active + resolved). Supports ?source=manual|graph
@@ -439,7 +439,7 @@ async def admin_incidents_all(
 async def admin_maintenances_all(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     maintenances = await get_all_maintenances(db)
@@ -459,7 +459,7 @@ async def admin_maintenances_all(
 async def new_incident_form(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     enabled_services, known_sources, all_labels = await asyncio.gather(
@@ -494,7 +494,7 @@ async def create_incident(
     source: Annotated[str, Form()] = "manual",
     external_id: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     incident = await create_manual_incident(
         db,
@@ -547,7 +547,7 @@ async def incident_detail(
     request: Request,
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     incident = await get_incident_by_id(db, incident_id)
@@ -590,7 +590,7 @@ async def update_incident(
     source: Annotated[str | None, Form()] = None,
     external_id: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     old = await get_incident_by_id(db, incident_id)
     old_status = old.status if old else None
@@ -634,7 +634,7 @@ async def update_incident(
 async def delete_incident(
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     deleted = await crud_delete_incident(db, incident_id)
     if not deleted:
@@ -649,7 +649,7 @@ async def add_post(
     content: Annotated[str, Form()],
     notify_subscribers: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     do_notify = notify_subscribers == "on"
     await add_incident_post(
@@ -696,7 +696,7 @@ async def add_post(
 @router.post("/services/refresh")
 async def refresh_services(
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """Fetch all services from Graph API and register any new ones as disabled."""
     try:
@@ -715,7 +715,7 @@ async def refresh_services(
 async def toggle_service(
     service_name: str,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """Enable or disable a service on the status page. Triggers backfill when enabling."""
     result = await db.execute(
@@ -738,7 +738,7 @@ async def toggle_service(
 async def toggle_uptime_display(
     service_name: str,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """Toggle whether the 90-day uptime percentage is shown for this service."""
     result = await db.execute(
@@ -757,7 +757,7 @@ async def admin_move_service(
     service_name: str,
     direction: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """Move service one slot up or down within its group (changes public-page order)."""
     moved = await move_service(db, service_name, direction)
@@ -772,7 +772,7 @@ async def update_service_group(
     service_name: str,
     group_name: Annotated[str, Form()] = "",
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     """Assign (or clear) the group for a monitored service."""
     await set_service_group(db, service_name, group_name)
@@ -785,7 +785,7 @@ async def set_service_status(
     service_name: str,
     status: Annotated[str, Form()],
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await set_service_status_manual(db, service_name, status)
     await db.commit()
@@ -796,7 +796,7 @@ async def set_service_status(
 async def suppress_incident(
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await toggle_suppress_incident(db, incident_id, suppress=True)
     await db.commit()
@@ -807,7 +807,7 @@ async def suppress_incident(
 async def unsuppress_incident(
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await toggle_suppress_incident(db, incident_id, suppress=False)
     await db.commit()
@@ -823,7 +823,7 @@ async def acknowledge_incident(
     request: Request,
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     email = _user_email(user)
     if email is None:
@@ -846,7 +846,7 @@ async def release_incident(
     request: Request,
     incident_id: int,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     await admin_update_incident(
         db,
@@ -864,7 +864,7 @@ async def release_incident(
 async def new_maintenance_form(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     enabled_services = await get_enabled_services(db)
@@ -888,7 +888,7 @@ async def create_maintenance(
     scheduled_start: Annotated[str | None, Form()] = None,
     scheduled_end: Annotated[str | None, Form()] = None,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
 ):
     incident = await create_manual_incident(
         db,
@@ -910,7 +910,7 @@ async def create_maintenance(
 async def debug_page(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     enabled = await get_enabled_services(db)
@@ -934,7 +934,7 @@ async def debug_page(
 async def debug_fetch(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    user: dict = Depends(require_auth),
+    user: dict = Depends(require_admin),
     nav: dict = Depends(admin_nav_context),
 ):
     """Live-fetch all Microsoft service health data and display raw results."""

--- a/app/routers/auth_router.py
+++ b/app/routers/auth_router.py
@@ -7,10 +7,26 @@ from app.config import settings
 
 router = APIRouter(tags=["auth"])
 
+# Only the claims the app actually needs are persisted in the (signed but
+# unencrypted, client-readable) session cookie – avoids leaking the full
+# OIDC userinfo payload.
+_KEPT_CLAIMS = ("name", "email", "preferred_username", "sub", "oid", "roles")
+
+
+def _safe_next(target: str | None) -> str:
+    """Reject off-site redirect targets (open-redirect guard).
+
+    Only same-origin absolute paths are allowed: must start with a single
+    '/' and not with '//' or '/\\' (protocol-relative URLs).
+    """
+    if not target or not target.startswith("/") or target.startswith(("//", "/\\")):
+        return "/"
+    return target
+
 
 @router.get("/auth/login")
 async def login(request: Request, next: str = "/"):
-    request.session["next"] = next
+    request.session["next"] = _safe_next(next)
     return await oauth.microsoft.authorize_redirect(request, settings.AZURE_REDIRECT_URI)
 
 
@@ -20,8 +36,8 @@ async def auth_callback(request: Request):
     userinfo = token.get("userinfo")
     if not userinfo:
         userinfo = await oauth.microsoft.userinfo(token=token)
-    request.session["user"] = dict(userinfo)
-    next_url = request.session.pop("next", "/")
+    request.session["user"] = {k: userinfo[k] for k in _KEPT_CLAIMS if k in userinfo}
+    next_url = _safe_next(request.session.pop("next", "/"))
     return RedirectResponse(url=next_url, status_code=302)
 
 

--- a/app/templates.py
+++ b/app/templates.py
@@ -1,8 +1,8 @@
 """Shared Jinja2 templates instance with all globals and filters pre-registered."""
 from datetime import datetime
 
-import bleach
 import mistune
+import nh3
 from fastapi.templating import Jinja2Templates
 
 from app import __version__
@@ -16,8 +16,8 @@ from app.i18n import (
 )
 from app.models import INCIDENT_BORDER, STATUS_BADGE_CLASSES, STATUS_TAILWIND_BAR
 
-_ALLOWED_MD_TAGS = ["p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "code", "pre", "blockquote"]
-_ALLOWED_MD_ATTRS = {"a": ["href", "title"]}
+_ALLOWED_MD_TAGS = {"p", "b", "i", "strong", "em", "a", "ul", "ol", "li", "br", "code", "pre", "blockquote"}
+_ALLOWED_MD_ATTRS = {"a": {"href", "title"}}
 _md = mistune.create_markdown(escape=False)
 
 templates = Jinja2Templates(directory="templates")
@@ -204,7 +204,7 @@ def _render_md(text: str | None) -> str:
     if not text:
         return ""
     raw_html = _md(text)
-    return bleach.clean(raw_html, tags=_ALLOWED_MD_TAGS, attributes=_ALLOWED_MD_ATTRS, strip=True)
+    return nh3.clean(raw_html, tags=_ALLOWED_MD_TAGS, attributes=_ALLOWED_MD_ATTRS)
 
 
 templates.env.filters["strftime_de"] = _strftime_localized

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aiosqlite==0.22.1
 apscheduler==3.11.2
 pydantic-settings==2.14.1
 python-dotenv==1.2.2
-bleach==6.3.0
+nh3==0.2.20
 mistune==3.2.1
 starlette==1.0.0
 cryptography>=48.0.0,<49


### PR DESCRIPTION
## Summary

Behebt die im Security-Review der App gefundenen Lücken. Schwerpunkt: Autorisierung des Admin-Bereichs, CSRF, Security-Header und mehrere Härtungsmaßnahmen.

### 🔴 Kritisch
- **Admin-Autorisierung** (vorher: *jeder* authentifizierte Tenant-User war Voll-Admin). `/admin` erfordert jetzt `require_admin`:
  - Primär über eine **Entra-ID App-Rolle** (`roles`-Claim, konfigurierbar via `ADMIN_ROLE`, Default `Admin`).
  - Optional ergänzt durch eine **`ADMIN_EMAILS`-Allowlist** (ODER-verknüpft).
  - **Legacy-Fallback** nur solange weder Rolle noch Allowlist greifen (kein Lock-out beim Upgrade); Startup-Warnung in dem Fall.
  - App-Rolle empfohlen statt Security-Gruppen: kein „group overage", kein Graph-Lookup, lesbare Rollennamen — und die Rolle kann trotzdem einer Security-Gruppe zugewiesen werden.
- **Open Redirect** beim Login: `?next=` wird auf same-origin-Pfade begrenzt (`_safe_next`).

### 🟠 Härtung
- **Security-Header-Middleware**: CSP (`frame-ancestors`, `form-action 'self'`, `object-src 'none'`, `base-uri 'self'`), `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`. `/embed` bleibt bewusst frame-bar (eigene CSP).
- **CSRF-Schutz**: Origin/Referer-Prüfung für alle state-changing Requests (ergänzt das `SameSite=lax`-Cookie).
- **Timing-sicherer `EMBED_API_KEY`-Vergleich** via `secrets.compare_digest`.
- **HTML-Escaping** in Benachrichtigungs-Mails (`html.escape`).
- **OData-`$filter`-Escaping** im Graph-Client (Single-Quote-Doubling).
- **Session-Cookie** speichert nur noch benötigte OIDC-Claims statt des vollen `userinfo`.
- **`nh3` statt `bleach`** (End-of-Life) für HTML-Sanitizing — strippt zusätzlich `javascript:`-URLs und setzt `rel="noopener noreferrer"`.

### Konfiguration (neu in `.env.example`)
- `ADMIN_ROLE` (Default `Admin`) — geforderter App-Rollen-Wert.
- `ADMIN_EMAILS` — optionale zusätzliche Allowlist.

## Test plan
- [x] `ruff check app/` — clean
- [x] `py_compile` aller Module
- [x] App-Import + Routen-Check mit Dummy-Env
- [x] `require_admin`-Logik (Rolle erlaubt / falsche Rolle 403 / Legacy-Allow / Allowlist-Match / DISABLE_AUTH)
- [x] Request-Level (TestClient): Security-Header gesetzt; `/embed` ohne X-Frame-Options + CSP `frame-ancestors *`; falscher Embed-Token → 401; CSRF blockt fehlende/fremde Origin (403) und erlaubt eigene Origin (200)
- [x] `nh3`-Sanitizer: Scripts & `javascript:`-hrefs entfernt, sichere Links erhalten
- [ ] Manuell gegen einen echten Entra-Tenant mit zugewiesener `Admin`-App-Rolle prüfen

### Deferred (Folge-Empfehlung)
- Bandit (Python-SAST) als CI-Job ergänzen — bewusst nicht in diesem PR, um ungetunte Findings als blockierendes Gate zu vermeiden.

https://claude.ai/code/session_01XX9GPNkGpbCh1tzQhF8KAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01XX9GPNkGpbCh1tzQhF8KAE)_