### PR TITLE
Fix CI route-listing crash (Starlette _IncludedRouter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,21 @@ jobs:
           from app.auth import LoginRequired
           from app.routers import admin, api, auth_router, embed, status
           from app.main import app
-          routes = [r.path for r in app.routes]
+
+          # Starlette wraps each app.include_router(...) as an opaque
+          # _IncludedRouter (no .path) rather than flattening it into
+          # individual Route/APIRoute entries - recurse via .original_router
+          # to reach the real routes underneath.
+          def all_paths(routes):
+              paths = []
+              for r in routes:
+                  if hasattr(r, 'path'):
+                      paths.append(r.path)
+                  elif hasattr(r, 'original_router'):
+                      paths.extend(all_paths(r.original_router.routes))
+              return paths
+
+          routes = all_paths(app.routes)
           assert '/' in routes
           assert '/embed' in routes
           assert '/auth/login' in routes


### PR DESCRIPTION
## Summary

Standalone fix for the `Syntax & Imports` → `Validate imports & app startup` CI step, which has been red on every push regardless of the actual diff (confirmed on `main`'s current head before this fix, and flagged from PR #150 where it's unrelated to that PR's changes).

Root cause: the pinned Starlette version wraps each `app.include_router(...)` call as an opaque `_IncludedRouter` object in `app.routes` instead of flattening it into individual `Route`/`APIRoute` entries. `routes = [r.path for r in app.routes]` then crashes with `AttributeError: '_IncludedRouter' object has no attribute 'path'` the moment it hits the first included router (`admin`, `api`, `auth_router`, `embed`, `status` are all included this way).

Fix: `_IncludedRouter` exposes `.original_router.routes`, which holds the real, flattened routes with `.path`. Recurse into that to rebuild the path list before the assertions.

## Verified locally

Ran the corrected script directly against this branch (`main` + this fix) - resolves 44 routes including all 5 originally asserted paths, no crash:

```
All imports OK, routes: ['/openapi.json', '/lang/{code}', '/static', '/sw.js', '/auth/login', ..., '/admin/', ...]
```

`ruff check app/` — clean (unaffected, this only touches `.github/workflows/ci.yml`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFjfhHs3cTGqyXyBvGPyTD)_