### PR TITLE
Demo: postmortem-with-timeline example, firewall auto-past, daily refresh script (#135)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,7 @@ demo-cert-monitoring/.oneuptime-logo-*.id
 !*.tfvars.example
 crash.log
 crash.*.log
+
+# refresh-demo.sh / scripts/refresh_demo.py track which rotating
+# "freshness" incidents they currently own here, across daily runs.
+demo-cert-monitoring/.refresh-demo-state.json

--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -216,6 +216,18 @@ getrennt statt eine Seite mit allem):
      erneut auslösen (No-op, kein Fehler) → beheben → alle vier
      Sicherheitsereignisse korrekt in `timelineIncidents`, nur DocuWare
      bleibt aktiv.
+   - **Postmortem-Beispiel mit Zeitachse und Root-Cause-Analyse (#135):**
+     "Jira-Ticketsuche zeitweise nicht verfügbar" (Anmeldung &
+     Ticket-Suche, vor 35 Tagen, `Resolved`) - anders als die drei
+     Sicherheitsereignisse oben (nur `declaredAt` zurückdatiert) hat
+     dieser Incident eine echte Zeitachse aus vier zeitversetzten
+     `IncidentPublicNote`-Einträgen (erkannt → untersucht → Ursache
+     gefunden → behoben, je mit eigenem `postedAt`) plus eine
+     strukturierte Analyse im nativen `Incident.rootCause`-Feld
+     (Auslöser/Auswirkung/Behebung/Follow-up-Maßnahmen) - beide Felder
+     im tatsächlichen OneUptime-Quellcode bestätigt
+     (`Common/Models/DatabaseModels/{Incident,IncidentPublicNote}.ts`),
+     nicht in die Beschreibung hineingetextet.
 
    Alle Dienste sind feste `Manual`-Monitore ohne Sensor, starten
    automatisch grün und werden nur gezielt (z.B. via Wartung/Incident) auf
@@ -250,7 +262,14 @@ getrennt statt eine Seite mit allem):
 (Patchday 3 läuft immer gerade jetzt, abgeschlossene Wartungen liegen
 immer 6-10 Tage in der Vergangenheit, die Druckerwartung immer am
 kommenden Freitag, das Firewall-Fenster immer Mi–Fr der nächsten Woche),
-damit die Demo auch Wochen später noch aktuell aussieht.
+damit die Demo auch Wochen später noch aktuell aussieht. **Ausnahme,
+bewusst (#135):** ist das Firewall-Fenster einer bereits bestehenden
+Ankündigung schon vorbei, wird es bei einem erneuten `./seed-oneuptime.sh`
+**nicht** erneut in die nächste Woche verschoben - die Ankündigung bleibt
+als vergangener Eintrag stehen (verschwindet dadurch automatisch von der
+aktiven Statusseite, siehe die `iso()`-Zeitzonen-Anmerkung oben zur
+Overview-API-Filterung) statt bei jedem Lauf unbegrenzt in die Zukunft zu
+wandern.
 
 Auch die Incident-Meldung selbst ist deutsch: kippt ein Monitor, legt
 OneUptime automatisch einen Incident **"&lt;Name&gt; ist offline"** an, mit dem
@@ -1039,6 +1058,35 @@ die geseedete Struktur mit zu zerstören; `./seed-oneuptime.sh` konvergiert
 die Struktur ohnehin bei jedem Lauf neu, danach erneut ausführen für einen
 konsistenten Zustand. Enthält `docker volume rm` (löscht Daten) - bewusst
 nicht automatisch mitgetestet, bitte gezielt selbst ausführen.
+
+## Demo täglich frisch halten (#135)
+
+`./refresh-demo.sh` - gedacht für einen täglichen Cron-Job, aber jederzeit
+auch manuell ausführbar (jeder Schritt ist idempotent/best-effort):
+
+1. **Heilt Liegengebliebenes:** ruft alle `fix-*.sh` best-effort auf, falls
+   von einer früheren Vorführung noch ein `break-*.sh` offen war - jeder
+   Fehler ("nichts zu beheben") wird verschluckt statt das Skript
+   abzubrechen. Läuft der Kern-Stack gerade nicht, wird der komplette
+   Lauf übersprungen (nichts ist einer Zielgruppe gegenüber sichtbar
+   kaputt, wenn die Demo gar nicht deployed ist).
+2. **Rotiert einen frischen, bereits aufgelösten Vorfall ein**
+   (`scripts/refresh_demo.py`) aus einem Themen-Pool (Jira-Benachrichtigungen,
+   Kalenderfreigaben, VPN-Neuverbindung, Blueant, WLAN, Jira-Anhänge) -
+   damit eine Demo auch Wochen später noch einen kürzlich behobenen
+   Vorfall zum Zeigen hat statt immer dieselben drei
+   Wochen alten Sicherheitsereignisse. Hält maximal zwei rotierende
+   Einträge gleichzeitig aktiv und löscht den ältesten, bevor ein neuer
+   dazukommt - welche Incidents zur Rotation gehören, steht in
+   `.refresh-demo-state.json` (gitignored), nicht in einem Text-Marker im
+   Vorfall selbst, damit die rotierten Einträge genauso aussehen wie jeder
+   andere echte Vorfall auf der Statusseite.
+
+Als Cron-Job:
+
+```cron
+0 6 * * * cd /pfad/zu/demo-cert-monitoring && ./refresh-demo.sh >> /tmp/refresh-demo.log 2>&1
+```
 
 ## Aufräumen
 

--- a/demo-cert-monitoring/refresh-demo.sh
+++ b/demo-cert-monitoring/refresh-demo.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# Daily "freshness" refresh for repeated demo showings (#135):
+#   1. Best-effort heals anything left broken from a previous demo (a
+#      break-*.sh someone forgot to fix-*.sh) - skipped quietly for any
+#      part of the stack that isn't currently running, since nothing is
+#      visibly broken to an audience if it's offline.
+#   2. Rotates in one freshly-resolved incident from a themed pool
+#      (scripts/refresh_demo.py) and retires the oldest once more than
+#      two are active, so a demo run weeks apart still has something
+#      recently resolved to point at instead of the same static history.
+#
+# Meant to be run once a day, e.g. via cron:
+#   0 6 * * * cd /path/to/demo-cert-monitoring && ./refresh-demo.sh >> /tmp/refresh-demo.log 2>&1
+# Safe to run manually any time too - every step is idempotent/best-effort.
+set -eu
+
+cd "$(dirname "$0")"
+
+echo "==> Demo refresh $(date '+%Y-%m-%d %H:%M') ..."
+
+if ! docker compose ps --status running --services 2>/dev/null | grep -q .; then
+  echo "    core stack isn't running - nothing to heal or rotate, done."
+  exit 0
+fi
+
+echo "==> Healing any scenario left broken from a previous demo (best-effort) ..."
+for script in fix-demo.sh fix-docuware.sh fix-customer-care.sh fix-leipzig-network.sh; do
+  if [ -x "./$script" ]; then
+    ./"$script" >/dev/null 2>&1 && echo "    $script: ok" || echo "    $script: nothing to fix / skipped"
+  fi
+done
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+if [ -f "$ONEUPTIME_CONFIG" ]; then
+  for script in fix-security.sh fix-printer.sh; do
+    if [ -x "./$script" ]; then
+      ./"$script" >/dev/null 2>&1 && echo "    $script: ok" || echo "    $script: nothing to fix / skipped"
+    fi
+  done
+
+  OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+  OU_PORT="${OU_PORT:-80}"
+  if [ "$OU_PORT" = "80" ]; then
+    OU_BASE="http://localhost"
+  else
+    OU_BASE="http://localhost:$OU_PORT"
+  fi
+  export OU_BASE
+
+  echo "==> Rotating in a fresh resolved incident ..."
+  python3 scripts/refresh_demo.py
+else
+  echo "    OneUptime not set up ($ONEUPTIME_CONFIG missing) - skipping incident rotation."
+fi
+
+echo "==> Refresh done."

--- a/demo-cert-monitoring/scripts/refresh_demo.py
+++ b/demo-cert-monitoring/scripts/refresh_demo.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Daily "freshness" rotation for the demo (#135): adds one new resolved
+incident from a themed pool and retires the oldest once the rotating set
+grows past MAX_ROTATING, so a demo repeated over weeks always has a
+recently-resolved incident to point at instead of the same three-week-old
+security events every time.
+
+Standalone (unlike seed_oneuptime.py, which runs its whole seed flow at
+import time and isn't safe to import as a library) - this only touches
+the rotating incidents it owns, all already-seeded monitors, so
+./seed-oneuptime.sh must have run at least once before this works.
+
+Which incidents belong to the rotation is tracked in a local state file
+(.refresh-demo-state.json, gitignored) rather than a marker embedded in
+the incident text - the whole point is these should read exactly like
+any other resolved incident on the status page, not like generated
+demo filler.
+
+Usage: python3 refresh_demo.py
+Invoked by ../refresh-demo.sh, which sets OU_BASE and STATE_FILE.
+"""
+import json
+import os
+import random
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+BASE = os.environ["OU_BASE"]
+EMAIL = os.environ.get("OU_EMAIL", "demo@example.com")
+PASSWORD = os.environ.get("OU_PASSWORD", "DemoDemo123!")
+PROJECT_NAME = os.environ.get("OU_PROJECT", "Zertifikats-Monitoring Demo")
+STATE_FILE = os.environ.get(
+    "REFRESH_STATE_FILE",
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                 ".refresh-demo-state.json"))
+
+MAX_ROTATING = 2  # how many auto-rotated incidents stay visible at once
+
+# (title, monitor name, description) - spans several already-seeded
+# IT-Services/Leipzig monitors so the rotation doesn't always land on the
+# same service. Kept short and low-drama (Minor, resolved within
+# minutes/hours) - this is background "freshness", not a new headline
+# story competing with DocuWare/the live-triggerable scenarios.
+POOL = [
+    ("Kurzzeitige Verzögerung bei Jira-Benachrichtigungen",
+     "Benachrichtigungen",
+     "E-Mail- und Push-Benachrichtigungen aus Jira kamen für rund 20 Minuten "
+     "verzögert an. Tickets selbst waren jederzeit normal erreichbar. Ursache "
+     "war ein kurzzeitig überlasteter Benachrichtigungsdienst, der sich von "
+     "selbst erholt hat."),
+    ("Kalenderfreigaben kurzzeitig nicht sichtbar",
+     "Kalender & Terminfreigabe",
+     "Freigegebene Kalender von Kolleginnen und Kollegen waren für kurze Zeit "
+     "nicht sichtbar - eigene Termine und Einladungen waren davon nicht "
+     "betroffen. Der Synchronisationsdienst wurde neu gestartet, seither "
+     "läuft alles wie gewohnt."),
+    ("VPN-Neuverbindung zeitweise erforderlich",
+     "VPN-Zugang",
+     "Ein Teil der Nutzenden musste sich einmalig neu mit dem VPN verbinden, "
+     "nachdem ein Zertifikat auf dem VPN-Gateway turnusgemäß erneuert wurde. "
+     "Kein Datenverlust, keine Sicherheitsauswirkung."),
+    ("Blueant kurzzeitig langsam",
+     "Blueant",
+     "Blueant reagierte für etwa 10 Minuten spürbar langsamer als gewohnt. "
+     "Ursache war ein einzelner stark ausgelasteter Anwendungsserver, der "
+     "automatisch aus dem Lastverbund genommen wurde."),
+    ("WLAN-Aussetzer im Hauptgebäude",
+     "WLAN",
+     "Im Hauptgebäude kam es für wenige Minuten zu vereinzelten "
+     "WLAN-Verbindungsabbrüchen. Ein Access Point hatte sich aufgehängt und "
+     "wurde automatisch neu gestartet."),
+    ("Datei-Anhänge in Jira kurzzeitig langsam",
+     "Anhänge & Dateien",
+     "Das Hoch- und Herunterladen von Datei-Anhängen in Jira war für kurze "
+     "Zeit deutlich langsamer als gewohnt. Tickets, Kommentare und die Suche "
+     "waren davon nicht betroffen."),
+]
+
+
+def call(path, payload, method="POST"):
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(payload).encode() if payload is not None else None,
+        method=method,
+    )
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if project_id:
+        req.add_header("ProjectID", project_id)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        sys.exit(f"ERROR: {path} -> HTTP {exc.code}: {exc.read().decode()[:300]}")
+    parsed = json.loads(body) if body else {}
+    if isinstance(parsed, dict) and "error" in parsed:
+        sys.exit(f"ERROR: {path} -> {parsed['error']}")
+    return parsed
+
+
+def typed(t, v):
+    return {"_type": t, "value": v}
+
+
+def entity_ref(obj_id):
+    return {"_id": obj_id}
+
+
+def iso(dt):
+    if dt.tzinfo is None:
+        dt = dt.astimezone()
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def get_list(model, query=None, select=None, limit=100):
+    return call(f"/api/{model}/get-list", {
+        "query": query or {}, "select": select or {"_id": True, "name": True},
+        "sort": {}, "skip": 0, "limit": limit,
+    }).get("data", [])
+
+
+def find_by_name(model, name, select=None, name_field="name"):
+    for row in get_list(model, select=select or {"_id": True, name_field: True}):
+        if row.get(name_field) == name:
+            return row
+    return None
+
+
+def load_state():
+    try:
+        with open(STATE_FILE) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"rotating": []}  # list of {"title": ..., "incidentId": ..., "createdAt": iso}
+
+
+def save_state(state):
+    with open(STATE_FILE, "w") as fh:
+        json.dump(state, fh, indent=2)
+
+
+login = call("/api/identity/login", {"data": {
+    "email": typed("Email", EMAIL), "password": typed("HashedString", PASSWORD),
+}})
+token = login.get("_miscData", {}).get("accessToken")
+if not token:
+    sys.exit(f"ERROR: login for {EMAIL} failed - has ./seed-oneuptime.sh run yet?")
+
+project = find_by_name("project", PROJECT_NAME)
+if not project:
+    sys.exit(f"ERROR: project '{PROJECT_NAME}' not found - run ./seed-oneuptime.sh first.")
+project_id = project["_id"]
+
+severities = get_list("incident-severity")
+minor_severity_id = next((s["_id"] for s in severities if "Minor" in s.get("name", "")),
+                         severities[0]["_id"])
+resolved_state_id = next(
+    s["_id"] for s in get_list("incident-state", select={"_id": True, "isResolvedState": True})
+    if s.get("isResolvedState"))
+
+state = load_state()
+rotating = state.get("rotating", [])
+
+# Retire the oldest entries once the rotating set would exceed MAX_ROTATING
+# after adding a new one - deleted outright (not just marked Resolved,
+# they already are) so the status page's incident history doesn't grow
+# forever across months of daily runs.
+while len(rotating) >= MAX_ROTATING:
+    oldest = rotating.pop(0)
+    call(f"/api/incident/{oldest['incidentId']}", None, method="DELETE")
+    print(f"    retired '{oldest['title']}'")
+
+used_titles = {r["title"] for r in rotating}
+candidates = [p for p in POOL if p[0] not in used_titles] or list(POOL)
+title, monitor_name, description = random.choice(candidates)
+
+monitor = find_by_name("monitor", monitor_name)
+if not monitor:
+    sys.exit(f"ERROR: monitor '{monitor_name}' not found - run ./seed-oneuptime.sh first.")
+
+# Declared a few hours ago and already resolved - reads as "something
+# minor happened today and got handled quickly", not a currently-active
+# problem.
+declared_at = datetime.now() - timedelta(hours=random.randint(2, 9))
+payload = {
+    "title": title,
+    "description": description,
+    "incidentSeverityId": minor_severity_id,
+    "currentIncidentStateId": resolved_state_id,
+    "monitors": [entity_ref(monitor["_id"])],
+    "declaredAt": iso(declared_at),
+    "projectId": project_id,
+}
+created = call("/api/incident", {"data": payload})
+rotating.append({"title": title, "incidentId": created["_id"], "createdAt": iso(datetime.now())})
+save_state({"rotating": rotating})
+print(f"==> Added '{title}' (resolved, {declared_at.strftime('%d.%m. %H:%M')}) - "
+      f"{len(rotating)}/{MAX_ROTATING} rotating incidents now active.")

--- a/demo-cert-monitoring/scripts/seed_oneuptime.py
+++ b/demo-cert-monitoring/scripts/seed_oneuptime.py
@@ -698,6 +698,99 @@ SECURITY_EVENTS = [
 for title, monitor_id, days_ago, description in SECURITY_EVENTS:
     ensure_security_incident(title, monitor_id, days_ago, description)
 
+# ── Postmortem-Beispiel: eine Zeitachse aus echten IncidentPublicNotes +
+# das native rootCause-Feld (#135) ─────────────────────────────────────────
+# Die drei SECURITY_EVENTS oben sind bewusst einzeilig (nur declaredAt
+# zurückdatiert) - für ein Postmortem-Beispiel braucht es eine echte
+# Zeitachse (mehrere zeitversetzte IncidentPublicNotes: erkannt ->
+# untersucht -> Ursache gefunden -> behoben) plus eine strukturierte
+# Root-Cause-Analyse. Confirmed against the actual OneUptime source
+# (Common/Models/DatabaseModels/{Incident,IncidentPublicNote}.ts, not
+# guessed): Incident has a dedicated Markdown `rootCause` column, and
+# IncidentPublicNote has a settable `postedAt` column - so both pieces
+# of this ask map onto real, native OneUptime fields instead of being
+# faked into the description text.
+POSTMORTEM_TITLE = "Jira-Ticketsuche zeitweise nicht verfügbar"
+postmortem_declared_at = datetime.now() - timedelta(days=35)
+POSTMORTEM_TIMELINE = [
+    (0, "**Erkannt.** Monitoring meldet eine erhöhte Fehlerquote bei der "
+        "Ticket-Suche in Jira. Die IT hat die Untersuchung begonnen."),
+    (8, "**Untersucht.** Der Fehler wurde auf den Suchindex-Dienst "
+        "eingegrenzt. Wir prüfen, ob ein Neustart des Dienstes hilft."),
+    (22, "**Ursache gefunden.** Ein automatisches Sicherheitsupdate hat den "
+         "Suchindex-Dienst in der Nacht auf eine inkompatible "
+         "Java-Version aktualisiert - dadurch stürzte er unter der "
+         "Vormittagslast wiederholt ab."),
+    (35, "**Behoben.** Der Suchindex-Dienst wurde auf die vorherige "
+         "Java-Version zurückgesetzt und läuft seither stabil. Die "
+         "Ticket-Suche funktioniert wieder normal."),
+]
+postmortem_root_cause = (
+    "**Auslöser:** Ein automatisches Sicherheitsupdate hat nachts die "
+    "Java-Laufzeitumgebung des Jira-Suchindex-Dienstes (Lucene) auf eine "
+    "Version aktualisiert, die mit der eingesetzten Suchindex-Version "
+    "nicht vollständig kompatibel war.\n\n"
+    "**Auswirkung:** Der Suchindex-Dienst stürzte unter der "
+    "Vormittagslast wiederholt ab und startete automatisch neu, was zu "
+    "zeitweise sehr langsamen oder fehlschlagenden Ticket-Suchen führte. "
+    "Anlegen und Bearbeiten von Tickets war durchgehend möglich - nur "
+    "die Suche war betroffen.\n\n"
+    "**Behebung:** Rollback der Java-Laufzeitumgebung auf die zuletzt "
+    "bekannt gute Version. Das automatische Sicherheitsupdate wurde für "
+    "diesen Dienst pausiert, bis die Kompatibilität mit der nächsten "
+    "Suchindex-Version geprüft ist.\n\n"
+    "**Follow-up-Maßnahmen:**\n"
+    "- Kompatibilitätstest neuer Java-Versionen in einer "
+    "Staging-Umgebung vor dem Rollout\n"
+    "- Alarmierung bereits bei wiederholten Dienst-Neustarts, nicht "
+    "erst beim kompletten Ausfall\n"
+    "- Java-Version des Suchindex-Dienstes in die "
+    "Änderungs-Checkliste für Sicherheitsupdates aufgenommen"
+)
+postmortem_description = (
+    "Die Ticket-Suche in Jira war zeitweise sehr langsam oder lieferte "
+    "keine Ergebnisse. **Anlegen und Bearbeiten von Tickets war "
+    "jederzeit möglich** - nur die Suche war betroffen. Die Störung ist "
+    "behoben; die vollständige Zeitachse und Root-Cause-Analyse stehen "
+    "unten."
+)
+
+postmortem_payload = {
+    "title": POSTMORTEM_TITLE,
+    "description": postmortem_description,
+    "rootCause": postmortem_root_cause,
+    "incidentSeverityId": security_severity,
+    "currentIncidentStateId": security_resolved_state_id,
+    "monitors": [entity_ref(monitor_ids["Anmeldung & Ticket-Suche"])],
+    "declaredAt": iso(postmortem_declared_at),
+}
+existing_postmortem = find_by_name("incident", POSTMORTEM_TITLE,
+                                   select={"_id": True, "title": True}, legacy=[], name_field="title")
+if existing_postmortem:
+    postmortem_incident_id = existing_postmortem["_id"]
+    call(f"/api/incident/{postmortem_incident_id}", {"data": postmortem_payload}, method="PUT")
+    print(f"    updated postmortem incident '{POSTMORTEM_TITLE}'")
+else:
+    postmortem_payload["projectId"] = project_id
+    postmortem_incident_id = call("/api/incident", {"data": postmortem_payload})["_id"]
+    print(f"    created postmortem incident '{POSTMORTEM_TITLE}' "
+          f"({postmortem_declared_at.strftime('%d.%m.%Y')})")
+
+existing_postmortem_notes = get_list(
+    "incident-public-note", query={"incidentId": postmortem_incident_id},
+    select={"_id": True, "note": True})
+for minutes_after, note_text in POSTMORTEM_TIMELINE:
+    if any(n.get("note") == note_text for n in existing_postmortem_notes):
+        continue
+    call("/api/incident-public-note", {"data": {
+        "projectId": project_id,
+        "incidentId": postmortem_incident_id,
+        "note": note_text,
+        "postedAt": iso(postmortem_declared_at + timedelta(minutes=minutes_after)),
+        "shouldStatusPageSubscribersBeNotifiedOnNoteCreated": False,
+    }})
+print(f"    postmortem timeline: {len(POSTMORTEM_TIMELINE)} entries ensured")
+
 # DocuWare-Cluster: einfache Nutzeransicht + Major Incident. Deliberately a
 # Manual monitor, NOT the demo-broken-site-style heartbeat: the whole
 # point of this example is "site reachable, login broken" - a distinction
@@ -1230,12 +1323,6 @@ ensure_scheduled_maintenance(
     printer_start, printer_end, sm_scheduled, [printer_monitor_id], [leipzig_page_id],
 )
 
-# Announcement: firewall upgrade window Wed 20:00 - Fri 06:00 next week.
-fw_monday = next_week_monday()
-fw_start = (fw_monday + timedelta(days=2)).replace(hour=20, minute=0)  # Wednesday
-fw_end = (fw_monday + timedelta(days=4)).replace(hour=6, minute=0)     # Friday
-
-
 def ensure_announcement(title, description, show_at, end_at, status_page_ids):
     found = find_by_name("status-page-announcement", title, select={"_id": True, "title": True},
                      legacy=[], name_field="title")
@@ -1255,15 +1342,60 @@ def ensure_announcement(title, description, show_at, end_at, status_page_ids):
     return created["_id"]
 
 
-ensure_announcement(
-    "Geplantes Firewall-Upgrade (Barracuda)",
-    f"Zwischen **{fmt_de(fw_start)}** und **{fmt_de(fw_end)}** führt die IT ein geplantes "
-    f"Upgrade der Barracuda-Firewall durch. Das Zeitfenster liegt außerhalb der "
-    f"Kernarbeitszeit; dennoch kann es zu **kurzen, wenige Minuten dauernden "
-    f"Unterbrechungen** der Internetverbindung kommen. Ein genauer Termin innerhalb "
-    f"des Fensters wird noch bekanntgegeben.",
-    now, fw_end, [it_service_page_id, leipzig_page_id],
-)
+def parse_iso_loosely(value):
+    """Best-effort parse of a Date/DateTime value as returned by get-list -
+    either a plain ISO string (how iso() writes it - Date/DateTime columns
+    take a plain string, see iso()'s own docstring above) or, defensively,
+    a {"_type": "Date", "value": ...} typed wrapper as other column types
+    use elsewhere in this script. Returns None on anything unexpected -
+    callers must treat that as "unknown, not confirmed past" rather than
+    fail the whole seed run over a formatting mismatch."""
+    if isinstance(value, dict):
+        value = value.get("value")
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# Announcement: firewall upgrade window Wed 20:00 - Fri 06:00 next week.
+# #135: once an existing announcement's window has already ended, leave
+# it alone instead of fast-forwarding it into next week again on every
+# reseed. OneUptime's own overview API already stops treating an
+# announcement as active once `now` passes `endAnnouncementAt` (see the
+# iso()-timezone bug note above) - so an already-elapsed window
+# naturally reads as history on the status page. Without this check,
+# reseeding the day after the window ended would silently resurrect it
+# into a brand-new future window instead of ever letting it finish -
+# exactly the "am Tag danach automatisch als vergangen behandeln" ask.
+FW_ANNOUNCEMENT_TITLE = "Geplantes Firewall-Upgrade (Barracuda)"
+existing_fw_announcement = find_by_name(
+    "status-page-announcement", FW_ANNOUNCEMENT_TITLE,
+    select={"_id": True, "title": True, "endAnnouncementAt": True},
+    legacy=[], name_field="title")
+fw_end_parsed = (
+    parse_iso_loosely(existing_fw_announcement.get("endAnnouncementAt"))
+    if existing_fw_announcement else None)
+fw_already_past = fw_end_parsed is not None and fw_end_parsed < datetime.now(timezone.utc)
+
+if fw_already_past:
+    print(f"    '{FW_ANNOUNCEMENT_TITLE}' window already ended ({fw_end_parsed.date()}) - "
+          f"leaving it as history instead of moving it to next week")
+else:
+    fw_monday = next_week_monday()
+    fw_start = (fw_monday + timedelta(days=2)).replace(hour=20, minute=0)  # Wednesday
+    fw_end = (fw_monday + timedelta(days=4)).replace(hour=6, minute=0)     # Friday
+    ensure_announcement(
+        FW_ANNOUNCEMENT_TITLE,
+        f"Zwischen **{fmt_de(fw_start)}** und **{fmt_de(fw_end)}** führt die IT ein geplantes "
+        f"Upgrade der Barracuda-Firewall durch. Das Zeitfenster liegt außerhalb der "
+        f"Kernarbeitszeit; dennoch kann es zu **kurzen, wenige Minuten dauernden "
+        f"Unterbrechungen** der Internetverbindung kommen. Ein genauer Termin innerhalb "
+        f"des Fensters wird noch bekanntgegeben.",
+        now, fw_end, [it_service_page_id, leipzig_page_id],
+    )
 
 # ── 6) Interne Admin-Sicht: Infrastruktur- und LLM-Observability ────────────
 # MonitorGroup/MonitorGroupResource organize monitors on OneUptime's OWN


### PR DESCRIPTION
## Summary

Works through several items from the demo backlog in #135 ("Demo: Offene Vorschläge & Verifikationen").

- **Postmortem-Beispiel mit Zeitachse und Root-Cause-Analyse**: new resolved historical incident, "Jira-Ticketsuche zeitweise nicht verfügbar", with a real timeline of four timestamped `IncidentPublicNote`s (erkannt → untersucht → Ursache gefunden → behoben, each with its own `postedAt`) and a structured writeup in the native `Incident.rootCause` Markdown field. Both fields confirmed against the actual OneUptime source (`Common/Models/DatabaseModels/{Incident,IncidentPublicNote}.ts`) rather than guessed.
- **Firewall-Ankündigung am Tag danach automatisch als vergangen behandeln**: previously, every `./seed-oneuptime.sh` run recomputed the firewall-upgrade window as "next week" unconditionally, so it could never actually become history. Now: if an existing announcement's window has already ended, it's left untouched instead of being fast-forwarded into the future again.
- **Automatisches "Auffrischen"**: `refresh-demo.sh` + `scripts/refresh_demo.py`, meant for a daily cron job (but safe to run manually anytime — every step is idempotent/best-effort). Heals anything left broken from a previous demo run (calls the `fix-*.sh` scripts, swallowing "nothing to fix" errors; skips entirely if the stack isn't running) and rotates in one freshly-resolved incident from a themed pool of 6, capping at 2 active and retiring the oldest first.

Two backlog items were investigated and intentionally **not** implemented (details in the linked comments on #135):
- **Abonnenten-Simulation**: OneUptime's public status page genuinely has no subscriber-count UI anywhere (confirmed by cloning and grepping the actual frontend source) — implementing it would mean faking something the product doesn't do, which goes against this demo's existing precedent (see the Service-Catalog decision against a fake dependency graph).
- **Grafana-DocuWare-Dashboard visuelle Bestätigung**: structurally verified (all 17 panels present), but actual pixel rendering needs a live browser against a live Grafana instance — not possible in this environment (Docker Hub pulls are blocked by this session's egress policy).

#143, #146 and #147 were also closed in this session after static-source and (where possible - the notification mockups are static HTML, no Docker needed) live-Chromium verification of their own outstanding "Noch offen" items.

## Test plan

- [x] `python3 -m py_compile` on `seed_oneuptime.py` and the new `refresh_demo.py` — passes.
- [x] `sh -n` on `refresh-demo.sh` — passes.
- [ ] Not verified end-to-end against a running OneUptime instance in this session (Docker Hub pulls blocked here — confirmed via `curl http://127.0.0.1:36509/__agentproxy/status`, `403` on `production.cloudfront.docker.com`). To verify: `./start-demo.sh --with-oneuptime && ./seed-oneuptime.sh` — expect the new "Jira-Ticketsuche zeitweise nicht verfügbar" incident with its 4-entry timeline and root-cause writeup to appear on the IT-Services status page; then `./refresh-demo.sh` to see the rotation add a themed incident.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnPKEJEq6XeyPzze5P3BQM)_