### PR TITLE
OpenTofu bootstrap for OpenBao access requests + requester form

### DIFF
--- a/.github/ISSUE_TEMPLATE/openbao-secret-request.yml
+++ b/.github/ISSUE_TEMPLATE/openbao-secret-request.yml
@@ -1,0 +1,56 @@
+name: OpenBao secret access request
+description: Request an OpenBao-backed secret (policy + token) for an app - handled by the Cloud Operator via infra/openbao (OpenTofu).
+title: "[OpenBao] "
+labels: ["openbao-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill this in, submit, and a Cloud Operator will provision access via
+        `infra/openbao` (OpenTofu) and hand you the resulting token/path over
+        a secure channel - see `infra/openbao/README.md` for how that step works.
+        No manual OpenBao CLI commands needed on your end.
+
+  - type: input
+    id: app_name
+    attributes:
+      label: App name
+      description: Short, unique, lowercase-with-dashes identifier for your app/service. Becomes the OpenBao policy name and part of the secret path.
+      placeholder: e.g. m365-statuspage
+    validations:
+      required: true
+
+  - type: input
+    id: secret_name
+    attributes:
+      label: Secret name
+      description: What this one secret is (you get exactly one read/write path per request - open a separate request for a second, unrelated secret).
+      placeholder: e.g. azure-client-secret
+    validations:
+      required: true
+
+  - type: input
+    id: requested_by
+    attributes:
+      label: Requested by (team or person)
+      description: Stored as token metadata for audit - who to contact about this token later.
+      placeholder: e.g. Platform Team / your name
+    validations:
+      required: true
+
+  - type: textarea
+    id: justification
+    attributes:
+      label: Why does this app need it?
+      description: One or two sentences - what the secret is for and which app/service will read it.
+    validations:
+      required: true
+
+  - type: input
+    id: token_period
+    attributes:
+      label: Token renewal period (optional)
+      description: How long before the token needs reissuing. Leave blank for the default (30 days).
+      placeholder: e.g. 2592000 (seconds) - default if left blank
+    validations:
+      required: false

--- a/.gitignore
+++ b/.gitignore
@@ -230,3 +230,14 @@ demo-cert-monitoring/.oneuptime-demo-summary
 # (Files are immutable in OneUptime - no update permission - so these
 # avoid re-uploading an identical logo on every seed run).
 demo-cert-monitoring/.oneuptime-logo-*.id
+
+# OpenTofu/Terraform - state and per-run vars hold live OpenBao tokens and
+# must never be committed. See infra/openbao/README.md.
+# (.terraform.lock.hcl is NOT ignored - that one should be committed, same as uv.lock.)
+**/.terraform/
+*.tfstate
+*.tfstate.*
+*.tfvars
+!*.tfvars.example
+crash.log
+crash.*.log

--- a/infra/openbao/README.md
+++ b/infra/openbao/README.md
@@ -1,0 +1,66 @@
+# OpenBao bootstrap (OpenTofu)
+
+Issues one app's OpenBao access in one `tofu apply`: a policy scoped to exactly that
+app's own KV v2 secret path, plus a token carrying that policy. Built for the
+Azure-client-secret flow in [`docs/azure-secret-openbao.md`](../../docs/azure-secret-openbao.md)
+(PR #150), but the module is generic - `app_name`/`secret_name` work for any app that
+needs one OpenBao-backed secret with the same read/write-your-own-path shape.
+
+## Who does what
+
+- **Anforderer (requester):** opens an issue with
+  [`.github/ISSUE_TEMPLATE/openbao-secret-request.yml`](../../.github/ISSUE_TEMPLATE/openbao-secret-request.yml) -
+  fills in app name, which secret, and why. That's their one manual step.
+- **Cloud Operator:** the only one who runs this module - needs VPN connectivity to
+  `secrets-prod.pyur.com` and an OpenBao token with rights to create policies and
+  tokens (an admin/root token, not the app's own eventual token). Copies the issue's
+  fields into `terraform.tfvars`, runs `tofu apply` (their approval gate - review the
+  plan before confirming), then hands the output token to the requester over your
+  org's normal secure channel. That is the entire manual surface once this module and
+  the issue form exist - no hand-written `bao policy write`/`bao token create` calls.
+
+## Usage
+
+```bash
+cd infra/openbao
+cp terraform.tfvars.example terraform.tfvars   # fill in from the requester's issue
+export VAULT_ADDR=https://secrets-prod.pyur.com   # same as openbao_address default
+export VAULT_TOKEN=<your own privileged OpenBao token>   # never put this in a file
+tofu init
+tofu plan   # review before applying - this is the approval step
+tofu apply
+tofu output -raw app_token   # hand this to the requester out of band; never log it
+```
+
+Give the requester `tofu output -raw app_token` as `OPENBAO_TOKEN`, and
+`tofu output secret_path` as `OPENBAO_SECRET_PATH`, on their app.
+
+## Prerequisites this module does NOT set up
+
+- The `secret` KV v2 mount itself (`bao secrets enable -path=secret -version=2 kv`) -
+  one-time, whole-instance setup, out of scope for a per-app bootstrap. If it's not
+  enabled yet, `tofu apply` fails with a clear "no handler for route" error from
+  OpenBao - enable the mount once, then re-run.
+- Your own privileged `VAULT_TOKEN` - this module creates OTHER apps' tokens, it
+  doesn't create yours.
+
+## Known limitations (read before relying on this)
+
+- **State holds the live token in plaintext** (`vault_token.app.client_token`, marked
+  `sensitive` in Terraform/OpenTofu's own output but NOT encrypted at rest in state).
+  Local state (the default if you don't configure a `backend` block) is fine for a
+  one-off bootstrap run from a throwaway checkout, but do **not** commit `*.tfstate`
+  (already gitignored) and do not leave it lying around on a shared machine. For
+  repeated use, configure a remote backend with encryption at rest (e.g. an Azure
+  Storage container with encryption enabled, if this org already uses one for other
+  Terraform/OpenTofu state) rather than local files.
+- **No self-renewal today.** The issued token is periodic (renewable via
+  `bao token renew` within each `token_period_seconds` window), but the app this
+  bootstraps doesn't call that itself yet - see `app/openbao_client.py` in the main
+  repo. In practice, re-run `tofu apply` with the same `terraform.tfvars` before the
+  period lapses to reissue a fresh token (OpenTofu will show a diff only on the token,
+  the policy stays unchanged). Put a reminder on whatever cadence matches
+  `token_period_seconds` (2592000s / 30 days by default).
+- **One token per app, not per environment.** If an app needs separate dev/prod
+  OpenBao access, run this module twice with different `app_name` values (e.g.
+  `m365-statuspage-dev`, `m365-statuspage-prod`) rather than sharing one token.

--- a/infra/openbao/main.tf
+++ b/infra/openbao/main.tf
@@ -1,0 +1,47 @@
+# Bootstraps the OpenBao access one requesting app needs: a policy scoped to
+# exactly its own KV v2 secret path, plus a token carrying that policy.
+#
+# Run by the Cloud Operator only (needs VPN + an OpenBao admin/root token in
+# VAULT_TOKEN - see README.md in this directory). Never run from CI: OpenBao
+# is VPN-only and not continuously reachable, and the resulting token is a
+# live credential that must be handed to the requester out of band, not
+# printed into a pipeline log.
+
+provider "vault" {
+  # Address only - auth comes from the VAULT_TOKEN environment variable
+  # (the operator's own privileged OpenBao token), never from a .tf file.
+  address = var.openbao_address
+}
+
+locals {
+  secret_path          = "${var.kv_mount}/data/${var.app_name}/${var.secret_name}"
+  secret_metadata_path = "${var.kv_mount}/metadata/${var.app_name}/${var.secret_name}"
+  policy_name          = "${var.app_name}-secret-access"
+}
+
+resource "vault_policy" "app" {
+  name = local.policy_name
+
+  policy = <<-EOT
+    path "${local.secret_path}" {
+      capabilities = ["create", "read", "update"]
+    }
+    path "${local.secret_metadata_path}" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_token" "app" {
+  policies = [vault_policy.app.name]
+  period = "${var.token_period_seconds}s"
+  renewable = true
+  no_default_policy = true
+
+  metadata = {
+    app_name         = var.app_name
+    requested_by     = var.requested_by
+    ticket_reference = var.ticket_reference
+    managed_by       = "opentofu:infra/openbao"
+  }
+}

--- a/infra/openbao/outputs.tf
+++ b/infra/openbao/outputs.tf
@@ -1,0 +1,15 @@
+output "policy_name" {
+  description = "Name of the created OpenBao policy."
+  value       = vault_policy.app.name
+}
+
+output "secret_path" {
+  description = "KV v2 path the issued token can read/write - set as OPENBAO_SECRET_PATH on the requesting app."
+  value       = local.secret_path
+}
+
+output "app_token" {
+  description = "The issued token - set as OPENBAO_TOKEN on the requesting app. Hand it to the requester over your org's normal secure channel (never via a CI log, a ticket comment, or Slack in plaintext); do not commit it. Retrieve with: tofu output -raw app_token"
+  value       = vault_token.app.client_token
+  sensitive   = true
+}

--- a/infra/openbao/terraform.tfvars.example
+++ b/infra/openbao/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Copy to terraform.tfvars (gitignored) and fill in from the requester's issue
+# (see ../../.github/ISSUE_TEMPLATE/openbao-secret-request.yml). Pre-filled
+# below with the M365 Statuspage app's own request as a worked example - if
+# you're bootstrapping exactly that app's OpenBao access (see PR #150 /
+# docs/azure-secret-openbao.md), these defaults are already correct as-is.
+
+app_name         = "m365-statuspage"
+secret_name      = "azure-client-secret"
+requested_by     = "team-or-person-from-the-issue"
+ticket_reference = "https://github.com/nic2045/My-M365-Statuspage/issues/REPLACE_ME"
+
+# Leave as default unless the requester asked for something else.
+# token_period_seconds = 2592000

--- a/infra/openbao/variables.tf
+++ b/infra/openbao/variables.tf
@@ -1,0 +1,47 @@
+variable "openbao_address" {
+  description = "Base URL of the OpenBao instance. Only reachable over VPN."
+  type        = string
+  default     = "https://secrets-prod.pyur.com"
+}
+
+variable "kv_mount" {
+  description = "KV v2 secrets engine mount OpenBao's Cloud Operator has already enabled (see ../../docs or README below) - this module only manages a policy + token scoped under it, never the mount itself."
+  type        = string
+  default     = "secret"
+}
+
+# ── Per-request fields (fill in from the Anforderer/requester issue form -
+# see ../../.github/ISSUE_TEMPLATE/openbao-secret-request.yml) ────────────────
+
+variable "app_name" {
+  description = "Short, unique, DNS-safe name for the requesting app/team - becomes the policy name and part of the secret path. Example: m365-statuspage"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.app_name))
+    error_message = "app_name must be lowercase alphanumeric with dashes only (used as a policy name and URL path segment)."
+  }
+}
+
+variable "secret_name" {
+  description = "Name of the specific secret under the app's own path prefix. Example: azure-client-secret. Full KV v2 path becomes {kv_mount}/data/{app_name}/{secret_name}."
+  type        = string
+  default     = "azure-client-secret"
+}
+
+variable "requested_by" {
+  description = "Who/which team requested this (from the issue form) - stored as token metadata for audit, not used in the policy itself."
+  type        = string
+}
+
+variable "ticket_reference" {
+  description = "Issue/ticket URL or number this request came from - stored as token metadata for audit."
+  type        = string
+  default     = ""
+}
+
+variable "token_period_seconds" {
+  description = "Renewal period for the issued token (a periodic token, renewable indefinitely via `bao token renew` within each window - but the app this module bootstraps does not self-renew today, so in practice this is the token's actual lifetime: re-run `tofu apply` before it lapses to reissue. 2592000s = 30 days by default; the README's Cloud-Operator checklist covers reissuing it."
+  type        = number
+  default     = 2592000 # 720h
+}

--- a/infra/openbao/versions.tf
+++ b/infra/openbao/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    # OpenBao is API-compatible with HashiCorp Vault - the vault provider talks
+    # to it unchanged, just pointed at OPENBAO_ADDR instead of a Vault server.
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Automates the two manual OpenBao setup steps from `docs/azure-secret-openbao.md` (write a policy, issue a token — see PR #150) into one OpenTofu module, plus a request form so the only manual work left is the Cloud Operator's own `tofu apply` (their approval gate) and handing over the resulting token.

- `infra/openbao/` (new) — OpenTofu module:
  - `vault_policy` scoped to exactly the requesting app's own KV v2 path (`{kv_mount}/data/{app_name}/{secret_name}` read/write, `.../metadata/...` read).
  - `vault_token` carrying that policy, `no_default_policy = true`, periodic + renewable, tagged with `app_name`/`requested_by`/`ticket_reference` metadata for audit.
  - `terraform.tfvars.example` pre-filled with the M365 Statuspage app's own values — doubles as this app's ready-to-apply request.
  - `README.md` — Cloud-Operator runbook (`tofu init/plan/apply`, `VAULT_ADDR`/`VAULT_TOKEN` env vars, never a token in a `.tf`/committed file) and explicitly documented limitations: local state holds the token in plaintext (recommend a remote encrypted backend beyond a one-off run), and no self-renewal yet — a lapsing token means re-applying, not automatic renewal.
- `.github/ISSUE_TEMPLATE/openbao-secret-request.yml` (new) — the requester-facing form: app name, secret name, requested-by, justification, optional token period. Its fields map 1:1 to the module's variables.
- `.gitignore` — ignores Terraform/OpenTofu local state and `*.tfvars` (keeps `.tfvars.example` and `.terraform.lock.hcl`, which should be committed).

Uses the `hashicorp/vault` provider — API-compatible with OpenBao, just pointed at `OPENBAO_ADDR`/`secrets-prod.pyur.com`.

## Not yet verified

No `tofu`/`terraform` CLI available in this environment, so the HCL was hand-reviewed for syntax/schema correctness (provider docs for `vault_policy`/`vault_token`) but never run through `tofu validate`/`tofu plan` against a real OpenBao instance (VPN-only, unreachable here). Please run `tofu init && tofu validate` — and ideally a real `tofu plan` against a scratch path — before the first production apply.

## Test plan

- [ ] `tofu init && tofu validate` in `infra/openbao/` — confirms the HCL itself is well-formed.
- [ ] Fill `terraform.tfvars` from the pre-filled example (M365 Statuspage's own request), `tofu plan`, review, `tofu apply` against a scratch/test OpenBao path first.
- [ ] Confirm the issued token can read/write exactly `secret/data/m365-statuspage/azure-client-secret` and nothing else.
- [ ] Open a test issue with the new form template to confirm it renders and validates as expected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFjfhHs3cTGqyXyBvGPyTD)_