### PR TITLE
Add standalone cert & availability monitoring demo stack (Prometheus/Grafana/OneUptime)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -291,3 +291,9 @@ Active phases (`active`/`acknowledged`/`monitoring`/`in_progress`) and non-opera
 | **Trivy Image Scan** | Docker image scanned for OS / library CVEs |
 | **Weekly Audit** | Monday-morning security scan, opens an issue on findings |
 | **Release workflow** | Tag `v*.*.*` → GHCR push (multi-arch) → GitHub release |
+
+---
+
+## Related: Certificate & Availability Monitoring (Demo)
+
+[`demo-cert-monitoring/`](demo-cert-monitoring/) contains a standalone demo stack (Prometheus + blackbox_exporter + Grafana + optional OneUptime) showing how generic website/TLS-certificate monitoring can be surfaced for two audiences: app owners (a Grafana dashboard) and end users (a public OneUptime status page). It's fully separate from this app — its own compose file, its own `.env`, no effect on this repo's CI/build.

--- a/README.md
+++ b/README.md
@@ -285,3 +285,9 @@ Aktive Phasen (`active`/`acknowledged`/`monitoring`/`in_progress`) und nicht-ope
 | **Trivy Image Scan** | Docker-Image auf OS- und Library-CVEs |
 | **Wöchentlicher Audit** | Montags automatischer Sicherheitsscan, öffnet Issue bei Findings |
 | **Release-Workflow** | Tag `v*.*.*` → GHCR-Push (multi-arch) → GitHub Release |
+
+---
+
+## Verwandtes: Zertifikats- & Verfügbarkeits-Monitoring (Demo)
+
+Unter [`demo-cert-monitoring/`](demo-cert-monitoring/) liegt ein eigenständiger Demo-Stack (Prometheus + blackbox_exporter + Grafana + optional OneUptime), der zeigt, wie generisches Website-/TLS-Zertifikats-Monitoring für App-Owner (Grafana-Dashboard) und Endnutzer (öffentliche OneUptime-Statuspage) aussehen kann. Er ist komplett getrennt von dieser App — eigenes Compose-File, eigenes `.env`, kein Einfluss auf CI/Build hier.

--- a/demo-cert-monitoring/.env.example
+++ b/demo-cert-monitoring/.env.example
@@ -1,0 +1,27 @@
+# ── Demo-Ziele ────────────────────────────────────────────────────────────
+# 2-3 URLs, kommagetrennt, ohne Leerzeichen um die Kommas.
+# Jede URL wird per HTTP(S)-Check (Erreichbarkeit) UND TLS-Zertifikatsprüfung
+# (Ablaufdatum) durch den blackbox_exporter überwacht.
+DEMO_TARGET_URLS=https://www.google.com,https://www.github.com,https://www.wikipedia.org
+
+# ── Grafana (App-Owner-Dashboard) ───────────────────────────────────────────
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me-please
+GRAFANA_PORT=3000
+
+# ── Prometheus / blackbox_exporter ──────────────────────────────────────────
+PROMETHEUS_PORT=9090
+BLACKBOX_EXPORTER_PORT=9115
+
+# ── OneUptime-Anbindung (öffentliche Statuspage für Endnutzer) ─────────────
+# Optional. Ohne diese Werte läuft der Prometheus/Grafana-Teil trotzdem
+# vollständig - nur der Sync zu OneUptime wird übersprungen.
+#
+# In OneUptime pro Ziel-URL einen Monitor vom Typ "Incoming Request" /
+# "Heartbeat" anlegen. OneUptime generiert dafür eine eindeutige URL, die
+# hier eingetragen wird - Reihenfolge muss zu DEMO_TARGET_URLS passen.
+# ONEUPTIME_HEARTBEAT_URLS=https://oneuptime.example.com/heartbeat/xxx,https://oneuptime.example.com/heartbeat/yyy,https://oneuptime.example.com/heartbeat/zzz
+ONEUPTIME_HEARTBEAT_URLS=
+
+# Wie oft (Sekunden) der Sync-Loop Prometheus abfragt und ggf. OneUptime pingt
+SYNC_INTERVAL_SECONDS=60

--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -1,0 +1,123 @@
+# Demo: Zertifikats- & Verfügbarkeits-Monitoring (Prometheus + Grafana + OneUptime)
+
+> Eigenständiger Demo-Stack. Getrennt von der M365-Statuspage-App in diesem
+> Repo (eigenes `docker-compose.yml`, eigenes `.env`, nicht Teil von CI oder
+> des Haupt-Docker-Images). Zeigt exemplarisch, wie Zertifikats-Ablauf und
+> Website-Verfügbarkeit für zwei Zielgruppen aufbereitet werden können:
+> App-Owner (technisches Grafana-Dashboard) und Endnutzer (öffentliche
+> OneUptime-Statuspage).
+
+## Architektur
+
+```
+                 ┌─────────────────────┐
+  DEMO_TARGET_   │   blackbox_exporter  │  HTTP(S)-Check + TLS-Cert-Ablauf
+  URLS (2-3 URLs)│   (probe /probe)     │  je konfigurierter URL
+                 └──────────┬───────────┘
+                            │ scrape
+                            ▼
+                 ┌─────────────────────┐
+                 │      Prometheus      │  einzige Quelle der Wahrheit
+                 │  (Metriken + Alerts) │
+                 └──────┬───────┬───────┘
+                         │       │
+             Prometheus  │       │  probe_success /
+             Datasource  │       │  probe_ssl_earliest_cert_expiry
+                         ▼       ▼
+              ┌────────────┐  ┌──────────────────┐
+              │  Grafana   │  │  oneuptime-sync   │ (optional)
+              │ App-Owner  │  │  pingt Heartbeat- │
+              │ Dashboard  │  │  URL bei "UP"     │
+              └────────────┘  └─────────┬─────────┘
+                                         ▼
+                              ┌────────────────────┐
+                              │      OneUptime      │
+                              │ öffentliche Status- │
+                              │ page für Endnutzer  │
+                              └────────────────────┘
+```
+
+Prometheus probt selbst - OneUptime bekommt nur das Ergebnis gemeldet
+(Heartbeat-Pattern), damit es nur eine Quelle der Wahrheit gibt und beide
+Ansichten (Grafana intern, OneUptime öffentlich) konsistent bleiben.
+
+## Setup
+
+```bash
+cd demo-cert-monitoring
+cp .env.example .env
+```
+
+In `.env` die **2-3 Demo-URLs** setzen:
+
+```dotenv
+DEMO_TARGET_URLS=https://www.google.com,https://www.github.com,https://www.wikipedia.org
+```
+
+Stack starten:
+
+```bash
+docker compose up -d
+```
+
+## Zugriff
+
+| Dienst | URL | Hinweis |
+|---|---|---|
+| Grafana (App-Owner) | http://localhost:3000 | Login `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` aus `.env`; Dashboard **"Website & Zertifikats-Monitoring (App-Owner)"** ist bereits provisioniert |
+| Prometheus | http://localhost:9090 | Rohdaten, Targets (`/targets`), Alert-Regeln (`/alerts`) |
+| blackbox_exporter | http://localhost:9115 | Debug: `/probe?target=https://...&module=http_2xx` |
+
+Das Grafana-Dashboard zeigt: Anzahl erreichbarer Websites, kürzeste
+verbleibende Zertifikatslaufzeit, eine Statustabelle je URL sowie
+Zeitreihen für Antwortzeit und Zertifikats-Countdown (Ampel-Schwellen bei
+30/14/3 Tagen).
+
+Zwei Alert-Regeln (`WebsiteDown`, `CertificateExpiringSoon` /
+`-Critical`) sind in Prometheus hinterlegt und in `/alerts` sichtbar - für
+die Demo ist **kein Alertmanager** verkabelt (keine E-Mail/Slack-Zustellung),
+das wäre der nächste Ausbauschritt für einen Produktiveinsatz.
+
+## OneUptime-Anbindung (öffentliche Statuspage)
+
+Der `oneuptime-sync`-Dienst ist optional und macht bei leerem
+`ONEUPTIME_HEARTBEAT_URLS` nichts (Prometheus + Grafana laufen trotzdem
+vollständig). Für die volle Demo:
+
+1. OneUptime-Konto anlegen (Cloud-Trial unter https://oneuptime.com oder
+   selbst gehostet - der offizielle Self-Hosted-Stack ist mit ~15
+   Diensten (Postgres, Redis, ClickHouse, ...) deutlich schwerer als dieser
+   Demo-Stack und deshalb hier bewusst **nicht** eingebettet).
+2. Pro Ziel-URL einen Monitor vom Typ **"Incoming Request" / "Heartbeat"**
+   anlegen. OneUptime generiert dafür eine eindeutige URL.
+3. Diese Monitore zu einer öffentlichen **Status Page** in OneUptime
+   hinzufügen.
+4. Die generierten Heartbeat-URLs in `.env` eintragen - **Reihenfolge muss
+   zu `DEMO_TARGET_URLS` passen**:
+
+   ```dotenv
+   DEMO_TARGET_URLS=https://a.example.com,https://b.example.com
+   ONEUPTIME_HEARTBEAT_URLS=https://oneuptime.example.com/heartbeat/xxx,https://oneuptime.example.com/heartbeat/yyy
+   ```
+
+5. Stack neu starten (`docker compose up -d`). Solange Prometheus für eine
+   URL `probe_success == 1` misst, pingt `oneuptime-sync` die zugehörige
+   Heartbeat-URL alle `SYNC_INTERVAL_SECONDS` (Default 60s). Bleibt der
+   Ping aus, markiert OneUptime den Monitor nach seiner eigenen
+   Kulanzzeit als "down" - dort konfigurierbar.
+
+## Aufräumen
+
+```bash
+docker compose down -v
+```
+
+## Warum getrennt vom Haupt-Repo-Code?
+
+Dieser Ordner ist bewusst isoliert (eigenes Compose-File, eigenes `.env`,
+kein Bezug zu `app/`, `Dockerfile`, `pyproject.toml` oder den
+GitHub-Actions-Workflows der M365-Statuspage). Er demonstriert einen
+anderen Anwendungsfall (generisches Website-/Zertifikats-Monitoring) mit
+einem anderen Technologie-Stack (Prometheus/Grafana/OneUptime statt
+FastAPI + Microsoft Graph API) und soll die Haupt-App nicht aufblähen oder
+deren CI/Build beeinflussen.

--- a/demo-cert-monitoring/blackbox/blackbox.yml
+++ b/demo-cert-monitoring/blackbox/blackbox.yml
@@ -1,0 +1,11 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      method: GET
+      preferred_ip_protocol: "ip4"
+      follow_redirects: true
+      tls_config:
+        insecure_skip_verify: false

--- a/demo-cert-monitoring/docker-compose.yml
+++ b/demo-cert-monitoring/docker-compose.yml
@@ -1,0 +1,87 @@
+# Eigenständiger Demo-Stack: Zertifikats- & Verfügbarkeits-Monitoring.
+#
+# - Prometheus + blackbox_exporter: probt DEMO_TARGET_URLS (HTTP-Check +
+#   TLS-Zertifikats-Ablauf) und ist die einzige Quelle der Wahrheit.
+# - Grafana: technisches Dashboard für App-Owner (Response-Time,
+#   Zertifikats-Countdown, Alarm-Schwellen).
+# - oneuptime-sync: optionaler Brückendienst, der Prometheus-Ergebnisse an
+#   OneUptime-Heartbeat-Monitore meldet, damit die öffentliche Statuspage
+#   für Endnutzer denselben Stand zeigt. Ohne ONEUPTIME_HEARTBEAT_URLS in
+#   .env läuft er einfach nicht mit.
+#
+# Unabhängig vom Haupt-docker-compose.yml der M365-Statuspage-App -
+# separat starten mit: docker compose -f demo-cert-monitoring/docker-compose.yml up -d
+
+services:
+  target-init:
+    image: alpine:3.20
+    container_name: cert-demo-target-init
+    env_file:
+      - .env
+    volumes:
+      - ./scripts/gen-targets.sh:/gen-targets.sh:ro
+      - prometheus_targets:/etc/prometheus/targets
+    entrypoint: ["sh", "/gen-targets.sh"]
+    restart: "no"
+
+  blackbox_exporter:
+    image: prom/blackbox-exporter:v0.25.0
+    container_name: cert-demo-blackbox-exporter
+    restart: unless-stopped
+    volumes:
+      - ./blackbox/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    ports:
+      - "${BLACKBOX_EXPORTER_PORT:-9115}:9115"
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: cert-demo-prometheus
+    restart: unless-stopped
+    depends_on:
+      target-init:
+        condition: service_completed_successfully
+      blackbox_exporter:
+        condition: service_started
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+      - prometheus_targets:/etc/prometheus/targets:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+
+  grafana:
+    image: grafana/grafana:11.3.1
+    container_name: cert-demo-grafana
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+
+  oneuptime-sync:
+    image: alpine:3.20
+    container_name: cert-demo-oneuptime-sync
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    env_file:
+      - .env
+    environment:
+      PROM_URL: http://prometheus:9090
+    volumes:
+      - ./scripts/oneuptime-sync.sh:/oneuptime-sync.sh:ro
+    entrypoint: ["sh", "/oneuptime-sync.sh"]
+
+volumes:
+  prometheus_targets:
+  prometheus_data:
+  grafana_data:

--- a/demo-cert-monitoring/grafana/dashboards/website-cert-monitoring.json
+++ b/demo-cert-monitoring/grafana/dashboards/website-cert-monitoring.json
@@ -1,0 +1,231 @@
+{
+  "title": "Website & Zertifikats-Monitoring (App-Owner)",
+  "uid": "website-cert-monitoring",
+  "timezone": "browser",
+  "editable": true,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "schemaVersion": 39,
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Websites erreichbar",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(probe_success{job=\"website_probes\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value_and_name"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Überwachte Websites",
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "count(probe_success{job=\"website_probes\"})",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value_and_name"
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Kürzeste verbleibende Zertifikatslaufzeit (Tage)",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "min((probe_ssl_earliest_cert_expiry{job=\"website_probes\"} - time()) / 86400)",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3 },
+              { "color": "yellow", "value": 14 },
+              { "color": "green", "value": 30 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "textMode": "value_and_name"
+      }
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Status je Website",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "probe_success{job=\"website_probes\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "A"
+        },
+        {
+          "expr": "(probe_ssl_earliest_cert_expiry{job=\"website_probes\"} - time()) / 86400",
+          "instant": true,
+          "format": "table",
+          "refId": "B"
+        },
+        {
+          "expr": "probe_duration_seconds{job=\"website_probes\"}",
+          "instant": true,
+          "format": "table",
+          "refId": "C"
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true
+            },
+            "renameByName": {
+              "instance": "Website",
+              "Value #A": "Erreichbar (1=ja/0=nein)",
+              "Value #B": "Zertifikat läuft ab in (Tage)",
+              "Value #C": "Antwortzeit (s)"
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Erreichbar (1=ja/0=nein)" },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "green", "value": 1 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Zertifikat läuft ab in (Tage)" },
+            "properties": [
+              { "id": "unit", "value": "d" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "red", "value": null },
+                    { "color": "orange", "value": 3 },
+                    { "color": "yellow", "value": 14 },
+                    { "color": "green", "value": 30 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Antwortzeit je Website",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds{job=\"website_probes\"}",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Verbleibende Zertifikatslaufzeit je Website",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "(probe_ssl_earliest_cert_expiry{job=\"website_probes\"} - time()) / 86400",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "d",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 3 },
+              { "color": "yellow", "value": 14 },
+              { "color": "green", "value": 30 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "thresholdsStyle": { "mode": "line" }
+      }
+    }
+  ]
+}

--- a/demo-cert-monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/demo-cert-monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "Website & Cert Monitoring"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/demo-cert-monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/demo-cert-monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/demo-cert-monitoring/prometheus/alert_rules.yml
+++ b/demo-cert-monitoring/prometheus/alert_rules.yml
@@ -1,0 +1,29 @@
+groups:
+  - name: website-and-certificate-alerts
+    rules:
+      - alert: WebsiteDown
+        expr: probe_success{job="website_probes"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.instance }} ist nicht erreichbar"
+          description: "Der HTTP(S)-Check für {{ $labels.instance }} schlägt seit mehr als 2 Minuten fehl."
+
+      - alert: CertificateExpiringSoon
+        expr: (probe_ssl_earliest_cert_expiry{job="website_probes"} - time()) / 86400 < 14
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "TLS-Zertifikat für {{ $labels.instance }} läuft bald ab"
+          description: "Das Zertifikat für {{ $labels.instance }} läuft in weniger als 14 Tagen ab."
+
+      - alert: CertificateExpiringCritical
+        expr: (probe_ssl_earliest_cert_expiry{job="website_probes"} - time()) / 86400 < 3
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "TLS-Zertifikat für {{ $labels.instance }} läuft in Kürze ab"
+          description: "Das Zertifikat für {{ $labels.instance }} läuft in weniger als 3 Tagen ab."

--- a/demo-cert-monitoring/prometheus/prometheus.yml
+++ b/demo-cert-monitoring/prometheus/prometheus.yml
@@ -1,0 +1,33 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "blackbox_exporter"
+    static_configs:
+      - targets: ["blackbox_exporter:9115"]
+
+  # Website-Erreichbarkeit + TLS-Zertifikatsprüfung (http_2xx-Modul liefert
+  # bei HTTPS-Zielen automatisch probe_ssl_earliest_cert_expiry mit).
+  - job_name: "website_probes"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/http_targets.json
+        refresh_interval: 30s
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox_exporter:9115

--- a/demo-cert-monitoring/scripts/gen-targets.sh
+++ b/demo-cert-monitoring/scripts/gen-targets.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Generates a Prometheus file_sd target list from the DEMO_TARGET_URLS
+# env var (comma-separated). Runs once at stack startup as an init
+# container; Prometheus picks up the resulting file via file_sd_configs.
+set -eu
+
+OUT_DIR=/etc/prometheus/targets
+OUT_FILE="$OUT_DIR/http_targets.json"
+mkdir -p "$OUT_DIR"
+
+urls="${DEMO_TARGET_URLS:-}"
+if [ -z "$urls" ]; then
+  echo "ERROR: DEMO_TARGET_URLS is empty. Set 2-3 URLs in .env, e.g.:" >&2
+  echo '  DEMO_TARGET_URLS=https://a.example.com,https://b.example.com' >&2
+  exit 1
+fi
+
+json_targets=""
+old_ifs="$IFS"
+IFS=','
+for u in $urls; do
+  IFS="$old_ifs"
+  u=$(echo "$u" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [ -z "$u" ] && continue
+  if [ -z "$json_targets" ]; then
+    json_targets="\"$u\""
+  else
+    json_targets="$json_targets, \"$u\""
+  fi
+  IFS=','
+done
+IFS="$old_ifs"
+
+cat > "$OUT_FILE" <<EOF
+[
+  {
+    "targets": [$json_targets]
+  }
+]
+EOF
+
+echo "Generated $OUT_FILE:"
+cat "$OUT_FILE"

--- a/demo-cert-monitoring/scripts/oneuptime-sync.sh
+++ b/demo-cert-monitoring/scripts/oneuptime-sync.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Bridges Prometheus (internal probes) to OneUptime (public status page).
+#
+# For every target in DEMO_TARGET_URLS with a matching entry (by position)
+# in ONEUPTIME_HEARTBEAT_URLS, this loop asks Prometheus whether the last
+# blackbox probe succeeded. If yes, it pings the OneUptime "Incoming
+# Request" / "Heartbeat" monitor URL, which OneUptime uses to derive
+# up/down state on the public status page.
+#
+# This keeps Prometheus/Grafana as the single source of truth: OneUptime
+# never probes the targets itself, it just reflects what Prometheus saw.
+#
+# If ONEUPTIME_HEARTBEAT_URLS is empty, the loop logs that and exits 0 -
+# the rest of the demo (Prometheus + Grafana) works fine without it.
+set -eu
+
+PROM_URL="${PROM_URL:-http://prometheus:9090}"
+INTERVAL="${SYNC_INTERVAL_SECONDS:-60}"
+TARGETS="${DEMO_TARGET_URLS:-}"
+HEARTBEATS="${ONEUPTIME_HEARTBEAT_URLS:-}"
+
+if [ -z "$HEARTBEATS" ]; then
+  echo "[oneuptime-sync] ONEUPTIME_HEARTBEAT_URLS not set - nothing to sync, exiting."
+  echo "[oneuptime-sync] Prometheus/Grafana keep monitoring regardless."
+  exit 0
+fi
+
+echo "[oneuptime-sync] installing curl + jq..."
+apk add --no-cache curl jq >/dev/null
+
+echo "[oneuptime-sync] starting sync loop, interval=${INTERVAL}s, prometheus=${PROM_URL}"
+
+while true; do
+  idx=0
+  echo "$TARGETS" | tr ',' '\n' | while read -r target; do
+    idx=$((idx + 1))
+    target=$(echo "$target" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ -z "$target" ] && continue
+
+    heartbeat=$(echo "$HEARTBEATS" | cut -d',' -f"$idx")
+    heartbeat=$(echo "$heartbeat" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+    if [ -z "$heartbeat" ]; then
+      echo "[oneuptime-sync] no heartbeat URL configured for target #$idx ($target), skipping"
+      continue
+    fi
+
+    success=$(curl -s --max-time 5 "$PROM_URL/api/v1/query" \
+      --data-urlencode "query=probe_success{instance=\"$target\"}" \
+      | jq -r '.data.result[0].value[1] // "0"' 2>/dev/null || echo "0")
+
+    if [ "$success" = "1" ]; then
+      echo "[oneuptime-sync] $target UP -> pinging OneUptime heartbeat"
+      curl -s -o /dev/null --max-time 5 "$heartbeat" \
+        || echo "[oneuptime-sync] WARN: heartbeat ping failed for $target"
+    else
+      echo "[oneuptime-sync] $target DOWN or unknown -> not pinging (OneUptime marks it down after its own grace period)"
+    fi
+  done
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary

- Adds a standalone demo stack under `demo-cert-monitoring/` showing how TLS certificate expiry and website availability can be monitored and surfaced to two different audiences: app owners (technical Grafana dashboard) and end users (public OneUptime status page).
- Stack: **Prometheus + blackbox_exporter** probe up to 2-3 demo URLs (configured via a single `DEMO_TARGET_URLS` env var) for HTTP(S) availability and TLS cert expiry; **Grafana** is auto-provisioned with a dashboard (up/down status, response time, cert-expiry countdown with 30/14/3-day thresholds); an optional `oneuptime-sync` sidecar pings OneUptime "Incoming Request"/Heartbeat monitor URLs whenever Prometheus reports a target as up, so the public status page reflects the same source of truth without duplicating probing logic.
- Fully isolated from the M365 status page app: its own `docker-compose.yml`, its own `.env` (git-ignored, `.env.example` provided), no changes to `app/`, the root `Dockerfile`/`docker-compose.yml`, `pyproject.toml`, or any GitHub Actions workflow — this repo's CI/build is unaffected.
- Added a short "related" section (with link) to both `README.md` and `README.en.md` pointing at the new demo folder.

## Details

- `demo-cert-monitoring/scripts/gen-targets.sh` turns the comma-separated `DEMO_TARGET_URLS` into a Prometheus `file_sd_configs` target file at container startup (no need to hand-edit `prometheus.yml` per demo).
- `demo-cert-monitoring/scripts/oneuptime-sync.sh` is a no-op (exits cleanly) when `ONEUPTIME_HEARTBEAT_URLS` is unset, so the Prometheus/Grafana half of the demo works standalone without requiring a OneUptime account.
- Two example Prometheus alert rules (`WebsiteDown`, `CertificateExpiringSoon`/`-Critical`) are included and visible in the Prometheus UI; no Alertmanager is wired up (documented as a follow-up for a real deployment, out of scope for this demo).
- README documents architecture, setup, and the OneUptime heartbeat-monitor connection steps.

## Test plan

- [x] Validated all YAML/JSON config files parse correctly (`yaml.safe_load` / `json.load`)
- [x] `sh -n` syntax check on both shell scripts
- [x] `docker compose config` successfully resolves the full stack (no Docker daemon available in this sandbox to do a live `up`, so runtime verification of container startup ordering/health should be done by a reviewer with Docker access)
- [x] Confirmed `demo-cert-monitoring/.env` is covered by the repo's existing root `.gitignore` `.env` pattern
- [ ] Live `docker compose up -d` smoke test against real demo URLs and a real OneUptime heartbeat monitor (not done here — no Docker daemon / no OneUptime account in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrshEuG9tj8aN8uRRtJmcn)_