### PR TITLE
Demo: live-triggerable printer-maintenance process (#148)

### DIFF
--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -225,6 +225,27 @@ getrennt statt eine Seite mit allem):
    (nutzerorientiert: was/wann/Alternative/Kontakt) und **abgeschlossen:**
    "Wartung Netzwerk-Switches (Rechenzentrum Leipzig)".
 
+   **Live auslösbarer Druckerwartungs-Prozess (#148):** Neben der
+   statischen "nächsten Freitag"-Wartung oben zeigt `./break-printer.sh`
+   den kompletten Prozess auf Knopfdruck: Drucker meldet eine Störung →
+   die IT terminiert kurzfristig eine Wartung ("Kurzfristige Wartung –
+   Drucker (Hauptgebäude)", 2 Stunden Vorlauf) → die Standort-Leipzig-
+   Statusseite zeigt sie sofort an. Der Monitor `Drucker (Hauptgebäude)`
+   bleibt dabei bewusst **Operational** - eine Scheduled Maintenance
+   kündigt eine Auswirkung nur an, sie erzeugt selbst keine; der Drucker
+   ist also bis zum Beginn der Wartung nicht eingeschränkt. `./fix-printer.sh`
+   setzt die Wartung auf "Completed" und reiht sie damit neben "Wartung
+   Netzwerk-Switches" als weiteren abgeschlossenen Eintrag ein. Eigener,
+   separat benannter Eintrag statt Wiederverwendung der statischen
+   Freitags-Wartung - gleiches Prinzip wie das live auslösbare vierte
+   Sicherheitsereignis oben, das ebenfalls neben statischen Einträgen
+   steht statt sie zu überschreiben (`scripts/printer_maintenance.py`,
+   kein Import von `seed_oneuptime.py`, siehe dortige Begründung). Auch im
+   Demo-Kontrollzentrum (`./control-panel.sh`) als Karte "Druckerwartung
+   (Prozess)" auslösbar, inkl. Link zu den Benachrichtigungs-Mockups, in
+   denen sich die Statuspage-Info für Mitarbeitende manuell durchklicken
+   lässt.
+
 **Alle Termine werden bei jedem Lauf neu relativ zu "heute" berechnet**
 (Patchday 3 läuft immer gerade jetzt, abgeschlossene Wartungen liegen
 immer 6-10 Tage in der Vergangenheit, die Druckerwartung immer am

--- a/demo-cert-monitoring/break-printer.sh
+++ b/demo-cert-monitoring/break-printer.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Triggers the printer-maintenance-process demo scenario (#148), live:
+# OneUptime gets a new Scheduled Maintenance "Kurzfristige Wartung -
+# Drucker (Hauptgebäude)" on short notice, visible immediately on the
+# Standort-Leipzig status page - the process this demonstrates is
+# "Drucker meldet Störung -> Techniker stellt Wartung ein -> Mitarbeiter
+# bekommt durch Statuspage Info". The printer monitor itself is never
+# touched: it stays Operational throughout, showing that a Scheduled
+# Maintenance only announces upcoming impact, it doesn't itself cause one
+# - "Drucker ist bis zur Wartung nicht eingeschränkt".
+#
+# Complements (doesn't replace) the static "next Friday" printer
+# maintenance seed-oneuptime.sh always creates - same idea as the live
+# security-incident scenario sitting alongside its resolved historical
+# incidents (see break-security.sh): a distinct, separately named entry.
+#
+# Requires OneUptime to be up and already seeded (./seed-oneuptime.sh).
+# Run from demo-cert-monitoring/. Reverse with ./fix-printer.sh.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  echo "       Run: ./start-demo.sh --with-oneuptime && ./seed-oneuptime.sh" >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Triggering the printer-maintenance-process scenario ..."
+python3 scripts/printer_maintenance.py break
+
+echo ""
+echo "==> Done. Within a few seconds the Standort-Leipzig status page shows:"
+echo "      - New scheduled maintenance \"Kurzfristige Wartung - Drucker (Hauptgebäude)\""
+echo "      - \"Drucker (Hauptgebäude)\" stays Operational - no restriction yet"
+echo "    Standort Leipzig: $OU_BASE (see .oneuptime-demo-summary for the exact URL)"
+echo "    Complete the maintenance with: ./fix-printer.sh"

--- a/demo-cert-monitoring/fix-printer.sh
+++ b/demo-cert-monitoring/fix-printer.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Reverses break-printer.sh: sets "Kurzfristige Wartung - Drucker
+# (Hauptgebäude)" to Completed, so it becomes another finished maintenance
+# entry on the Standort-Leipzig status page instead of an open one.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Completing the printer-maintenance-process scenario ..."
+python3 scripts/printer_maintenance.py fix
+
+echo ""
+echo "==> Done. \"Kurzfristige Wartung - Drucker (Hauptgebäude)\" is now Completed."

--- a/demo-cert-monitoring/scripts/control-panel.html
+++ b/demo-cert-monitoring/scripts/control-panel.html
@@ -155,10 +155,10 @@
     <h1>Demo-Kontrollzentrum</h1>
     <p>
       Startpunkt für die komplette Demo: alle Statusseiten, Dashboards und
-      Werkzeuge auf einen Blick, plus die drei Vorfall-Skripte live von
-      hier aus steuerbar - statt im Terminal. Status kommt live aus
-      Prometheus (der Wahrheitsquelle des Stacks). Läuft nur lokal
-      (127.0.0.1).
+      Werkzeuge auf einen Blick, plus alle Vorfall- und Prozess-Skripte
+      live von hier aus steuerbar - statt im Terminal. Status kommt live
+      aus Prometheus bzw. OneUptime (der jeweiligen Wahrheitsquelle).
+      Läuft nur lokal (127.0.0.1).
     </p>
   </header>
 
@@ -219,7 +219,7 @@
     </a>
   </div>
 
-  <div class="section-title">Vorfall-Szenarien</div>
+  <div class="section-title">Vorfall- &amp; Prozess-Szenarien</div>
   <div class="grid">
 
     <div class="card">
@@ -330,6 +330,36 @@
       </div>
     </div>
 
+    <div class="card">
+      <div class="card-head">
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#5b5fc7"/>
+          <rect x="12" y="10" width="24" height="10" rx="1.5" fill="none" stroke="#fff" stroke-width="2.2"/>
+          <rect x="10" y="20" width="28" height="14" rx="2" fill="none" stroke="#fff" stroke-width="2.2"/>
+          <rect x="16" y="30" width="16" height="9" fill="#fff"/>
+          <circle cx="32" cy="25" r="1.6" fill="#fff"/>
+        </svg>
+        <div>
+          <h2>Druckerwartung (Prozess)</h2>
+          <span class="status unknown" id="status-printer"><span class="dot"></span>wird geprüft…</span>
+        </div>
+      </div>
+      <p class="story">
+        <strong>Passiert:</strong> Drucker im Hauptgebäude meldet eine
+        Störung, die IT kündigt kurzfristig eine Wartung an.<br>
+        <strong>Zeigt:</strong> Meldung → Terminierung → Mitarbeiter-Info
+        per Statuspage - der Drucker bleibt bis zur Wartung selbst
+        uneingeschränkt nutzbar.
+      </p>
+      <div class="links">
+        <a href="http://localhost" target="_blank">OneUptime</a>
+        <a href="/mockups/index.html" target="_blank">Benachrichtigungs-Mockups</a>
+      </div>
+      <div class="actions">
+        <button class="btn-break" onclick="run('break-printer', 'printer')">Wartung ankündigen</button>
+        <button class="btn-fix" onclick="run('fix-printer', 'printer')">Abschließen</button>
+      </div>
+    </div>
+
   </div>
 
   <div class="log-section">
@@ -374,7 +404,7 @@
       try {
         const res = await fetch("/api/status");
         const data = await res.json();
-        for (const key of ["demo", "docuware", "customer-care", "security"]) {
+        for (const key of ["demo", "docuware", "customer-care", "security", "printer"]) {
           const el = document.getElementById("status-" + key);
           const state = data[key] || "unknown";
           el.className = "status " + state;

--- a/demo-cert-monitoring/scripts/control_panel_server.py
+++ b/demo-cert-monitoring/scripts/control_panel_server.py
@@ -43,6 +43,8 @@ ACTIONS = {
     "fix-customer-care": ("fix-customer-care.sh", "Customer-Care-Vorfall beheben"),
     "break-security": ("break-security.sh", "Sicherheits-Vorfall auslösen"),
     "fix-security": ("fix-security.sh", "Sicherheits-Vorfall beheben"),
+    "break-printer": ("break-printer.sh", "Druckerwartung ankündigen"),
+    "fix-printer": ("fix-printer.sh", "Druckerwartung abschließen"),
 }
 
 
@@ -141,11 +143,58 @@ def get_security_state():
         return "unknown"
 
 
+def get_printer_state():
+    """healthy/unhealthy/unknown for the printer-maintenance-process
+    scenario (#148) - like the security scenario, this one lives in
+    OneUptime (a Scheduled Maintenance, no metric backs it): "unhealthy"
+    means the live-triggered "Kurzfristige Wartung" entry is currently
+    announced (not yet Completed), "healthy" means none is open right
+    now. Deliberately not about the printer's own monitor status - that
+    one is never touched by this scenario, see break-printer.sh."""
+    global _ou_token
+    try:
+        if not _ou_token and not _ou_login():
+            return "unknown"
+        req = urllib.request.Request(
+            f"{OU_BASE}/api/scheduled-maintenance/get-list", method="POST",
+            data=json.dumps({
+                "query": {}, "select": {
+                    "title": True,
+                    "currentScheduledMaintenanceState": {"isResolvedState": True},
+                },
+                "sort": {}, "skip": 0, "limit": 100,
+            }).encode())
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Authorization", f"Bearer {_ou_token}")
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                body = json.load(resp)
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                _ou_token = None  # token expired/invalid - retry once with a fresh login
+                if not _ou_login():
+                    return "unknown"
+                req.add_header("Authorization", f"Bearer {_ou_token}")
+                with urllib.request.urlopen(req, timeout=5) as resp:
+                    body = json.load(resp)
+            else:
+                raise
+        for m in body.get("data", []):
+            if m.get("title") == "Kurzfristige Wartung – Drucker (Hauptgebäude)":
+                resolved = (m.get("currentScheduledMaintenanceState") or {}).get("isResolvedState", True)
+                return "unhealthy" if not resolved else "healthy"
+        return "healthy"
+    except (urllib.error.URLError, ValueError, KeyError, TimeoutError):
+        return "unknown"
+
+
 def get_status():
     """healthy/unhealthy/unknown per scenario, read live from Prometheus -
     no separate state file invented here, Prometheus already is the
     stack's single source of truth (see docker-compose.yml header).
-    The security scenario is the one exception (see get_security_state())."""
+    The security and printer scenarios are the exceptions (see
+    get_security_state()/get_printer_state()) - both live in OneUptime,
+    not Prometheus."""
     cert_days = prom_query('(probe_ssl_earliest_cert_expiry{demo_fixture="true"} - time()) / 86400')
     docuware_node2 = prom_query('docuware_mssql_cluster_node_up{node="db2"}')
     cc_chemnitz = prom_query('cc_site_vpn_up{site="Chemnitz"}')
@@ -160,6 +209,7 @@ def get_status():
         "docuware": state(docuware_node2, lambda v: v >= 1),
         "customer-care": state(cc_chemnitz, lambda v: v >= 1),
         "security": get_security_state(),
+        "printer": get_printer_state(),
     }
 
 

--- a/demo-cert-monitoring/scripts/printer_maintenance.py
+++ b/demo-cert-monitoring/scripts/printer_maintenance.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Live break/fix for the printer-maintenance-process demo scenario (#148).
+
+Standalone (unlike seed_oneuptime.py, which runs its whole seed flow at
+import time and isn't safe to import as a library) - this only touches
+one Scheduled Maintenance entry it owns, on the already-seeded printer
+monitor and Leipzig status page, so ./seed-oneuptime.sh must have run at
+least once before this works.
+
+Story this demonstrates (issue #148): "Drucker meldet Störung" - a fault
+gets reported - "Techniker stellt Wartung ein" - IT reacts by scheduling
+a maintenance window on short notice - "Mitarbeiter bekommt durch
+Statuspage Info" - the Leipzig status page shows it immediately.
+Crucially, the printer monitor itself is never touched here: it stays
+Operational throughout, exactly what "Drucker ist bis zur Wartung nicht
+eingeschränkt" (not restricted until the maintenance) means - Scheduled
+Maintenance only announces upcoming impact, it does not itself set an
+outage. This complements (not replaces) the static "next Friday"
+printer-maintenance entry seed_oneuptime.py always creates - same
+pattern as the live security-incident scenario sitting alongside three
+already-resolved historical incidents (see security_incident.py):
+a distinct, separately named entry so the live-triggered story never
+collides with or overwrites the routine one.
+
+Usage: python3 printer_maintenance.py break|fix
+Invoked by ../break-printer.sh / ../fix-printer.sh, which set OU_BASE.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+BASE = os.environ["OU_BASE"]
+EMAIL = os.environ.get("OU_EMAIL", "demo@example.com")
+PASSWORD = os.environ.get("OU_PASSWORD", "DemoDemo123!")
+PROJECT_NAME = os.environ.get("OU_PROJECT", "Zertifikats-Monitoring Demo")
+
+PRINTER_MONITOR_NAME = "Drucker (Hauptgebäude)"
+LEIPZIG_PAGE_NAME = "Statusseite Standort Leipzig"
+MAINTENANCE_TITLE = "Kurzfristige Wartung – Drucker (Hauptgebäude)"
+
+token = None
+project_id = None
+
+
+def call(path, payload, method="POST"):
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(payload).encode() if payload is not None else None,
+        method=method,
+    )
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if project_id:
+        req.add_header("ProjectID", project_id)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        sys.exit(f"ERROR: {path} -> HTTP {exc.code}: {exc.read().decode()[:300]}")
+    parsed = json.loads(body) if body else {}
+    if isinstance(parsed, dict) and "error" in parsed:
+        sys.exit(f"ERROR: {path} -> {parsed['error']}")
+    return parsed
+
+
+def typed(t, v):
+    return {"_type": t, "value": v}
+
+
+def entity_ref(obj_id):
+    return {"_id": obj_id}
+
+
+def iso(dt):
+    # Same conversion as seed_oneuptime.py's iso(): ScheduledMaintenance's
+    # Date/DateTime columns take a plain ISO string, and every `dt` built
+    # here is a naive local-time value that must go through the local
+    # tzinfo before formatting as UTC - see seed_oneuptime.py for the bug
+    # this avoids (dates landing hours in the future otherwise).
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def get_list(model, query=None, select=None, limit=100):
+    return call(f"/api/{model}/get-list", {
+        "query": query or {}, "select": select or {"_id": True, "name": True},
+        "sort": {}, "skip": 0, "limit": limit,
+    }).get("data", [])
+
+
+def find_by_name(model, name, select=None, name_field="name"):
+    for row in get_list(model, select=select or {"_id": True, name_field: True}):
+        if row.get(name_field) == name:
+            return row
+    return None
+
+
+login = call("/api/identity/login", {"data": {
+    "email": typed("Email", EMAIL), "password": typed("HashedString", PASSWORD),
+}})
+token = login.get("_miscData", {}).get("accessToken")
+if not token:
+    sys.exit(f"ERROR: login for {EMAIL} failed - has ./seed-oneuptime.sh run yet?")
+
+project = find_by_name("project", PROJECT_NAME)
+if not project:
+    sys.exit(f"ERROR: project '{PROJECT_NAME}' not found - run ./seed-oneuptime.sh first.")
+project_id = project["_id"]
+
+printer_monitor = find_by_name("monitor", PRINTER_MONITOR_NAME)
+if not printer_monitor:
+    sys.exit(f"ERROR: monitor '{PRINTER_MONITOR_NAME}' not found - run ./seed-oneuptime.sh first.")
+printer_monitor_id = printer_monitor["_id"]
+
+leipzig_page = find_by_name("status-page", LEIPZIG_PAGE_NAME)
+if not leipzig_page:
+    sys.exit(f"ERROR: status page '{LEIPZIG_PAGE_NAME}' not found - run ./seed-oneuptime.sh first.")
+leipzig_page_id = leipzig_page["_id"]
+
+sm_states = get_list("scheduled-maintenance-state", select={
+    "_id": True, "name": True, "isScheduledState": True, "isResolvedState": True})
+scheduled_state_id = next(s["_id"] for s in sm_states if s.get("isScheduledState"))
+resolved_state_id = next(s["_id"] for s in sm_states if s.get("isResolvedState"))
+
+mode = sys.argv[1] if len(sys.argv) > 1 else ""
+if mode == "break":
+    now = datetime.now()
+    starts_at = now + timedelta(hours=2)
+    ends_at = starts_at + timedelta(hours=3)
+
+    description = (
+        "Der Drucker im Hauptgebäude hat eine Störung gemeldet. Die IT hat "
+        "daraufhin kurzfristig ein Wartungsfenster eingeplant: "
+        f"{starts_at.strftime('%H:%M')}–{ends_at.strftime('%H:%M')} Uhr. "
+        "**Der Drucker funktioniert bis zum Beginn der Wartung ganz normal "
+        "weiter** - erst während des Wartungsfensters bitte auf den "
+        "Drucker im 2. OG (Raum 214) oder den Farbdrucker in der "
+        "Teeküche ausweichen. Bei dringenden Druckaufträgen wendet euch "
+        "an den IT-Helpdesk (Ext. 4242)."
+    )
+
+    # Same forward-only state-transition rule as incidents (see
+    # security_incident.py) applies here too - a Resolved entry can't move
+    # back to Scheduled via PUT, so a stale one from a previous run gets
+    # deleted and recreated instead, same as that script's incident retrigger.
+    existing = find_by_name(
+        "scheduled-maintenance", MAINTENANCE_TITLE, name_field="title",
+        select={"_id": True, "title": True,
+                "currentScheduledMaintenanceState": {"isResolvedState": True}})
+    if existing and (existing.get("currentScheduledMaintenanceState") or {}).get("isResolvedState"):
+        call(f"/api/scheduled-maintenance/{existing['_id']}", None, method="DELETE")
+        existing = None
+
+    payload = {
+        "title": MAINTENANCE_TITLE, "description": description,
+        "startsAt": iso(starts_at), "endsAt": iso(ends_at),
+        "monitors": [entity_ref(printer_monitor_id)],
+        "statusPages": [entity_ref(leipzig_page_id)],
+        "shouldStatusPageSubscribersBeNotifiedOnEventCreated": True,
+    }
+    if existing:
+        payload["currentScheduledMaintenanceStateId"] = scheduled_state_id
+        call(f"/api/scheduled-maintenance/{existing['_id']}", {"data": payload}, method="PUT")
+    else:
+        payload["currentScheduledMaintenanceStateId"] = scheduled_state_id
+        payload["projectId"] = project_id
+        call("/api/scheduled-maintenance", {"data": payload})
+
+    print(f"==> '{MAINTENANCE_TITLE}' ist jetzt angekündigt (Status: Scheduled).")
+    print(f"    Fenster: {starts_at.strftime('%d.%m. %H:%M')}–{ends_at.strftime('%H:%M')} Uhr.")
+    print(f"    Monitor '{PRINTER_MONITOR_NAME}' bleibt Operational - keine Einschränkung bislang.")
+
+elif mode == "fix":
+    maintenance = find_by_name("scheduled-maintenance", MAINTENANCE_TITLE, name_field="title")
+    if not maintenance:
+        sys.exit(f"ERROR: '{MAINTENANCE_TITLE}' not found - run './printer_maintenance.py break' first.")
+
+    call(f"/api/scheduled-maintenance/{maintenance['_id']}", {"data": {
+        "currentScheduledMaintenanceStateId": resolved_state_id,
+    }}, method="PUT")
+
+    print(f"==> '{MAINTENANCE_TITLE}' ist jetzt abgeschlossen (Status: Completed).")
+
+else:
+    sys.exit("Usage: printer_maintenance.py break|fix")


### PR DESCRIPTION
## Summary

Closes #148. Adds a live-triggerable demo of the printer-maintenance
process described in the issue: **Drucker meldet Störung → Techniker
stellt Wartung ein → Mitarbeiter bekommt durch Statuspage Info**, with
the printer explicitly **not restricted until the maintenance** actually
starts.

- `demo-cert-monitoring/scripts/printer_maintenance.py` (break/fix) –
  standalone script (same pattern as `security_incident.py`) that
  creates/updates a new, separately named Scheduled Maintenance
  ("Kurzfristige Wartung – Drucker (Hauptgebäude)", 2h notice) on
  OneUptime's already-seeded printer monitor and Standort-Leipzig status
  page, and completes it again on `fix`. It never touches the printer
  monitor's own status — a Scheduled Maintenance only announces upcoming
  impact, it doesn't cause one, which is exactly the point the issue asks
  to demonstrate.
- `break-printer.sh` / `fix-printer.sh` – wrapper scripts, same shape as
  the existing `break-security.sh` / `fix-security.sh`.
- Wired into the demo control panel
  (`demo-cert-monitoring/scripts/control_panel_server.py` +
  `control-panel.html`): a new "Druckerwartung (Prozess)" card with its
  own live status polling, so it can be clicked through manually during a
  demo exactly as the issue asks ("kann durch Demo Übersicht
  durchgeleitet werden ... manuell Klick").
- Documented in `demo-cert-monitoring/README.md` next to the existing
  static "next Friday" printer maintenance it complements (same
  precedent as the live security-incident scenario sitting alongside its
  resolved historical incidents).

This complements, and deliberately does not replace, the existing static
printer-maintenance entry that `seed_oneuptime.py` always creates for
"next Friday" — the new entry is separately named so the live-triggered
story never collides with or overwrites the routine one.

## Test plan

- [x] `python3 -m py_compile` on `printer_maintenance.py` and
      `control_panel_server.py` — passes.
- [x] `sh -n` on `break-printer.sh` / `fix-printer.sh` — passes.
- [ ] Not verified end-to-end against a running OneUptime instance in
      this session (the self-hosted stack takes a while to boot per its
      own README). To verify: `./start-demo.sh --with-oneuptime &&
      ./seed-oneuptime.sh && ./break-printer.sh` — expect the new
      "Kurzfristige Wartung – Drucker (Hauptgebäude)" entry to appear on
      the Standort-Leipzig status page immediately, with
      `Drucker (Hauptgebäude)` still Operational; then `./fix-printer.sh`
      to complete it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnPKEJEq6XeyPzze5P3BQM)_