### PR TITLE
Azure client-secret rotation via OpenBao

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,24 @@ AZURE_CLIENT_ID=your-app-client-id-here
 AZURE_CLIENT_SECRET=your-client-secret-here
 AZURE_REDIRECT_URI=https://statuspage.example.com/auth/callback
 
+# Optional: separate, höher privilegierte Credentials (Application.ReadWrite.All)
+# NUR für die Secret-Rotation über OpenBao (siehe unten) – die App selbst braucht
+# im Alltag nur ServiceHealth.Read.All. Leer lassen = AZURE_* oben wird auch für
+# die Rotation verwendet (nur sinnvoll, wenn diese eine App-Registrierung bewusst
+# beide Berechtigungen hat).
+AZURE_MGMT_TENANT_ID=
+AZURE_MGMT_CLIENT_ID=
+AZURE_MGMT_CLIENT_SECRET=
+
+# OpenBao – optionaler Speicher für AZURE_CLIENT_SECRET statt/zusätzlich zu .env.
+# Nur über VPN erreichbar, siehe app/azure_secret_manager.py bzw. den Button
+# "Aus OpenBao laden / rotieren" unter Admin → Einstellungen → Azure AD App.
+OPENBAO_ADDR=https://secrets-prod.pyur.com
+OPENBAO_SECRET_PATH=secret/data/m365-statuspage/azure-client-secret
+OPENBAO_TOKEN=
+OPENBAO_RENEWAL_THRESHOLD_DAYS=30
+OPENBAO_NEW_SECRET_LIFETIME_DAYS=180
+
 # Sicherheit – Session-Schlüssel.
 # Leer lassen: Beim ersten Start wird automatisch ein 32-Byte-Hex-String
 # generiert und unter data/secret_key persistiert (überlebt Neustarts).

--- a/README.en.md
+++ b/README.en.md
@@ -95,6 +95,37 @@ On first visit you will be redirected to Entra ID.
 
 ---
 
+## Client secret via OpenBao (optional)
+
+Instead of keeping `AZURE_CLIENT_SECRET` only in `.env`/the DB, the app can pull it from
+[OpenBao](https://openbao.org/) (Vault-API-compatible) and rotate it itself — Admin →
+Settings → Azure AD app → **"Load from OpenBao / rotate"**.
+
+**Flow** (`app/azure_secret_manager.py` + `app/openbao_client.py`):
+
+1. Read the secret from OpenBao (`OPENBAO_SECRET_PATH`, KV v2).
+2. Still valid (further than `OPENBAO_RENEWAL_THRESHOLD_DAYS` from expiry) and not forced ->
+   use it as-is, no Azure call at all.
+3. Missing / expiring soon / "Force rotation" checked -> **rotate**: create a new client
+   secret via Microsoft Graph (`addPassword` - Graph only ever returns a secret's plaintext
+   at that moment; an existing one can only be queried as metadata afterwards), store it in
+   OpenBao, then remove the previous secret from the app registration (`removePassword`).
+4. Either way, the result is saved under "Save Azure AD app" - `graph_client.py`, `auth.py`
+   and `notifications.py` keep reading it unchanged via `app_settings.get_azure_settings()`.
+
+**Test the renewal path** without waiting for a real expiry: tick "Force rotation" next to the
+sync button - rotates immediately regardless of the stored secret's remaining lifetime.
+
+**VPN required:** OpenBao is reachable over VPN only. If it's unreachable, the sync fails with
+an error message asking you to connect the VPN - just click the button again afterwards.
+
+**Permissions:** rotation needs a token with `Application.ReadWrite.All` on the app
+registration - more than the app needs day to day (`ServiceHealth.Read.All`). Set
+`AZURE_MGMT_TENANT_ID`/`_CLIENT_ID`/`_CLIENT_SECRET` to use a separate, narrower-scoped
+credential for that instead of permanently over-privileging the main app registration.
+
+---
+
 ## Admin authorization (app role)
 
 By default **every** authenticated tenant user can access `/admin` (legacy behaviour; a warning is logged at startup). For production, restrict the admin area via an **Entra ID app role** — conveniently driven by a security group:
@@ -130,6 +161,12 @@ Alternatively or in addition, set an email allowlist (`ADMIN_EMAILS`, OR-combine
 | `POLL_INTERVAL_MINUTES` | Polling interval in minutes | `10` |
 | `DEFAULT_LANGUAGE` | Fallback UI language when no cookie / Accept-Language match. Supported: `de`, `en` | `de` |
 | `DEBUG` | Enables `/api/docs` and verbose logging | `false` |
+| `AZURE_MGMT_TENANT_ID` / `_CLIENT_ID` / `_CLIENT_SECRET` | Separate credentials used ONLY for the OpenBao secret rotation (`Application.ReadWrite.All`) - empty = `AZURE_*` is also used for it | *(empty)* |
+| `OPENBAO_ADDR` | Base URL of the OpenBao server (VPN-only) | `https://secrets-prod.pyur.com` |
+| `OPENBAO_SECRET_PATH` | KV v2 path of the Azure client secret | `secret/data/m365-statuspage/azure-client-secret` |
+| `OPENBAO_TOKEN` | OpenBao token with read/write on the path above | *(empty)* |
+| `OPENBAO_RENEWAL_THRESHOLD_DAYS` | Rotate when the stored secret expires within this many days | `30` |
+| `OPENBAO_NEW_SECRET_LIFETIME_DAYS` | Lifetime given to a newly created secret | `180` |
 
 **Supported `MONITORED_SERVICES` values** (must match the Graph API names exactly):
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,40 @@ Beim ersten Aufruf wird man zu Entra ID weitergeleitet.
 
 ---
 
+## Client-Secret über OpenBao (optional)
+
+Statt `AZURE_CLIENT_SECRET` nur in `.env`/der DB zu pflegen, kann die App das Secret aus
+[OpenBao](https://openbao.org/) (Vault-API-kompatibel) holen und dort selbst rotieren –
+Admin → Einstellungen → Azure AD App → **„Aus OpenBao laden / rotieren"**.
+
+**Ablauf** (`app/azure_secret_manager.py` + `app/openbao_client.py`):
+
+1. Sekret aus OpenBao lesen (`OPENBAO_SECRET_PATH`, KV v2).
+2. Noch gültig (weiter als `OPENBAO_RENEWAL_THRESHOLD_DAYS` vom Ablauf entfernt) und kein
+   erzwungener Renew → direkt übernehmen, kein Azure-Zugriff nötig.
+3. Fehlt / läuft bald ab / „Rotation erzwingen" angehakt → **rotieren**: neues Client-Secret
+   über Microsoft Graph anlegen (`addPassword` – Graph gibt den Klartext eines Secrets nur in
+   diesem einen Moment zurück, ein bestehendes lässt sich danach nur noch als Metadaten
+   abfragen), in OpenBao ablegen, dann das alte Secret über die App-Registrierung entfernen
+   (`removePassword`).
+4. Das Ergebnis wird in beiden Fällen unter „Azure AD App speichern" abgelegt – `graph_client.py`,
+   `auth.py` und `notifications.py` lesen es unverändert über `app_settings.get_azure_settings()`.
+
+**Renewal testen**, ohne auf einen echten Ablauf zu warten: Checkbox „Rotation erzwingen" beim
+Sync-Button aktivieren – rotiert sofort unabhängig von der Restlaufzeit des gespeicherten Secrets.
+
+**VPN-Pflicht:** OpenBao ist nur über VPN erreichbar. Ist es nicht erreichbar, bricht der Sync
+mit einer Fehlermeldung ab, die zum Verbinden des VPNs auffordert – einfach den Button danach
+erneut klicken.
+
+**Berechtigungen:** Die Rotation braucht ein Token mit `Application.ReadWrite.All` auf die
+App-Registrierung – mehr, als die App im Alltag benötigt (`ServiceHealth.Read.All`). Über
+`AZURE_MGMT_TENANT_ID`/`_CLIENT_ID`/`_CLIENT_SECRET` lässt sich dafür eine separate,
+enger berechtigte Credential hinterlegen, statt der Haupt-App-Registrierung diese zusätzliche
+Berechtigung dauerhaft zu geben.
+
+---
+
 ## Admin-Berechtigung (App-Rolle)
 
 Standardmäßig hat **jeder** authentifizierte Tenant-Benutzer Zugriff auf `/admin` (Legacy-Verhalten; beim Start wird gewarnt). Für Produktion solltest du den Admin-Bereich über eine **Entra-ID App-Rolle** einschränken — bequem steuerbar per Security-Gruppe:
@@ -126,6 +160,12 @@ Alternativ oder ergänzend kannst du eine E-Mail-Allowlist setzen (`ADMIN_EMAILS
 | `MONITORED_SERVICES` | Kommagetrennte Dienstnamen (Graph API exakt) | Exchange Online, SharePoint Online, Microsoft Teams |
 | `POLL_INTERVAL_MINUTES` | Abfrageintervall in Minuten | `10` |
 | `DEBUG` | Aktiviert `/api/docs`, ausführliches Logging | `false` |
+| `AZURE_MGMT_TENANT_ID` / `_CLIENT_ID` / `_CLIENT_SECRET` | Separate Credentials NUR für die OpenBao-Secret-Rotation (`Application.ReadWrite.All`) – leer = `AZURE_*` wird auch dafür verwendet | *(leer)* |
+| `OPENBAO_ADDR` | Basis-URL des OpenBao-Servers (nur über VPN erreichbar) | `https://secrets-prod.pyur.com` |
+| `OPENBAO_SECRET_PATH` | KV-v2-Pfad des Azure-Client-Secrets | `secret/data/m365-statuspage/azure-client-secret` |
+| `OPENBAO_TOKEN` | OpenBao-Token mit Lese-/Schreibrecht auf obigem Pfad | *(leer)* |
+| `OPENBAO_RENEWAL_THRESHOLD_DAYS` | Rotieren, wenn das gespeicherte Secret innerhalb dieser Tage abläuft | `30` |
+| `OPENBAO_NEW_SECRET_LIFETIME_DAYS` | Gültigkeitsdauer eines neu erstellten Secrets | `180` |
 
 **Unterstützte `MONITORED_SERVICES`-Werte** (Graph API-Namen exakt einhalten):
 

--- a/app/azure_secret_manager.py
+++ b/app/azure_secret_manager.py
@@ -1,0 +1,211 @@
+"""Get-or-rotate the Entra ID app registration's client secret via OpenBao.
+
+Lifecycle:
+  1. Read the current secret from OpenBao (KV v2 - see app.openbao_client).
+  2. Still valid (further than OPENBAO_RENEWAL_THRESHOLD_DAYS from expiry) and
+     not forced -> use it as-is, no Microsoft Graph calls at all.
+  3. Missing / expiring soon / forced -> rotate: create a new client secret on
+     the app registration via Microsoft Graph (addPassword - the only way to
+     ever see a secret's plaintext; an existing one can only be queried as
+     metadata afterwards), store it in OpenBao, then remove the previous
+     credential so the app registration doesn't accumulate old secrets.
+  4. Either way, persist the resulting secret into this app's own settings
+     (app_settings.save_azure_settings) so graph_client.py/auth.py/
+     notifications.py keep working unchanged - they only ever read the
+     effective secret via app_settings.get_azure_settings().
+
+Rotating needs an access token with Application.ReadWrite.All on the app
+registration - a higher privilege than this app's own day-to-day
+ServiceHealth.Read.All. AZURE_MGMT_* settings (falling back to the AZURE_*
+ones - see app/config.py) let that be a separate, narrower-scoped credential
+instead of over-privileging the app's main one; either way it's only needed
+on the rotate path, never for reading an already-valid secret out of OpenBao.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import msal
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.app_settings import save_azure_settings
+from app.config import settings
+from app.openbao_client import OpenBaoUnreachableError, get_secret, is_reachable, set_secret
+
+logger = logging.getLogger(__name__)
+
+_GRAPH_BASE = "https://graph.microsoft.com/v1.0"
+_GRAPH_TIMEOUT = 15.0
+
+
+class AzureSecretSyncError(RuntimeError):
+    """Any failure in get_or_rotate_client_secret - message is meant to be user-facing."""
+
+
+@dataclass
+class SecretSyncResult:
+    client_secret: str
+    rotated: bool
+    expires_on: str
+
+
+@dataclass
+class _NewSecret:
+    client_secret: str
+    key_id: str
+    expires_on: str
+
+
+async def get_or_rotate_client_secret(
+    db: AsyncSession,
+    *,
+    tenant_id: str,
+    client_id: str,
+    force: bool = False,
+) -> SecretSyncResult:
+    """Get the effective client secret from OpenBao, rotating it first if needed.
+
+    Always writes the result into this app's Azure settings (DB), so callers
+    just need to re-read app_settings.get_azure_settings() afterwards - or use
+    the returned client_secret directly.
+    """
+    address = settings.OPENBAO_ADDR
+    if not await is_reachable(address):
+        raise AzureSecretSyncError(
+            f"OpenBao ({address}) ist nicht erreichbar - vermutlich ist die VPN-Verbindung "
+            "nicht aktiv. VPN verbinden und erneut versuchen."
+        )
+    if not settings.OPENBAO_TOKEN:
+        raise AzureSecretSyncError("OPENBAO_TOKEN ist nicht gesetzt.")
+
+    path = settings.OPENBAO_SECRET_PATH
+    try:
+        stored = await get_secret(address, settings.OPENBAO_TOKEN, path)
+    except OpenBaoUnreachableError as exc:
+        raise AzureSecretSyncError(str(exc)) from exc
+
+    needs_rotation = force or not stored or not stored.get("expires_on")
+    if not needs_rotation:
+        expires_on = datetime.fromisoformat(stored["expires_on"])
+        needs_rotation = expires_on < datetime.now(UTC) + timedelta(
+            days=settings.OPENBAO_RENEWAL_THRESHOLD_DAYS
+        )
+
+    if not needs_rotation:
+        logger.info("Using cached OpenBao secret (valid until %s).", stored["expires_on"])
+        await save_azure_settings(
+            db, tenant_id=tenant_id, client_id=client_id, client_secret=stored["client_secret"]
+        )
+        return SecretSyncResult(
+            client_secret=stored["client_secret"], rotated=False, expires_on=stored["expires_on"]
+        )
+
+    new_secret = await _rotate_client_secret(
+        client_id=client_id, previous_key_id=(stored or {}).get("key_id")
+    )
+    try:
+        await set_secret(
+            address,
+            settings.OPENBAO_TOKEN,
+            path,
+            {
+                "client_id": client_id,
+                "tenant_id": tenant_id,
+                "client_secret": new_secret.client_secret,
+                "key_id": new_secret.key_id,
+                "expires_on": new_secret.expires_on,
+            },
+        )
+    except OpenBaoUnreachableError as exc:
+        raise AzureSecretSyncError(str(exc)) from exc
+
+    logger.info("Rotated Azure client secret via Graph (expires %s).", new_secret.expires_on)
+    await save_azure_settings(
+        db, tenant_id=tenant_id, client_id=client_id, client_secret=new_secret.client_secret
+    )
+    return SecretSyncResult(
+        client_secret=new_secret.client_secret, rotated=True, expires_on=new_secret.expires_on
+    )
+
+
+async def _get_mgmt_access_token() -> str:
+    mgmt_tenant = settings.AZURE_MGMT_TENANT_ID or settings.AZURE_TENANT_ID
+    mgmt_client = settings.AZURE_MGMT_CLIENT_ID or settings.AZURE_CLIENT_ID
+    mgmt_secret = settings.AZURE_MGMT_CLIENT_SECRET or settings.AZURE_CLIENT_SECRET
+
+    app = msal.ConfidentialClientApplication(
+        client_id=mgmt_client,
+        client_credential=mgmt_secret,
+        authority=f"https://login.microsoftonline.com/{mgmt_tenant}",
+    )
+    # MSAL token acquisition is synchronous - run in a thread, same as graph_client.py.
+    result = await asyncio.to_thread(
+        app.acquire_token_for_client, ["https://graph.microsoft.com/.default"]
+    )
+    if "access_token" not in result:
+        error = result.get("error_description", result.get("error", "unknown"))
+        raise AzureSecretSyncError(
+            "Konnte kein Graph-Token für die Secret-Rotation holen "
+            f"({error[:200]}). Braucht eine App-Registrierung mit "
+            "Application.ReadWrite.All - siehe AZURE_MGMT_* in .env.example."
+        )
+    return result["access_token"]
+
+
+async def _rotate_client_secret(*, client_id: str, previous_key_id: str | None) -> _NewSecret:
+    token = await _get_mgmt_access_token()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async with httpx.AsyncClient(timeout=_GRAPH_TIMEOUT) as client:
+        lookup = await client.get(
+            f"{_GRAPH_BASE}/applications",
+            headers=headers,
+            params={"$filter": f"appId eq '{client_id}'"},
+        )
+        lookup.raise_for_status()
+        apps = lookup.json().get("value", [])
+        if not apps:
+            raise AzureSecretSyncError(
+                f"Keine Entra-ID-App-Registrierung für ClientId '{client_id}' gefunden."
+            )
+        app_object_id = apps[0]["id"]
+
+        end_date_time = datetime.now(UTC) + timedelta(
+            days=settings.OPENBAO_NEW_SECRET_LIFETIME_DAYS
+        )
+        created_resp = await client.post(
+            f"{_GRAPH_BASE}/applications/{app_object_id}/addPassword",
+            headers=headers,
+            json={
+                "passwordCredential": {
+                    "displayName": f"openbao-managed-{datetime.now(UTC):%Y%m%d-%H%M%S}",
+                    "endDateTime": end_date_time.isoformat(),
+                }
+            },
+        )
+        created_resp.raise_for_status()
+        created = created_resp.json()
+
+        if previous_key_id and previous_key_id != created["keyId"]:
+            remove_resp = await client.post(
+                f"{_GRAPH_BASE}/applications/{app_object_id}/removePassword",
+                headers=headers,
+                json={"keyId": previous_key_id},
+            )
+            if remove_resp.status_code >= 400:
+                logger.warning(
+                    "Could not remove previous client secret (keyId %s) from app %s: %s",
+                    previous_key_id,
+                    app_object_id,
+                    remove_resp.text[:200],
+                )
+
+    return _NewSecret(
+        client_secret=created["secretText"],
+        key_id=created["keyId"],
+        expires_on=created["endDateTime"],
+    )

--- a/app/azure_secret_manager.py
+++ b/app/azure_secret_manager.py
@@ -60,6 +60,25 @@ class _NewSecret:
     expires_on: str
 
 
+@dataclass
+class _StoredSecret:
+    """Typed view of the OpenBao KV v2 record - converted from the raw dict right after
+    fetching, so metadata fields (expires_on, key_id) are ordinary dataclass attributes
+    instead of subscripts on the same dict object that also holds client_secret."""
+
+    client_secret: str
+    key_id: str | None
+    expires_on: str | None
+
+
+def _parse_stored_secret(raw: dict | None) -> _StoredSecret | None:
+    if raw is None:
+        return None
+    return _StoredSecret(
+        client_secret=raw["client_secret"], key_id=raw.get("key_id"), expires_on=raw.get("expires_on")
+    )
+
+
 async def get_or_rotate_client_secret(
     db: AsyncSession,
     *,
@@ -84,28 +103,28 @@ async def get_or_rotate_client_secret(
 
     path = settings.OPENBAO_SECRET_PATH
     try:
-        stored = await get_secret(address, settings.OPENBAO_TOKEN, path)
+        stored = _parse_stored_secret(await get_secret(address, settings.OPENBAO_TOKEN, path))
     except OpenBaoUnreachableError as exc:
         raise AzureSecretSyncError(str(exc)) from exc
 
-    needs_rotation = force or not stored or not stored.get("expires_on")
+    needs_rotation = force or not stored or not stored.expires_on
     if not needs_rotation:
-        expires_on = datetime.fromisoformat(stored["expires_on"])
+        expires_on = datetime.fromisoformat(stored.expires_on)
         needs_rotation = expires_on < datetime.now(UTC) + timedelta(
             days=settings.OPENBAO_RENEWAL_THRESHOLD_DAYS
         )
 
     if not needs_rotation:
-        logger.info("Using cached OpenBao secret (valid until %s).", stored["expires_on"])
+        logger.info("Using cached OpenBao secret (valid until %s).", stored.expires_on)
         await save_azure_settings(
-            db, tenant_id=tenant_id, client_id=client_id, client_secret=stored["client_secret"]
+            db, tenant_id=tenant_id, client_id=client_id, client_secret=stored.client_secret
         )
         return SecretSyncResult(
-            client_secret=stored["client_secret"], rotated=False, expires_on=stored["expires_on"]
+            client_secret=stored.client_secret, rotated=False, expires_on=stored.expires_on
         )
 
     new_secret = await _rotate_client_secret(
-        client_id=client_id, previous_key_id=(stored or {}).get("key_id")
+        client_id=client_id, previous_key_id=stored.key_id if stored else None
     )
     try:
         await set_secret(

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,23 @@ class Settings(BaseSettings):
     AZURE_CLIENT_SECRET: str = "your-client-secret"
     AZURE_REDIRECT_URI: str = "http://localhost:8000/auth/callback"
 
+    # Optional, more privileged credentials (Application.ReadWrite.All) used ONLY to rotate
+    # AZURE_CLIENT_SECRET via Microsoft Graph (see app/azure_secret_manager.py) - the app's own
+    # AZURE_* credentials only need ServiceHealth.Read.All day to day. Falls back to AZURE_*
+    # when unset, for setups that deliberately grant the one app registration both.
+    AZURE_MGMT_TENANT_ID: str = ""
+    AZURE_MGMT_CLIENT_ID: str = ""
+    AZURE_MGMT_CLIENT_SECRET: str = ""
+
+    # OpenBao (Vault-API-compatible) – optional backing store for AZURE_CLIENT_SECRET, so the
+    # secret lives there instead of only in .env/the DB. Reachable ONLY over VPN, not
+    # continuously - see app/openbao_client.py.
+    OPENBAO_ADDR: str = "https://secrets-prod.pyur.com"
+    OPENBAO_SECRET_PATH: str = "secret/data/m365-statuspage/azure-client-secret"
+    OPENBAO_TOKEN: str = ""
+    OPENBAO_RENEWAL_THRESHOLD_DAYS: int = 30
+    OPENBAO_NEW_SECRET_LIFETIME_DAYS: int = 180
+
     # Session security – empty/placeholder triggers auto-generation on first run
     # (persisted to data/secret_key so sessions survive restarts).
     SECRET_KEY: str = ""

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -293,6 +293,10 @@ LABELS_DE: dict[str, str] = {
     "admin.azure_save":               "Speichern & Verbindung prüfen",
     "admin.azure_status_configured":  "Verbunden",
     "admin.azure_status_pending":     "Unvollständig",
+    "admin.azure_openbao_heading":    "OpenBao-Sync",
+    "admin.azure_openbao_hint":       "Client-Secret aus OpenBao übernehmen (falls noch keins hinterlegt: neu erstellen und dort ablegen). OpenBao ist nur über VPN erreichbar.",
+    "admin.azure_openbao_force":      "Rotation erzwingen (Renewal testen)",
+    "admin.azure_openbao_sync":       "Aus OpenBao laden / rotieren",
     "toast.azure_saved":              "Azure AD App gespeichert.",
     # Admin – global search palette (Cmd+K / Ctrl+K)
     "admin.search.placeholder":        "Suchen…",
@@ -617,6 +621,10 @@ LABELS_EN: dict[str, str] = {
     "admin.azure_save":               "Save & test connection",
     "admin.azure_status_configured":  "Connected",
     "admin.azure_status_pending":     "Incomplete",
+    "admin.azure_openbao_heading":    "OpenBao sync",
+    "admin.azure_openbao_hint":       "Pull the client secret from OpenBao (create a new one and store it there if none exists yet). OpenBao is reachable over VPN only.",
+    "admin.azure_openbao_force":      "Force rotation (test renewal)",
+    "admin.azure_openbao_sync":       "Load from OpenBao / rotate",
     "toast.azure_saved":              "Azure AD app saved.",
     # Admin – global search palette (Cmd+K / Ctrl+K)
     "admin.search.placeholder":        "Search…",

--- a/app/openbao_client.py
+++ b/app/openbao_client.py
@@ -1,0 +1,75 @@
+"""Minimal async OpenBao (HashiCorp Vault-API-compatible) client.
+
+Talks to OpenBao's plain HTTP KV v2 API via httpx - no `bao` CLI or Vault SDK
+dependency needed. Used by app.azure_secret_manager to store/read the Entra ID
+app registration's client secret instead of only ever persisting it in this
+app's own database.
+
+OpenBao is reachable ONLY over the org VPN, not continuously - reachability is
+checked separately (is_reachable) so callers can surface "connect the VPN and
+try again" instead of a raw connection-error traceback.
+"""
+from __future__ import annotations
+
+import httpx
+
+_REQUEST_TIMEOUT = 10.0
+
+
+class OpenBaoUnreachableError(RuntimeError):
+    """OpenBao could not be reached at all (VPN down, DNS failure, timeout)."""
+
+
+async def is_reachable(address: str, *, transport: httpx.BaseTransport | None = None) -> bool:
+    """True once OpenBao responds to ANY HTTP status - not just 200.
+
+    /v1/sys/health returns non-200 for perfectly reachable-but-not-ready states
+    (503 sealed, 429 standby, 501 uninitialized) - those still mean the VPN is
+    up and OpenBao is there. Only a connection-level failure (no HTTP response
+    at all) means "not reachable".
+
+    -transport is a test-only hook (httpx.MockTransport) - production callers
+    never pass it, so httpx uses its normal network transport.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, transport=transport) as client:
+            await client.get(f"{address}/v1/sys/health")
+        return True
+    except httpx.HTTPError:
+        return False
+
+
+async def get_secret(
+    address: str, token: str, path: str, *, transport: httpx.BaseTransport | None = None
+) -> dict | None:
+    """Read the current version of a KV v2 secret. None if nothing is stored yet (404)."""
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, transport=transport) as client:
+        try:
+            response = await client.get(f"{address}/v1/{path}", headers={"X-Vault-Token": token})
+        except httpx.HTTPError as exc:
+            raise OpenBaoUnreachableError(f"OpenBao request failed: {exc}") from exc
+    if response.status_code == 404:
+        return None
+    response.raise_for_status()
+    return response.json()["data"]["data"]
+
+
+async def set_secret(
+    address: str,
+    token: str,
+    path: str,
+    data: dict,
+    *,
+    transport: httpx.BaseTransport | None = None,
+) -> None:
+    """Write a new KV v2 version. OpenBao keeps prior versions itself - never overwritten here."""
+    async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT, transport=transport) as client:
+        try:
+            response = await client.post(
+                f"{address}/v1/{path}",
+                headers={"X-Vault-Token": token},
+                json={"data": data},
+            )
+        except httpx.HTTPError as exc:
+            raise OpenBaoUnreachableError(f"OpenBao request failed: {exc}") from exc
+    response.raise_for_status()

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -19,6 +19,7 @@ from app.app_settings import (
     verify_smtp_connection,
 )
 from app.auth import require_admin
+from app.azure_secret_manager import AzureSecretSyncError, get_or_rotate_client_secret
 from app.config import settings
 from app.crud import (
     add_incident_post,
@@ -321,6 +322,48 @@ async def admin_save_azure_settings(
     azure_cfg = await get_azure_settings(db)
     ok, msg = await verify_azure_connection(
         azure_cfg.tenant_id, azure_cfg.client_id, azure_cfg.client_secret
+    )
+    flash(request, msg, "success" if ok else "error")
+    return RedirectResponse(url="/admin/settings#azure", status_code=303)
+
+
+@router.post("/settings/azure/openbao")
+async def admin_sync_azure_secret_from_openbao(
+    request: Request,
+    force: Annotated[str, Form()] = "",
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(require_admin),
+):
+    """Get-or-rotate AZURE_CLIENT_SECRET via OpenBao (see app/azure_secret_manager.py).
+
+    Uses the currently saved tenant/client ID (form save via /settings/azure is
+    still how those are set) - this only ever touches the secret itself.
+    """
+    azure_cfg = await get_azure_settings(db)
+    try:
+        result = await get_or_rotate_client_secret(
+            db, tenant_id=azure_cfg.tenant_id, client_id=azure_cfg.client_id, force=force == "1"
+        )
+    except AzureSecretSyncError as exc:
+        flash(request, str(exc), "error")
+        return RedirectResponse(url="/admin/settings#azure", status_code=303)
+    await db.commit()
+
+    if result.rotated:
+        flash(
+            request,
+            f"Neues Client-Secret via Microsoft Graph erstellt und in OpenBao abgelegt "
+            f"(gültig bis {result.expires_on}).",
+            "success",
+        )
+    else:
+        flash(
+            request,
+            f"Client-Secret aus OpenBao übernommen (gültig bis {result.expires_on}).",
+            "success",
+        )
+    ok, msg = await verify_azure_connection(
+        azure_cfg.tenant_id, azure_cfg.client_id, result.client_secret
     )
     flash(request, msg, "success" if ok else "error")
     return RedirectResponse(url="/admin/settings#azure", status_code=303)

--- a/templates/admin/settings.html
+++ b/templates/admin/settings.html
@@ -247,6 +247,23 @@
         </button>
       </div>
     </form>
+
+    {# OpenBao-backed secret sync/rotation #}
+    <div class="border-t border-gray-100 dark:border-gray-800 px-5 py-4 bg-gray-50/50 dark:bg-gray-900/40">
+      <p class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-2">{{ L["admin.azure_openbao_heading"] }}</p>
+      <p class="text-[11px] text-gray-400 dark:text-gray-500 mb-2">{{ L["admin.azure_openbao_hint"] }}</p>
+      <form method="post" action="/admin/settings/azure/openbao" class="flex flex-wrap items-center gap-3">
+        <label class="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          <input type="checkbox" name="force" value="1"
+                 class="rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500" />
+          {{ L["admin.azure_openbao_force"] }}
+        </label>
+        <button type="submit"
+                class="text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-600 hover:text-gray-900 hover:border-gray-400 dark:text-gray-400 dark:hover:text-gray-200 transition-colors">
+          {{ L["admin.azure_openbao_sync"] }}
+        </button>
+      </form>
+    </div>
   </div>
 </section>
 

--- a/tests/test_azure_secret_manager.py
+++ b/tests/test_azure_secret_manager.py
@@ -1,0 +1,137 @@
+"""Unit tests for app.azure_secret_manager's get-or-rotate orchestration logic.
+
+Mocks at the module boundary (is_reachable/get_secret/set_secret/_rotate_client_secret/
+save_azure_settings) rather than hitting real OpenBao, Microsoft Graph, or a DB - this
+covers the decision logic (cache vs. rotate, error surfacing), not the Graph/OpenBao wire
+formats themselves (those can't be verified without a real tenant/OpenBao instance - see
+docs/README caveats).
+"""
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app import azure_secret_manager as mgr
+from app.azure_secret_manager import AzureSecretSyncError, _NewSecret
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+CLIENT_ID = "22222222-2222-2222-2222-222222222222"
+
+
+class _FakeAsyncFn:
+    """Simple async-callable recorder for monkeypatching module-level async functions."""
+
+    def __init__(self, return_value=None, side_effect=None):
+        self.return_value = return_value
+        self.side_effect = side_effect
+        self.calls = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.return_value
+
+
+@pytest.fixture(autouse=True)
+def _openbao_settings(monkeypatch):
+    monkeypatch.setattr(mgr.settings, "OPENBAO_ADDR", "https://secrets-prod.pyur.com")
+    monkeypatch.setattr(mgr.settings, "OPENBAO_SECRET_PATH", "secret/data/test/azure")
+    monkeypatch.setattr(mgr.settings, "OPENBAO_TOKEN", "test-token")
+    monkeypatch.setattr(mgr.settings, "OPENBAO_RENEWAL_THRESHOLD_DAYS", 30)
+
+
+@pytest.mark.asyncio
+async def test_raises_when_openbao_unreachable(monkeypatch):
+    monkeypatch.setattr(mgr, "is_reachable", _FakeAsyncFn(return_value=False))
+
+    with pytest.raises(AzureSecretSyncError, match="VPN"):
+        await mgr.get_or_rotate_client_secret(db=None, tenant_id=TENANT_ID, client_id=CLIENT_ID)
+
+
+@pytest.mark.asyncio
+async def test_uses_cached_secret_when_still_valid(monkeypatch):
+    far_future = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+    stored = {"client_secret": "cached-secret", "expires_on": far_future, "key_id": "kid-1"}
+
+    monkeypatch.setattr(mgr, "is_reachable", _FakeAsyncFn(return_value=True))
+    monkeypatch.setattr(mgr, "get_secret", _FakeAsyncFn(return_value=stored))
+    set_secret_fn = _FakeAsyncFn()
+    monkeypatch.setattr(mgr, "set_secret", set_secret_fn)
+    rotate_fn = _FakeAsyncFn()
+    monkeypatch.setattr(mgr, "_rotate_client_secret", rotate_fn)
+    save_fn = _FakeAsyncFn()
+    monkeypatch.setattr(mgr, "save_azure_settings", save_fn)
+
+    result = await mgr.get_or_rotate_client_secret(
+        db=None, tenant_id=TENANT_ID, client_id=CLIENT_ID
+    )
+
+    assert result.client_secret == "cached-secret"
+    assert result.rotated is False
+    assert rotate_fn.calls == []  # no Graph call for a still-valid secret
+    assert set_secret_fn.calls == []  # nothing new to persist to OpenBao
+    assert save_fn.calls[0][1]["client_secret"] == "cached-secret"
+
+
+@pytest.mark.asyncio
+async def test_rotates_when_nothing_stored_yet(monkeypatch):
+    new_secret = _NewSecret(client_secret="fresh-secret", key_id="kid-2", expires_on="2027-01-01")
+
+    monkeypatch.setattr(mgr, "is_reachable", _FakeAsyncFn(return_value=True))
+    monkeypatch.setattr(mgr, "get_secret", _FakeAsyncFn(return_value=None))
+    set_secret_fn = _FakeAsyncFn()
+    monkeypatch.setattr(mgr, "set_secret", set_secret_fn)
+    monkeypatch.setattr(mgr, "_rotate_client_secret", _FakeAsyncFn(return_value=new_secret))
+    save_fn = _FakeAsyncFn()
+    monkeypatch.setattr(mgr, "save_azure_settings", save_fn)
+
+    result = await mgr.get_or_rotate_client_secret(
+        db=None, tenant_id=TENANT_ID, client_id=CLIENT_ID
+    )
+
+    assert result.client_secret == "fresh-secret"
+    assert result.rotated is True
+    assert set_secret_fn.calls[0][0][3]["client_secret"] == "fresh-secret"
+    assert save_fn.calls[0][1]["client_secret"] == "fresh-secret"
+
+
+@pytest.mark.asyncio
+async def test_rotates_when_expiring_soon(monkeypatch):
+    soon = (datetime.now(UTC) + timedelta(days=5)).isoformat()  # inside the 30-day threshold
+    stored = {"client_secret": "old-secret", "expires_on": soon, "key_id": "kid-old"}
+    new_secret = _NewSecret(client_secret="new-secret", key_id="kid-new", expires_on="2027-01-01")
+
+    monkeypatch.setattr(mgr, "is_reachable", _FakeAsyncFn(return_value=True))
+    monkeypatch.setattr(mgr, "get_secret", _FakeAsyncFn(return_value=stored))
+    monkeypatch.setattr(mgr, "set_secret", _FakeAsyncFn())
+    rotate_fn = _FakeAsyncFn(return_value=new_secret)
+    monkeypatch.setattr(mgr, "_rotate_client_secret", rotate_fn)
+    monkeypatch.setattr(mgr, "save_azure_settings", _FakeAsyncFn())
+
+    result = await mgr.get_or_rotate_client_secret(
+        db=None, tenant_id=TENANT_ID, client_id=CLIENT_ID
+    )
+
+    assert result.rotated is True
+    # previous_key_id was passed through so the old credential can be cleaned up
+    assert rotate_fn.calls[0][1]["previous_key_id"] == "kid-old"
+
+
+@pytest.mark.asyncio
+async def test_force_rotates_even_when_still_valid(monkeypatch):
+    far_future = (datetime.now(UTC) + timedelta(days=90)).isoformat()
+    stored = {"client_secret": "old-secret", "expires_on": far_future, "key_id": "kid-old"}
+    new_secret = _NewSecret(client_secret="forced-secret", key_id="kid-new", expires_on="2027-01-01")
+
+    monkeypatch.setattr(mgr, "is_reachable", _FakeAsyncFn(return_value=True))
+    monkeypatch.setattr(mgr, "get_secret", _FakeAsyncFn(return_value=stored))
+    monkeypatch.setattr(mgr, "set_secret", _FakeAsyncFn())
+    monkeypatch.setattr(mgr, "_rotate_client_secret", _FakeAsyncFn(return_value=new_secret))
+    monkeypatch.setattr(mgr, "save_azure_settings", _FakeAsyncFn())
+
+    result = await mgr.get_or_rotate_client_secret(
+        db=None, tenant_id=TENANT_ID, client_id=CLIENT_ID, force=True
+    )
+
+    assert result.client_secret == "forced-secret"
+    assert result.rotated is True

--- a/tests/test_openbao_client.py
+++ b/tests/test_openbao_client.py
@@ -1,0 +1,91 @@
+"""Unit tests for app.openbao_client - no real network access (httpx.MockTransport)."""
+import json
+
+import httpx
+import pytest
+
+from app.openbao_client import OpenBaoUnreachableError, get_secret, is_reachable, set_secret
+
+ADDRESS = "https://secrets-prod.pyur.com"
+PATH = "secret/data/m365-statuspage/azure-client-secret"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_is_reachable_true_on_200():
+    def handler(request):
+        return httpx.Response(200, json={"initialized": True})
+
+    assert await is_reachable(ADDRESS, transport=_transport(handler)) is True
+
+
+@pytest.mark.asyncio
+async def test_is_reachable_true_on_sealed_503():
+    """A non-200 HTTP response still means OpenBao itself answered - VPN is up."""
+
+    def handler(request):
+        return httpx.Response(503, json={"sealed": True})
+
+    assert await is_reachable(ADDRESS, transport=_transport(handler)) is True
+
+
+@pytest.mark.asyncio
+async def test_is_reachable_false_on_connect_error():
+    def handler(request):
+        raise httpx.ConnectError("connection refused", request=request)
+
+    assert await is_reachable(ADDRESS, transport=_transport(handler)) is False
+
+
+@pytest.mark.asyncio
+async def test_get_secret_returns_data():
+    def handler(request):
+        assert request.headers["X-Vault-Token"] == "tok"
+        return httpx.Response(200, json={"data": {"data": {"client_secret": "s3cr3t"}}})
+
+    result = await get_secret(ADDRESS, "tok", PATH, transport=_transport(handler))
+    assert result == {"client_secret": "s3cr3t"}
+
+
+@pytest.mark.asyncio
+async def test_get_secret_returns_none_on_404():
+    def handler(request):
+        return httpx.Response(404, json={"errors": []})
+
+    result = await get_secret(ADDRESS, "tok", PATH, transport=_transport(handler))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_secret_raises_on_connection_failure():
+    def handler(request):
+        raise httpx.ConnectTimeout("timed out", request=request)
+
+    with pytest.raises(OpenBaoUnreachableError):
+        await get_secret(ADDRESS, "tok", PATH, transport=_transport(handler))
+
+
+@pytest.mark.asyncio
+async def test_get_secret_raises_on_permission_denied():
+    def handler(request):
+        return httpx.Response(403, json={"errors": ["permission denied"]})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await get_secret(ADDRESS, "tok", PATH, transport=_transport(handler))
+
+
+@pytest.mark.asyncio
+async def test_set_secret_posts_wrapped_data():
+    captured = {}
+
+    def handler(request):
+        captured["body"] = request.read()
+        return httpx.Response(200, json={"data": {"version": 2}})
+
+    await set_secret(
+        ADDRESS, "tok", PATH, {"client_secret": "new"}, transport=_transport(handler)
+    )
+    assert json.loads(captured["body"]) == {"data": {"client_secret": "new"}}


### PR DESCRIPTION
## Summary

Implementation for: get the Entra ID app registration's client secret, store/read it in OpenBao instead of only `.env`/the DB, support testing the renewal path with a forced/short expiry, and use the secret for this app's own Graph auth. OpenBao (`secrets-prod.pyur.com`) is VPN-only, so the sync surfaces a "connect the VPN and retry" error rather than a raw connection failure.

- `app/openbao_client.py` (new) — minimal async httpx client for OpenBao's KV v2 API: `is_reachable` (any HTTP response = reachable, only a connection-level failure means "down"), `get_secret`/`set_secret`.
- `app/azure_secret_manager.py` (new) — `get_or_rotate_client_secret(db, tenant_id, client_id, force=...)`:
  1. Reads the current secret from OpenBao.
  2. Still valid (further than `OPENBAO_RENEWAL_THRESHOLD_DAYS` from expiry) and not forced → use it as-is, no Graph call at all.
  3. Missing / expiring soon / forced → **rotate**: create a new client secret via Microsoft Graph (`addPassword` — the only way to ever see a secret's plaintext), store it in OpenBao, then remove the previous credential (`removePassword`).
  4. Either way, persists the result via the existing `app_settings.save_azure_settings`, so `graph_client.py`/`auth.py`/`notifications.py` keep working unchanged — they only ever read the effective secret via `app_settings.get_azure_settings()`.
- `app/routers/admin.py` — new `POST /admin/settings/azure/openbao` route, wired into Admin → Settings → Azure AD app as a **"Load from OpenBao / rotate"** button with a **"Force rotation"** checkbox (the fast way to test renewal without waiting for a real secret to approach expiry).
- `app/config.py` + `.env.example` — `OPENBAO_ADDR`/`OPENBAO_SECRET_PATH`/`OPENBAO_TOKEN`/`OPENBAO_RENEWAL_THRESHOLD_DAYS`/`OPENBAO_NEW_SECRET_LIFETIME_DAYS`, plus optional `AZURE_MGMT_TENANT_ID`/`_CLIENT_ID`/`_CLIENT_SECRET` for a narrower-scoped rotation credential (rotation needs `Application.ReadWrite.All`, more than the app's own day-to-day `ServiceHealth.Read.All`).
- `README.md` / `README.en.md` — new "Client-Secret über OpenBao" section + config reference rows.
- `tests/test_openbao_client.py`, `tests/test_azure_secret_manager.py` (new) — unit tests via `httpx.MockTransport` and module-boundary mocks (13 tests, no real network/DB required).

No new dependencies — `httpx` and `msal` were already project dependencies.

## Verified locally

- `uv run ruff check app/` — clean.
- `uv run pytest tests/test_openbao_client.py tests/test_azure_secret_manager.py` — 13/13 passed.
- CI's own "Validate imports & app startup" + "DB initialisation" steps reproduced locally — pass.
- Manually exercised the new route end-to-end via `starlette.testclient.TestClient` (with `DEBUG=true` so the session cookie isn't `Secure`-only, matching plain-http test traffic): confirms the VPN-unreachable path returns the correct German flash message through the full route → manager → template chain (this sandbox has no route to `secrets-prod.pyur.com`, so only the "unreachable" path could be exercised end-to-end).

## Not yet verified (no live OpenBao/Azure access from this environment)

- The actual OpenBao KV v2 wire format and Microsoft Graph `addPassword`/`removePassword` calls against a real tenant/OpenBao instance — reviewed against the documented APIs, but not run live.
- Recommend a first run with a test app registration and a scratch OpenBao path before relying on this in production, and double-checking the `AZURE_MGMT_*` credential actually has `Application.ReadWrite.All` before clicking "Load from OpenBao / rotate".

## Test plan

- [ ] Set `OPENBAO_TOKEN` and (optionally) `AZURE_MGMT_*`, connect VPN, click "Load from OpenBao / rotate" against a test app registration — confirm a new secret is created in Entra ID and stored in OpenBao.
- [ ] Click it again without "Force rotation" — confirm the cached OpenBao secret is reused with no new Graph call.
- [ ] Click it with "Force rotation" checked — confirm it rotates and the previous credential is removed from the app registration.
- [ ] Disconnect VPN and click the button — confirm the German "please connect VPN" error shows instead of a stack trace.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFjfhHs3cTGqyXyBvGPyTD)_