### PR TITLE
Add IT-Ops overview dashboard linking all other perspectives

### DIFF
--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -916,6 +916,35 @@ Szenario **komplett durch** - Grafana ist hier nur der Anfang:
   (Delete-und-Neuanlegen aus dem Resolved-Zustand) und ein fest
   verdrahteter Link sonst sofort veralten würde.
 
+## IT-Ops – Gesamtübersicht (Grafana, alle Bereiche)
+
+`grafana/dashboards/it-ops-overview.json` - die sechste Dashboard-Perspektive,
+diesmal nicht pro Bereich, sondern **quer über alle**: eine Ampel-Kachel je
+Bereich (Website & Zertifikate, DocuWare-Cluster, Customer Care, Standort
+Leipzig - jede grün/rot nach demselben "Gesamtstatus (1 = gesund)"-Muster,
+das die Einzeldashboards schon verwenden) und ein Klick auf eine Kachel
+springt direkt ins zugehörige Detail-Dashboard (Grafanas Panel-`links`).
+
+Der eigentliche Punkt dieses Dashboards: **dieselben Prometheus-Metriken
+sehen aus jeder Perspektive anders aus.** Ein großes Markdown-Textpanel
+("Weitere Perspektiven") verlinkt explizit gruppiert nach Zielgruppe:
+
+- **Technische Sicht (Grafana)** - die anderen 5 Dashboards, je mit ihrer
+  Zielgruppe (App-Owner/Technical Owner/Facility-IT)
+- **Endnutzer-Sicht** - die öffentliche OneUptime-Statuspage über die
+  Dashboard-Variable `$oneuptime_url` (Default `http://localhost/`, im
+  Dashboard selbst änderbar, ohne die JSON-Datei zu editieren - passend zum
+  selben Muster wie in `mockups/index.html`)
+- **Weitere Werkzeuge** - Demo-Kontrollzentrum, Prometheus (die eigentliche
+  Quelle der Wahrheit hinter allen Dashboards), Mailpit, Benachrichtigungs-
+  Mockups
+
+Zusätzlich verlinkt das Dashboard selbst (Grafanas Dashboard-`links`, oben
+im Toolbar-Dropdown) zu den anderen 5 - Navigation geht also sowohl über
+das sichtbare Textpanel als auch nativ über Grafana. Im
+[Demo-Kontrollzentrum](#demo-kontrollzentrum) taucht es als erste Karte
+unter "Dashboards" auf.
+
 ## Test-Incident live durchspielen: "Zertifikat abgelaufen, IT arbeitet an Behebung"
 
 `demo-broken-site` startet **gesund** (gültiges Zertifikat,

--- a/demo-cert-monitoring/grafana/dashboards/it-ops-overview.json
+++ b/demo-cert-monitoring/grafana/dashboards/it-ops-overview.json
@@ -1,0 +1,330 @@
+{
+ "title": "IT-Ops – Gesamtübersicht (alle Bereiche)",
+ "uid": "it-ops-overview",
+ "timezone": "browser",
+ "editable": true,
+ "refresh": "30s",
+ "time": {
+  "from": "now-6h",
+  "to": "now"
+ },
+ "schemaVersion": 39,
+ "links": [
+  {
+   "title": "Website & Zertifikate (App-Owner)",
+   "type": "link",
+   "icon": "dashboard",
+   "url": "/d/website-cert-monitoring",
+   "targetBlank": false
+  },
+  {
+   "title": "DocuWare-Cluster (App-Owner)",
+   "type": "link",
+   "icon": "dashboard",
+   "url": "/d/docuware-cluster-status",
+   "targetBlank": false
+  },
+  {
+   "title": "Customer Care (Technical Owner)",
+   "type": "link",
+   "icon": "dashboard",
+   "url": "/d/customer-care-overview",
+   "targetBlank": false
+  },
+  {
+   "title": "Avaya Callcenter-Betrieb",
+   "type": "link",
+   "icon": "dashboard",
+   "url": "/d/avaya-callcenter-operations",
+   "targetBlank": false
+  },
+  {
+   "title": "Standort Leipzig – Netzwerk (Facility-IT)",
+   "type": "link",
+   "icon": "dashboard",
+   "url": "/d/leipzig-network-topology",
+   "targetBlank": false
+  }
+ ],
+ "templating": {
+  "list": [
+   {
+    "name": "oneuptime_url",
+    "type": "textbox",
+    "label": "OneUptime-URL (Endnutzer-Statuspage)",
+    "current": {
+     "text": "http://localhost/",
+     "value": "http://localhost/"
+    },
+    "query": "http://localhost/"
+   }
+  ]
+ },
+ "panels": [
+  {
+   "id": 100,
+   "type": "row",
+   "title": "Gesamtstatus je Bereich",
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 0
+   },
+   "collapsed": false,
+   "panels": []
+  },
+  {
+   "id": 101,
+   "type": "stat",
+   "title": "Website & Zertifikate – Gesamtstatus (1 = gesund)",
+   "description": "Kein Website-Ausfall und kein abgelaufenes Zertifikat. Details im verlinkten Dashboard.",
+   "gridPos": {
+    "h": 6,
+    "w": 6,
+    "x": 0,
+    "y": 1
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "targets": [
+    {
+     "expr": "(sum(probe_success{job=~\"website_probes|demo_broken_site\"} < bool 1) == bool 0) * (sum(((probe_ssl_earliest_cert_expiry{job=~\"website_probes|demo_broken_site\"} - time()) / 86400) < bool 0) == bool 0)",
+     "instant": true,
+     "refId": "A"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    },
+    "textMode": "value"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "links": [
+    {
+     "title": "Zum Website- & Zertifikats-Dashboard",
+     "url": "/d/website-cert-monitoring",
+     "targetBlank": false
+    }
+   ]
+  },
+  {
+   "id": 102,
+   "type": "stat",
+   "title": "DocuWare-Cluster – Gesamtstatus (1 = gesund)",
+   "description": "DB-Cluster-Knoten, Hardware und die Website selbst. Details im verlinkten Dashboard.",
+   "gridPos": {
+    "h": 6,
+    "w": 6,
+    "x": 6,
+    "y": 1
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "targets": [
+    {
+     "expr": "min(docuware_mssql_cluster_node_up) * on() min(docuware_hardware_status) * on() probe_success{job=\"docuware_site\"}",
+     "instant": true,
+     "refId": "A"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    },
+    "textMode": "value"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "links": [
+    {
+     "title": "Zum DocuWare-Cluster-Dashboard",
+     "url": "/d/docuware-cluster-status",
+     "targetBlank": false
+    }
+   ]
+  },
+  {
+   "id": 103,
+   "type": "stat",
+   "title": "Customer Care – Gesamtstatus (1 = gesund)",
+   "description": "Standort-VPNs und Avaya-SIP-Registrierung. Details im verlinkten Dashboard.",
+   "gridPos": {
+    "h": 6,
+    "w": 6,
+    "x": 12,
+    "y": 1
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "targets": [
+    {
+     "expr": "min(cc_site_vpn_up) * on() cc_avaya_sip_registration_status",
+     "instant": true,
+     "refId": "A"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    },
+    "textMode": "value"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "links": [
+    {
+     "title": "Zum Customer-Care-Dashboard",
+     "url": "/d/customer-care-overview",
+     "targetBlank": false
+    }
+   ]
+  },
+  {
+   "id": 104,
+   "type": "stat",
+   "title": "Standort Leipzig – Gesamtstatus (1 = gesund)",
+   "description": "Kein Netzwerkgerät offline. Details im verlinkten Dashboard.",
+   "gridPos": {
+    "h": 6,
+    "w": 6,
+    "x": 18,
+    "y": 1
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "targets": [
+    {
+     "expr": "sum(net_device_up < bool 1) == bool 0",
+     "instant": true,
+     "refId": "A"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    },
+    "textMode": "value"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     }
+    },
+    "overrides": []
+   },
+   "links": [
+    {
+     "title": "Zum Leipzig-Netzwerk-Dashboard",
+     "url": "/d/leipzig-network-topology",
+     "targetBlank": false
+    }
+   ]
+  },
+  {
+   "id": 110,
+   "type": "row",
+   "title": "Weitere Perspektiven",
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 7
+   },
+   "collapsed": false,
+   "panels": []
+  },
+  {
+   "id": 111,
+   "type": "text",
+   "title": "Dieselben Daten, andere Zielgruppe",
+   "gridPos": {
+    "h": 14,
+    "w": 24,
+    "x": 0,
+    "y": 8
+   },
+   "options": {
+    "mode": "markdown",
+    "content": "Ein und dieselben Prometheus-Metriken sehen je nach Zielgruppe komplett anders aus. Diese Seite ist die **IT-Ops-Perspektive** (Gesamtstatus über alle Bereiche); von hier aus geht es zu den anderen:\n\n### Technische Sicht (Grafana) – App-Owner / Technical Owner / Facility-IT\n\n- [Website & Zertifikate](/d/website-cert-monitoring) – Verfügbarkeit + TLS-Ablauf, App-Owner-Sicht\n- [DocuWare-Cluster](/d/docuware-cluster-status) – App-, DB-, Loadbalancer- und Hardware-Ebene\n- [Customer Care – Standortübersicht](/d/customer-care-overview) – VPNs, Citrix, Cognigy, Netzwerk-Topologie\n- [Avaya Callcenter-Betrieb](/d/avaya-callcenter-operations) – Warteschlange, Service Level, ACHT\n- [Standort Leipzig – Netzwerk](/d/leipzig-network-topology) – Switches/Router, Facility-IT-Sicht\n\n### Endnutzer-Sicht – öffentliche Statuspage\n\n- [OneUptime-Statuspage](${oneuptime_url}) – dieselben Vorfälle, aber ohne technische Details: nur \"betroffen / nicht betroffen\" plus Incident-Updates. URL oben im Dashboard-Variablenfeld anpassbar, falls OneUptime nicht auf dem Standardport läuft.\n\n### Weitere Werkzeuge\n\n- [Demo-Kontrollzentrum](http://localhost:7100/) – alle Seiten, Dashboards und Vorfall-Skripte an einem Ort\n- [Prometheus](http://localhost:9090/alerts) – Rohdaten & Alert-Regeln, die einzige Quelle der Wahrheit hinter allen Dashboards\n- [Mailpit](http://localhost:8025) – echte Benachrichtigungs-E-Mails, die OneUptime bei einem Vorfall verschickt\n- [Benachrichtigungs-Mockups](http://localhost:7100/mockups/index.html) – wie derselbe Vorfall in E-Mail/Teams/mobil/BMC aussehen würde"
+   }
+  }
+ ]
+}

--- a/demo-cert-monitoring/scripts/control-panel.html
+++ b/demo-cert-monitoring/scripts/control-panel.html
@@ -179,6 +179,10 @@
     </a>
 
     <div class="hub-group">Dashboards (App-Owner/Technical Owner)</div>
+    <a class="hub-card" href="http://localhost:3000/d/it-ops-overview" target="_blank">
+      <div class="hub-icon" style="background:#f46800;">G</div>
+      <div class="hub-text"><div class="t">IT-Ops – Gesamtübersicht</div><div class="d">Grafana, alle Bereiche + Perspektiven-Links</div></div>
+    </a>
     <a class="hub-card" href="http://localhost:3000/d/website-cert-monitoring" target="_blank">
       <div class="hub-icon" style="background:#f46800;">G</div>
       <div class="hub-text"><div class="t">Website &amp; Zertifikate</div><div class="d">Grafana</div></div>


### PR DESCRIPTION
## Summary

- New `demo-cert-monitoring/grafana/dashboards/it-ops-overview.json`: one "Gesamtstatus (1 = gesund)" stat tile per domain (Website & Zertifikate, DocuWare-Cluster, Customer Care, Standort Leipzig), each reusing the exact healthy-check PromQL expression its own dashboard already uses, and each clickable straight through to that dashboard via Grafana panel `links`.
- The point of the dashboard: the same underlying Prometheus data reads completely differently depending on who's looking at it. A markdown text panel ("Weitere Perspektiven") makes that explicit and groups links by audience:
  - **Technical view (Grafana)** — the other 5 dashboards, each with its audience noted (App-Owner/Technical Owner/Facility-IT)
  - **End-user view** — the public OneUptime status page, via a `$oneuptime_url` dashboard variable (same override pattern already used in `mockups/index.html`, no JSON editing needed to point at a non-default OneUptime instance)
  - **Other tools** — the demo control panel, Prometheus (the actual source of truth behind every dashboard), Mailpit, the notification mockups
- Dashboard-level `links` (Grafana's top toolbar dropdown) provide the same cross-navigation natively, in addition to the visible markdown panel.
- Wired into `scripts/control-panel.html` as the first "Dashboards" hub card.
- Documented in `README.md` alongside the other per-dashboard sections.

No changes to `docker-compose.yml` needed — the existing dashboard provisioner (`grafana/provisioning/dashboards/dashboards.yml`) already scans the whole `grafana/dashboards/` folder, so the new file is picked up automatically.

## Test plan

- [x] All 6 dashboard JSON files re-validated with `json.load`
- [x] Re-used the exact same "Gesamtstatus" PromQL expressions each source dashboard already has (no new metrics/logic invented) — verified string-for-string against the current files on `main`
- [x] `control-panel.html` re-parsed without errors; confirmed exactly 6 Grafana dashboard links now present in the hub grid
- [ ] Visual check in a running Grafana + control panel (not done here — no Docker daemon in this sandbox)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrshEuG9tj8aN8uRRtJmcn)_