### PR TITLE
Grafana demo dashboards: drop raw "Value" sublines, label two raw tables

### DIFF
--- a/demo-cert-monitoring/grafana/dashboards/avaya-callcenter-operations.json
+++ b/demo-cert-monitoring/grafana/dashboards/avaya-callcenter-operations.json
@@ -73,7 +73,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -126,7 +126,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -180,7 +180,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -234,7 +234,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {

--- a/demo-cert-monitoring/grafana/dashboards/customer-care-overview.json
+++ b/demo-cert-monitoring/grafana/dashboards/customer-care-overview.json
@@ -37,7 +37,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -85,7 +85,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -133,7 +133,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -185,7 +185,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -660,7 +660,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -713,7 +713,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {

--- a/demo-cert-monitoring/grafana/dashboards/docuware-cluster-status.json
+++ b/demo-cert-monitoring/grafana/dashboards/docuware-cluster-status.json
@@ -37,7 +37,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -85,7 +85,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -133,7 +133,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -163,7 +163,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    },
    "fieldConfig": {
     "defaults": {
@@ -498,7 +498,62 @@
      "format": "table",
      "refId": "A"
     }
-   ]
+   ],
+   "transformations": [
+    {
+     "id": "organize",
+     "options": {
+      "excludeByName": {
+       "Time": true,
+       "__name__": true,
+       "job": true,
+       "instance": true
+      },
+      "renameByName": {
+       "node": "Knoten"
+      }
+     }
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byFrameRefID",
+       "options": "A"
+      },
+      "properties": [
+       {
+        "id": "displayName",
+        "value": "Online"
+       },
+       {
+        "id": "custom.cellOptions",
+        "value": {
+         "type": "color-background"
+        }
+       },
+       {
+        "id": "thresholds",
+        "value": {
+         "mode": "absolute",
+         "steps": [
+          {
+           "color": "red",
+           "value": null
+          },
+          {
+           "color": "green",
+           "value": 1
+          }
+         ]
+        }
+       }
+      ]
+     }
+    ]
+   }
   },
   {
    "id": 13,
@@ -667,7 +722,62 @@
      "format": "table",
      "refId": "A"
     }
-   ]
+   ],
+   "transformations": [
+    {
+     "id": "organize",
+     "options": {
+      "excludeByName": {
+       "Time": true,
+       "__name__": true,
+       "job": true,
+       "instance": true
+      },
+      "renameByName": {
+       "component": "Komponente"
+      }
+     }
+    }
+   ],
+   "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+     {
+      "matcher": {
+       "id": "byFrameRefID",
+       "options": "A"
+      },
+      "properties": [
+       {
+        "id": "displayName",
+        "value": "Status"
+       },
+       {
+        "id": "custom.cellOptions",
+        "value": {
+         "type": "color-background"
+        }
+       },
+       {
+        "id": "thresholds",
+        "value": {
+         "mode": "absolute",
+         "steps": [
+          {
+           "color": "red",
+           "value": null
+          },
+          {
+           "color": "green",
+           "value": 1
+          }
+         ]
+        }
+       }
+      ]
+     }
+    ]
+   }
   }
  ]
 }

--- a/demo-cert-monitoring/grafana/dashboards/leipzig-network-topology.json
+++ b/demo-cert-monitoring/grafana/dashboards/leipzig-network-topology.json
@@ -37,7 +37,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -85,7 +85,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -138,7 +138,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -191,7 +191,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {

--- a/demo-cert-monitoring/grafana/dashboards/website-cert-monitoring.json
+++ b/demo-cert-monitoring/grafana/dashboards/website-cert-monitoring.json
@@ -74,7 +74,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -123,7 +123,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -171,7 +171,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -219,7 +219,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -267,7 +267,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {
@@ -324,7 +324,7 @@
       "lastNotNull"
      ]
     },
-    "textMode": "value_and_name"
+    "textMode": "value"
    }
   },
   {


### PR DESCRIPTION
## Summary

Follow-up on the `demo-cert-monitoring/` Grafana dashboards (now 5 of them: website-cert-monitoring, avaya-callcenter-operations, customer-care-overview, docuware-cluster-status, leipzig-network-topology) - requested cleanup of "Value"/"Value #A" style technical labels and any panels lacking sensible titles.

- **Panel titles**: audited all ~60 panels across all 5 dashboards - already descriptive German titles everywhere, no changes needed there.
- **Stat-panel sublines**: every single-value stat panel (aggregates like `count(...)`, `sum(...)`, `min(...)`, `max(...)`, `avg(...)`, `rate(...)` with no remaining labels) used `textMode: "value_and_name"` with no `displayName`/`legendFormat` override. Since a labelless Prometheus result's default series name is the literal string `"Value"`, Grafana rendered that word as a subline under every single one of these 22 big-number tiles. Switched them to `textMode: "value"` - the panel title already says what the number is, so the subline was redundant technical noise, not additional information.
- **Two raw tables in `docuware-cluster-status.json`** ("DB-Cluster – Knotenstatus", "Hardware-Status (SAN / Strom / Kühlung)") had no `transformations`/`fieldConfig.overrides` at all, so they'd show raw Prometheus columns (`Time`, `__name__`, `job`, `instance`, `Value`). Added the same organize+rename+color-background pattern already used elsewhere in these dashboards (e.g. `node`→`Knoten`, `component`→`Komponente`, `Value`→`Online`/`Status` with red/green thresholds).
- Timeseries/barchart panels, the `nodeGraph`/`geomap` panels, and the other table panels already had proper `legendFormat`/`renameByName`/`byFrameRefID` overrides in place from earlier work - left untouched (the node-graph panels in particular rely on Grafana's `id`/`title`/`subTitle`/`mainStat` field-name contract, which isn't a labeling bug even though the names look technical).

## Test plan

- [x] All 5 dashboard JSON files re-validated with `json.load`
- [x] Diffed each file to confirm only the intended `textMode`/`transformations`/`fieldConfig` fields changed (136 insertions / 26 deletions across 5 files, no other panels touched)
- [ ] Visual check in a running Grafana (not done here - no Docker daemon in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrshEuG9tj8aN8uRRtJmcn)_