### PR TITLE
In-app OpenBao access request form (/openbao-request)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,16 @@ OPENBAO_TOKEN=
 OPENBAO_RENEWAL_THRESHOLD_DAYS=30
 OPENBAO_NEW_SECRET_LIFETIME_DAYS=180
 
+# GitHub – NUR zum Einreichen von OpenBao-Zugriffsanfragen über die In-App-Seite
+# "/openbao-request" (Alternative zum GitHub-Issue-Formular für Anforderer ohne
+# eigenen GitHub-Account). Fine-grained PAT mit "Issues: Read and write" NUR auf
+# das Repo unten. Leer lassen = die Seite zeigt einen Hinweis statt automatisch
+# einzureichen. Bewusst nicht "GITHUB_TOKEN" genannt – manche Umgebungen (CI-Runner,
+# Dev-Sandboxes) setzen von sich aus eine generische GITHUB_TOKEN-Variable, die
+# sonst unbeabsichtigt übernommen würde.
+OPENBAO_REQUEST_GITHUB_TOKEN=
+OPENBAO_REQUEST_GITHUB_REPO=nic2045/My-M365-Statuspage
+
 # Sicherheit – Session-Schlüssel.
 # Leer lassen: Beim ersten Start wird automatisch ein 32-Byte-Hex-String
 # generiert und unter data/secret_key persistiert (überlebt Neustarts).

--- a/README.en.md
+++ b/README.en.md
@@ -124,6 +124,14 @@ registration - more than the app needs day to day (`ServiceHealth.Read.All`). Se
 `AZURE_MGMT_TENANT_ID`/`_CLIENT_ID`/`_CLIENT_SECRET` to use a separate, narrower-scoped
 credential for that instead of permanently over-privileging the main app registration.
 
+**Requesting OpenBao access for a (new) app:** `infra/openbao/` (OpenTofu) automates the
+Cloud Operator side (policy + token) - requesters submit either via the GitHub issue form
+(`.github/ISSUE_TEMPLATE/openbao-secret-request.yml`) or, without a GitHub account, via
+**`/openbao-request`** in this app (any logged-in tenant user, see the nav bar) - files the
+same kind of issue automatically. Configure via `OPENBAO_REQUEST_GITHUB_TOKEN`/
+`OPENBAO_REQUEST_GITHUB_REPO` (see configuration reference below); without a token set, the
+page just shows a message instead of submitting automatically.
+
 ---
 
 ## Admin authorization (app role)
@@ -167,6 +175,8 @@ Alternatively or in addition, set an email allowlist (`ADMIN_EMAILS`, OR-combine
 | `OPENBAO_TOKEN` | OpenBao token with read/write on the path above | *(empty)* |
 | `OPENBAO_RENEWAL_THRESHOLD_DAYS` | Rotate when the stored secret expires within this many days | `30` |
 | `OPENBAO_NEW_SECRET_LIFETIME_DAYS` | Lifetime given to a newly created secret | `180` |
+| `OPENBAO_REQUEST_GITHUB_TOKEN` | Fine-grained PAT (`Issues: Read and write`) for `/openbao-request` - empty = page only shows a message | *(empty)* |
+| `OPENBAO_REQUEST_GITHUB_REPO` | Target repo (`owner/name`) for the issues it files | `nic2045/My-M365-Statuspage` |
 
 **Supported `MONITORED_SERVICES` values** (must match the Graph API names exactly):
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ App-Registrierung – mehr, als die App im Alltag benötigt (`ServiceHealth.Read
 enger berechtigte Credential hinterlegen, statt der Haupt-App-Registrierung diese zusätzliche
 Berechtigung dauerhaft zu geben.
 
+**OpenBao-Zugriff für eine (neue) App anfordern:** `infra/openbao/` (OpenTofu) automatisiert
+die Cloud-Operator-Seite (Policy + Token) – Anforderer reichen ihre Anfrage entweder über das
+GitHub-Issue-Formular (`.github/ISSUE_TEMPLATE/openbao-secret-request.yml`) oder, ohne eigenen
+GitHub-Account, über **`/openbao-request`** in dieser App ein (jeder eingeloggte Tenant-Nutzer,
+siehe Navigationsleiste) – legt automatisch das gleiche Issue an. Setup dafür:
+`OPENBAO_REQUEST_GITHUB_TOKEN`/`OPENBAO_REQUEST_GITHUB_REPO` (siehe Konfigurationsreferenz
+unten); ohne gesetzten Token zeigt die Seite nur einen Hinweis statt automatisch einzureichen.
+
 ---
 
 ## Admin-Berechtigung (App-Rolle)
@@ -166,6 +174,8 @@ Alternativ oder ergänzend kannst du eine E-Mail-Allowlist setzen (`ADMIN_EMAILS
 | `OPENBAO_TOKEN` | OpenBao-Token mit Lese-/Schreibrecht auf obigem Pfad | *(leer)* |
 | `OPENBAO_RENEWAL_THRESHOLD_DAYS` | Rotieren, wenn das gespeicherte Secret innerhalb dieser Tage abläuft | `30` |
 | `OPENBAO_NEW_SECRET_LIFETIME_DAYS` | Gültigkeitsdauer eines neu erstellten Secrets | `180` |
+| `OPENBAO_REQUEST_GITHUB_TOKEN` | Fine-grained PAT (`Issues: Read and write`) für `/openbao-request` – leer = Seite zeigt nur einen Hinweis | *(leer)* |
+| `OPENBAO_REQUEST_GITHUB_REPO` | Ziel-Repo (`owner/name`) für die dort angelegten Issues | `nic2045/My-M365-Statuspage` |
 
 **Unterstützte `MONITORED_SERVICES`-Werte** (Graph API-Namen exakt einhalten):
 

--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,16 @@ class Settings(BaseSettings):
     OPENBAO_RENEWAL_THRESHOLD_DAYS: int = 30
     OPENBAO_NEW_SECRET_LIFETIME_DAYS: int = 180
 
+    # GitHub - used only to file OpenBao secret-access requests on behalf of logged-in users
+    # who don't have/want a GitHub account (see app/routers/openbao_request.py). Use a
+    # fine-grained PAT scoped to Issues:write on the repo below only - never repo-admin,
+    # never other repos. Deliberately NOT named plain GITHUB_TOKEN/GITHUB_REPO - some
+    # deployment environments (CI runners, dev sandboxes) set a generic GITHUB_TOKEN of
+    # their own in the process environment, which pydantic-settings would silently pick up
+    # instead of an explicitly configured value.
+    OPENBAO_REQUEST_GITHUB_TOKEN: str = ""
+    OPENBAO_REQUEST_GITHUB_REPO: str = "nic2045/My-M365-Statuspage"
+
     # Session security – empty/placeholder triggers auto-generation on first run
     # (persisted to data/secret_key so sessions survive restarts).
     SECRET_KEY: str = ""

--- a/app/github_issue_client.py
+++ b/app/github_issue_client.py
@@ -1,0 +1,52 @@
+"""Minimal async GitHub REST client: creates one issue.
+
+Used by app.routers.openbao_request to file an OpenBao secret-access request
+(see .github/ISSUE_TEMPLATE/openbao-secret-request.yml) on behalf of a
+logged-in user who doesn't have (or doesn't want to use) a GitHub account -
+same destination repo, same fields, so the Cloud Operator's process
+(infra/openbao/README.md) never needs to know which path a request came in
+through.
+"""
+from __future__ import annotations
+
+import httpx
+
+_API_BASE = "https://api.github.com"
+_TIMEOUT = 15.0
+
+
+class GitHubIssueError(RuntimeError):
+    """Raised when filing the GitHub issue fails - message is user-facing."""
+
+
+async def create_issue(
+    *,
+    repo: str,
+    token: str,
+    title: str,
+    body: str,
+    labels: list[str],
+    transport: httpx.BaseTransport | None = None,
+) -> str:
+    """Creates an issue in `repo` ("owner/name"). Returns the issue's HTML URL.
+
+    -transport is a test-only hook (httpx.MockTransport) - production callers never pass
+    it, so httpx uses its normal network transport.
+    """
+    async with httpx.AsyncClient(timeout=_TIMEOUT, transport=transport) as client:
+        try:
+            response = await client.post(
+                f"{_API_BASE}/repos/{repo}/issues",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json={"title": title, "body": body, "labels": labels},
+            )
+        except httpx.HTTPError as exc:
+            raise GitHubIssueError(f"GitHub war nicht erreichbar: {exc}") from exc
+    if response.status_code >= 400:
+        raise GitHubIssueError(
+            f"GitHub hat die Anfrage abgelehnt (HTTP {response.status_code}): {response.text[:200]}"
+        )
+    return response.json()["html_url"]

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -351,6 +351,21 @@ LABELS_DE: dict[str, str] = {
     "duration.month_one":             "1 Monat",
     "duration.month_many":            "{n} Monate",
     "datetime.today":                 "heute",
+    # OpenBao secret-access request form
+    "openbao_request.title":            "OpenBao-Zugriff anfordern",
+    "openbao_request.intro":            "Fordert einen OpenBao-verwalteten Secret-Zugriff für eine App an - ein Cloud Operator richtet Policy und Token über infra/openbao (OpenTofu) ein und meldet sich mit dem Ergebnis. Kein GitHub-Account nötig.",
+    "openbao_request.app_name_label":   "App-Name",
+    "openbao_request.app_name_hint":    "Kurz, eindeutig, klein geschrieben mit Bindestrichen - wird Policy-Name und Teil des Secret-Pfads.",
+    "openbao_request.secret_name_label": "Secret-Name",
+    "openbao_request.secret_name_hint": "Genau ein Secret pro Anfrage - für ein weiteres, unabhängiges Secret bitte separat anfragen.",
+    "openbao_request.requested_by_label": "Angefordert von (Team oder Person)",
+    "openbao_request.justification_label": "Warum wird der Zugriff benötigt?",
+    "openbao_request.token_period_label": "Token-Renewal-Zeitraum (optional)",
+    "openbao_request.token_period_hint": "In Sekunden. Leer lassen für den Standard (30 Tage).",
+    "openbao_request.submit":           "Anfrage einreichen",
+    "openbao_request.success_title":    "Anfrage eingereicht",
+    "openbao_request.success_body":     "Ein Cloud Operator prüft die Anfrage und meldet sich mit dem Ergebnis. Verfolgen kannst du sie hier:",
+    "openbao_request.error_not_configured": "Automatische Einreichung ist nicht konfiguriert (OPENBAO_REQUEST_GITHUB_TOKEN fehlt) - bitte den Cloud Operator direkt kontaktieren.",
 }
 
 
@@ -679,6 +694,21 @@ LABELS_EN: dict[str, str] = {
     "duration.month_one":             "1 month",
     "duration.month_many":            "{n} months",
     "datetime.today":                 "today",
+    # OpenBao secret-access request form
+    "openbao_request.title":            "Request OpenBao access",
+    "openbao_request.intro":            "Request an OpenBao-managed secret for an app - a Cloud Operator sets up the policy and token via infra/openbao (OpenTofu) and follows up with the result. No GitHub account needed.",
+    "openbao_request.app_name_label":   "App name",
+    "openbao_request.app_name_hint":    "Short, unique, lowercase-with-dashes - becomes the policy name and part of the secret path.",
+    "openbao_request.secret_name_label": "Secret name",
+    "openbao_request.secret_name_hint": "Exactly one secret per request - open a separate request for a second, unrelated secret.",
+    "openbao_request.requested_by_label": "Requested by (team or person)",
+    "openbao_request.justification_label": "Why is this access needed?",
+    "openbao_request.token_period_label": "Token renewal period (optional)",
+    "openbao_request.token_period_hint": "In seconds. Leave blank for the default (30 days).",
+    "openbao_request.submit":           "Submit request",
+    "openbao_request.success_title":    "Request submitted",
+    "openbao_request.success_body":     "A Cloud Operator will review it and follow up with the result. Track it here:",
+    "openbao_request.error_not_configured": "Automatic submission isn't configured (OPENBAO_REQUEST_GITHUB_TOKEN missing) - please contact the Cloud Operator directly.",
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from app.i18n import (
     resolve_language,
     set_current_language,
 )
-from app.routers import admin, api, auth_router, embed, status
+from app.routers import admin, api, auth_router, embed, openbao_request, status
 from app.routers.subscribers import router as subscribers_router
 from app.scheduler import start_scheduler, stop_scheduler
 
@@ -201,3 +201,4 @@ app.include_router(embed.router)
 app.include_router(api.router)
 app.include_router(admin.router)
 app.include_router(subscribers_router)
+app.include_router(openbao_request.router)

--- a/app/routers/openbao_request.py
+++ b/app/routers/openbao_request.py
@@ -1,0 +1,122 @@
+"""Web form mirroring .github/ISSUE_TEMPLATE/openbao-secret-request.yml, for
+requesters who don't have (or don't want to use) a GitHub account. Files the
+exact same shape of issue via the GitHub API, so the Cloud Operator's process
+(infra/openbao/README.md) never needs to know which path a request came in
+through - just the resulting issue.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse
+
+from app.auth import require_auth
+from app.config import settings
+from app.github_issue_client import GitHubIssueError, create_issue
+from app.templates import templates
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["openbao-request"])
+
+
+def _build_issue(
+    *,
+    app_name: str,
+    secret_name: str,
+    requested_by: str,
+    justification: str,
+    token_period: str,
+    submitted_by: str,
+) -> tuple[str, str]:
+    title = f"[OpenBao] {app_name}"
+    body = "\n".join(
+        [
+            "### App name",
+            "",
+            app_name,
+            "",
+            "### Secret name",
+            "",
+            secret_name,
+            "",
+            "### Requested by (team or person)",
+            "",
+            requested_by,
+            "",
+            "### Why does this app need it?",
+            "",
+            justification,
+            "",
+            "### Token renewal period (optional)",
+            "",
+            token_period or "_(default)_",
+            "",
+            "---",
+            f"_Filed via the in-app request form by {submitted_by}._",
+        ]
+    )
+    return title, body
+
+
+@router.get("/openbao-request", response_class=HTMLResponse)
+async def openbao_request_form(request: Request, user: dict = Depends(require_auth)):
+    return templates.TemplateResponse(
+        request,
+        "openbao_request.html",
+        {
+            "user": user,
+            "page_title": "OpenBao",
+            "form": {
+                "app_name": "",
+                "secret_name": "",
+                "requested_by": user.get("name") or user.get("email") or "",
+                "justification": "",
+                "token_period": "",
+            },
+        },
+    )
+
+
+@router.post("/openbao-request", response_class=HTMLResponse)
+async def openbao_request_submit(
+    request: Request,
+    app_name: Annotated[str, Form()],
+    secret_name: Annotated[str, Form()],
+    requested_by: Annotated[str, Form()],
+    justification: Annotated[str, Form()],
+    token_period: Annotated[str, Form()] = "",
+    user: dict = Depends(require_auth),
+):
+    form = {
+        "app_name": app_name.strip(),
+        "secret_name": secret_name.strip(),
+        "requested_by": requested_by.strip(),
+        "justification": justification.strip(),
+        "token_period": token_period.strip(),
+    }
+    context = {"user": user, "page_title": "OpenBao", "form": form}
+
+    if not settings.OPENBAO_REQUEST_GITHUB_TOKEN:
+        context["error"] = "openbao_request.error_not_configured"
+        return templates.TemplateResponse(request, "openbao_request.html", context)
+
+    submitted_by = user.get("email") or user.get("preferred_username") or user.get("sub", "unknown")
+    title, body = _build_issue(**form, submitted_by=submitted_by)
+    try:
+        issue_url = await create_issue(
+            repo=settings.OPENBAO_REQUEST_GITHUB_REPO,
+            token=settings.OPENBAO_REQUEST_GITHUB_TOKEN,
+            title=title,
+            body=body,
+            labels=["openbao-request"],
+        )
+    except GitHubIssueError as exc:
+        logger.warning("Failed to file OpenBao request issue: %s", exc)
+        context["error_detail"] = str(exc)
+        return templates.TemplateResponse(request, "openbao_request.html", context)
+
+    return templates.TemplateResponse(
+        request, "openbao_request.html", {**context, "success_url": issue_url}
+    )

--- a/infra/openbao/README.md
+++ b/infra/openbao/README.md
@@ -10,7 +10,9 @@ needs one OpenBao-backed secret with the same read/write-your-own-path shape.
 
 - **Anforderer (requester):** opens an issue with
   [`.github/ISSUE_TEMPLATE/openbao-secret-request.yml`](../../.github/ISSUE_TEMPLATE/openbao-secret-request.yml) -
-  fills in app name, which secret, and why. That's their one manual step.
+  or, without a GitHub account, fills in the same fields at `/openbao-request` in the
+  M365 Statuspage app itself (any logged-in tenant user - files the identical issue via
+  the GitHub API). Either way: app name, which secret, and why. That's their one manual step.
 - **Cloud Operator:** the only one who runs this module - needs VPN connectivity to
   `secrets-prod.pyur.com` and an OpenBao token with rights to create policies and
   tokens (an admin/root token, not the app's own eventual token). Copies the issue's

--- a/templates/base.html
+++ b/templates/base.html
@@ -121,6 +121,10 @@
           class="text-sm font-medium text-white/80 hover:text-white transition-colors"
         >{{ L["admin.title"] }}</a>
         <a
+          href="/openbao-request"
+          class="text-sm font-medium text-white/80 hover:text-white transition-colors hidden sm:block"
+        >{{ L["openbao_request.title"] }}</a>
+        <a
           href="/auth/logout"
           class="text-sm font-medium text-white/80 hover:text-white transition-colors"
         >{{ L["page.logout"] }}</a>

--- a/templates/openbao_request.html
+++ b/templates/openbao_request.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="max-w-lg mx-auto mt-12 mb-12">
+  <div class="mb-6">
+    <h1 class="text-xl font-semibold text-gray-900 dark:text-white">{{ L["openbao_request.title"] }}</h1>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{{ L["openbao_request.intro"] }}</p>
+  </div>
+
+  {% if success_url %}
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 px-8 py-10 shadow-sm text-center">
+    <div class="w-12 h-12 rounded-full bg-emerald-100 dark:bg-emerald-900/40 flex items-center justify-center mx-auto mb-4">
+      <svg class="w-6 h-6 text-emerald-600 dark:text-emerald-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+      </svg>
+    </div>
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">{{ L["openbao_request.success_title"] }}</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{{ L["openbao_request.success_body"] }}</p>
+    <a href="{{ success_url }}" target="_blank" rel="noopener"
+       class="inline-flex items-center gap-1.5 text-sm text-brand dark:text-brand-light hover:underline">
+      {{ success_url }}
+    </a>
+  </div>
+  {% else %}
+
+  {% if error %}
+  <div class="mb-4 px-4 py-3 rounded-xl bg-red-50 border border-red-200 text-red-800 dark:bg-red-950/60 dark:border-red-800 dark:text-red-200 text-sm">
+    {{ L[error] }}
+  </div>
+  {% elif error_detail %}
+  <div class="mb-4 px-4 py-3 rounded-xl bg-red-50 border border-red-200 text-red-800 dark:bg-red-950/60 dark:border-red-800 dark:text-red-200 text-sm">
+    {{ error_detail }}
+  </div>
+  {% endif %}
+
+  <div class="bg-white dark:bg-gray-900 rounded-2xl border border-gray-100 dark:border-gray-800 shadow-sm overflow-hidden">
+    <form method="post" action="/openbao-request" class="p-5 space-y-4">
+      <div>
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{{ L["openbao_request.app_name_label"] }}</label>
+        <input type="text" name="app_name" required
+               value="{{ form.app_name }}"
+               placeholder="m365-statuspage"
+               autocomplete="off" spellcheck="false"
+               class="w-full text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+        <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{{ L["openbao_request.app_name_hint"] }}</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{{ L["openbao_request.secret_name_label"] }}</label>
+        <input type="text" name="secret_name" required
+               value="{{ form.secret_name }}"
+               placeholder="azure-client-secret"
+               autocomplete="off" spellcheck="false"
+               class="w-full text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+        <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{{ L["openbao_request.secret_name_hint"] }}</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{{ L["openbao_request.requested_by_label"] }}</label>
+        <input type="text" name="requested_by" required
+               value="{{ form.requested_by }}"
+               class="w-full text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{{ L["openbao_request.justification_label"] }}</label>
+        <textarea name="justification" required rows="3"
+                  class="w-full text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500">{{ form.justification }}</textarea>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">{{ L["openbao_request.token_period_label"] }}</label>
+        <input type="number" name="token_period" min="0"
+               value="{{ form.token_period }}"
+               placeholder="2592000"
+               class="w-full text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-800 dark:text-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono" />
+        <p class="text-[11px] text-gray-400 dark:text-gray-500 mt-1">{{ L["openbao_request.token_period_hint"] }}</p>
+      </div>
+
+      <div class="flex items-center justify-end pt-2 border-t border-gray-100 dark:border-gray-800">
+        <button type="submit"
+                class="inline-flex items-center gap-2 text-sm px-4 py-1.5 rounded-lg bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50 font-medium transition-colors">
+          {{ L["openbao_request.submit"] }}
+        </button>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_github_issue_client.py
+++ b/tests/test_github_issue_client.py
@@ -1,0 +1,59 @@
+"""Unit tests for app.github_issue_client - no real network access (httpx.MockTransport)."""
+import httpx
+import pytest
+
+from app.github_issue_client import GitHubIssueError, create_issue
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+@pytest.mark.asyncio
+async def test_create_issue_returns_html_url():
+    def handler(request):
+        assert request.headers["Authorization"] == "Bearer tok"
+        assert request.url.path == "/repos/nic2045/My-M365-Statuspage/issues"
+        return httpx.Response(201, json={"html_url": "https://github.com/nic2045/My-M365-Statuspage/issues/1"})
+
+    url = await create_issue(
+        repo="nic2045/My-M365-Statuspage",
+        token="tok",
+        title="[OpenBao] foo",
+        body="body",
+        labels=["openbao-request"],
+        transport=_transport(handler),
+    )
+    assert url == "https://github.com/nic2045/My-M365-Statuspage/issues/1"
+
+
+@pytest.mark.asyncio
+async def test_create_issue_raises_on_http_error_status():
+    def handler(request):
+        return httpx.Response(403, json={"message": "GitHub access is not enabled"})
+
+    with pytest.raises(GitHubIssueError):
+        await create_issue(
+            repo="nic2045/My-M365-Statuspage",
+            token="tok",
+            title="t",
+            body="b",
+            labels=[],
+            transport=_transport(handler),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_issue_raises_on_connection_failure():
+    def handler(request):
+        raise httpx.ConnectError("connection refused", request=request)
+
+    with pytest.raises(GitHubIssueError):
+        await create_issue(
+            repo="nic2045/My-M365-Statuspage",
+            token="tok",
+            title="t",
+            body="b",
+            labels=[],
+            transport=_transport(handler),
+        )

--- a/tests/test_openbao_request_route.py
+++ b/tests/test_openbao_request_route.py
@@ -1,0 +1,78 @@
+"""Route-level smoke tests for /openbao-request via Starlette's TestClient.
+
+Uses DISABLE_AUTH (dev-mode auth bypass) instead of a real OIDC login, and
+monkeypatches app.routers.openbao_request.create_issue instead of hitting
+GitHub - this is about the route wiring and error/success rendering, not the
+GitHub API itself (see test_github_issue_client.py for that).
+"""
+import asyncio
+
+import pytest
+from starlette.testclient import TestClient
+
+import app.routers.openbao_request as openbao_request_module
+from app.config import settings
+from app.database import init_db
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def _test_settings(monkeypatch):
+    monkeypatch.setattr(settings, "DISABLE_AUTH", True)
+    monkeypatch.setattr(settings, "DEBUG", True)  # non-Secure session cookie for plain-http TestClient
+    monkeypatch.setattr(settings, "OPENBAO_REQUEST_GITHUB_TOKEN", "test-token")
+
+
+@pytest.fixture
+def client():
+    # Deliberately NOT a context manager: `with TestClient(app) as c` runs the app's
+    # lifespan (start_scheduler(), which immediately tries to poll Microsoft Graph with
+    # whatever Azure creds are configured) - irrelevant to this route and slow/flaky in a
+    # sandboxed test run. Plain instantiation skips lifespan entirely.
+    asyncio.run(init_db())
+    return TestClient(app, follow_redirects=False)
+
+
+def test_form_renders(client):
+    r = client.get("/openbao-request")
+    assert r.status_code == 200
+    assert 'name="app_name"' in r.text
+
+
+def test_submit_success_shows_issue_url(client, monkeypatch):
+    async def fake_create_issue(**kwargs):
+        assert kwargs["repo"] == settings.OPENBAO_REQUEST_GITHUB_REPO
+        assert "[OpenBao] foo-app" in kwargs["title"]
+        return "https://github.com/nic2045/My-M365-Statuspage/issues/42"
+
+    monkeypatch.setattr(openbao_request_module, "create_issue", fake_create_issue)
+
+    r = client.post(
+        "/openbao-request",
+        data={
+            "app_name": "foo-app",
+            "secret_name": "bar-secret",
+            "requested_by": "me",
+            "justification": "testing",
+            "token_period": "",
+        },
+    )
+    assert r.status_code == 200
+    assert "https://github.com/nic2045/My-M365-Statuspage/issues/42" in r.text
+
+
+def test_submit_without_token_shows_error(client, monkeypatch):
+    monkeypatch.setattr(settings, "OPENBAO_REQUEST_GITHUB_TOKEN", "")
+
+    r = client.post(
+        "/openbao-request",
+        data={
+            "app_name": "foo-app",
+            "secret_name": "bar-secret",
+            "requested_by": "me",
+            "justification": "testing",
+            "token_period": "",
+        },
+    )
+    assert r.status_code == 200
+    assert "OPENBAO_REQUEST_GITHUB_TOKEN" in r.text


### PR DESCRIPTION
## Summary

Requesters don't need a GitHub account to ask for OpenBao access: a small in-app form (`/openbao-request`, any logged-in tenant user, linked from the nav bar) with the same fields as `.github/ISSUE_TEMPLATE/openbao-secret-request.yml`, which files the identical shape of GitHub issue via the API. The Cloud Operator's process (`infra/openbao/README.md`, from #152) doesn't need to know or care which path a given request came in through.

- `app/github_issue_client.py` (new) — minimal async GitHub REST client, one function (`create_issue`).
- `app/routers/openbao_request.py` + `templates/openbao_request.html` (new) — `GET /openbao-request` renders the form (pre-filled `requested_by` from the logged-in user); `POST` files the issue and shows its URL, or a clear error if `OPENBAO_REQUEST_GITHUB_TOKEN` isn't configured (rather than silently failing).
- `app/config.py` + `.env.example` — `OPENBAO_REQUEST_GITHUB_TOKEN`/`OPENBAO_REQUEST_GITHUB_REPO`.
- `app/i18n.py` — DE/EN labels for the new page, matching the rest of the app.
- `templates/base.html` — nav link for any logged-in user.
- README.md / README.en.md / `infra/openbao/README.md` — cross-links.

### A naming choice worth flagging

Deliberately `OPENBAO_REQUEST_GITHUB_TOKEN`/`_REPO`, not plain `GITHUB_TOKEN`/`GITHUB_REPO`. Caught this empirically while testing locally: some environments (CI runners, dev sandboxes) already export a generic `GITHUB_TOKEN` in the process environment for their own purposes, which `pydantic-settings` reads from the environment by default — a plain `GITHUB_TOKEN` setting would have silently picked that ambient value up instead of an explicitly configured one and filed a request against the wrong credential/target. The more specific name avoids the collision entirely.

## Verified locally

- `ruff check app/ tests/` — clean.
- Full `pytest tests/` (excluding the Docker integration test, which needs a running container) — 19/19 passed, including new `tests/test_github_issue_client.py` (`httpx.MockTransport`, no real network) and `tests/test_openbao_request_route.py` (route-level, `create_issue` monkeypatched).
- CI's own "Validate imports & app startup" reproduced locally — passes, `/openbao-request` present in the route list.
- Manually exercised both paths with `starlette.testclient.TestClient`: without `OPENBAO_REQUEST_GITHUB_TOKEN` set, confirmed **no outbound network call happens at all** and the correct "not configured" message renders (this is exactly the check that caught the naming collision above — a first attempt using plain `GITHUB_TOKEN` made a real outbound call in this environment because an ambient token was already present).

**Test-infra note for future route tests in this repo:** `with TestClient(app) as c:` (context-manager form) runs the app's lifespan and therefore `start_scheduler()`, which immediately tries to poll Microsoft Graph — hangs/times out in a sandboxed test run with no real Azure connectivity. Plain `TestClient(app)` instantiation (no `with`) skips lifespan and is what the new route test uses.

## Not yet verified

No real GitHub PAT or live OIDC login available in this environment, so the actual issue-creation call and the OIDC login redirect were not exercised end-to-end against real services — only the code paths around them (config, error handling, template rendering).

## Test plan

- [ ] Set `OPENBAO_REQUEST_GITHUB_TOKEN` (a fine-grained PAT scoped to `Issues: Read and write` on this repo only) and open `/openbao-request` while logged in — submit and confirm an issue is filed with the `openbao-request` label and the same shape as the manual issue-form template.
- [ ] Leave the token unset and confirm the page shows the configured error message instead of attempting a request.
- [ ] Confirm the nav link appears for any logged-in user, not just admins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFjfhHs3cTGqyXyBvGPyTD)_