### PR TITLE
Demo control panel: sublink audit, printer roles, on-call deep-links, 7th card, distinct colors

### DIFF
--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -254,9 +254,31 @@ getrennt statt eine Seite mit allem):
    steht statt sie zu überschreiben (`scripts/printer_maintenance.py`,
    kein Import von `seed_oneuptime.py`, siehe dortige Begründung). Auch im
    Demo-Kontrollzentrum (`./control-panel.sh`) als Karte "Druckerwartung
-   (Prozess)" auslösbar, inkl. Link zu den Benachrichtigungs-Mockups, in
-   denen sich die Statuspage-Info für Mitarbeitende manuell durchklicken
-   lässt.
+   (Prozess)" auslösbar - **mit expliziter Admin-/Nutzer-Trennung**, damit
+   die Demo die beiden Rollen nebeneinander zeigt statt nur eine Seite:
+   "Admin" verlinkt direkt auf OneUptimes Scheduled-Maintenance-Liste
+   (`/scheduled-maintenance-events`, wo Techniker die Wartung tatsächlich
+   anlegen), "Nutzer" auf die Standort-Leipzig-Statusseite selbst sowie
+   auf `mockups/benachrichtigung-email.html#drucker` - ein URL-Hash, der
+   das E-Mail-Mockup direkt auf die Druckerwartungs-Nachricht springen
+   lässt (`selectMail()` im Mockup wertet `location.hash` aus), statt dass
+   in der Vorführung erst durch den Posteingang geklickt werden muss.
+
+**Kontrollzentrum-Review, alle Karten:** bei der Gelegenheit auch die
+übrigen sechs Karten in `./control-panel.sh` auf fehlende Sublinks
+durchgesehen - Zertifikats-Karte bekam einen direkten Link zur
+Zertifikate-Statusseite (Nutzer-Sicht, vorher nur Grafana/Prometheus/
+Mailpit), Customer-Care-Karte einen Link zum neuen
+Avaya-Callcenter-Dashboard (das Szenario lässt live auch dessen
+Warteschlange volllaufen, war aber nirgends verlinkt), und Security-Karte
+einen direkten Statusseiten-Link statt nur des generischen
+OneUptime-Logins. Jede Karte gruppiert ihre Links jetzt zusätzlich unter
+"Admin"/"Nutzer"-Labels statt einer undifferenzierten Liste. **Farblich
+unterscheidbar:** jede Karte hat eine eigene Akzentfarbe (farbiger oberer
+Rand + leicht eingefärbter Hintergrund, nicht nur das kleine Icon wie
+vorher) - sieben klar unterscheidbare Farbtöne, damit man während einer
+Vorführung nicht erst den Kartentitel lesen muss, um die richtige Karte
+zu finden.
 
 **Alle Termine werden bei jedem Lauf neu relativ zu "heute" berechnet**
 (Patchday 3 läuft immer gerade jetzt, abgeschlossene Wartungen liegen
@@ -357,6 +379,21 @@ Demo-Story statt isoliert):
   Beispielen. Ohne echten Push-/SMS-/E-Mail-Provider in diesem lokalen
   Stack bleibt der Effekt visuell (Eskalationskette auf der
   Incident-Detailseite), keine echte Benachrichtigung.
+
+  **Direkt verlinkt statt gesucht:** die Eskalationsregel selbst und ihr
+  tatsächliches Auslösen liegen in OneUptime mehrere Klicks tief in den
+  On-Call-Duty-Einstellungen vergraben - für eine Vorführung zu langsam
+  zu finden. `seed_oneuptime.py` schreibt die (über Reseeds hinweg
+  stabile) Policy-ID deshalb in `.oneuptime-demo-summary`;
+  `control_panel_server.py` baut daraus zwei Direktlinks, die auf den
+  Sicherheits- und DocuWare-Festplatte-Karten im Kontrollzentrum
+  erscheinen: **"On-Call-Eskalation"** (`.../on-call-duty/policies/<id>/escalation`
+  - zeigt die konfigurierte 5-Minuten-Regel) und **"On-Call-Protokoll"**
+  (`.../on-call-duty/policies/<id>/execution-logs` - zeigt jedes
+  tatsächliche Auslösen der Regel, live nachvollziehbar nach jedem
+  `break-security.sh`/`break-docuware-disk.sh`). Beide Routen aus dem
+  echten OneUptime-Quellcode bestätigt (`RouteMap.ts`,
+  `ON_CALL_DUTY_POLICY_VIEW_ESCALATION`/`_EXECUTION_LOGS`), nicht geraten.
 - **Service Catalog**: drei `Service`-Einträge (DocuWare, Customer Care,
   Standort Leipzig – Netzwerk) mit Beschreibung, Farbe und Owner-Team
   "Owners" - dieselben Komponenten, die die Demo an anderer Stelle schon
@@ -498,6 +535,15 @@ im Keller, 10 Access-Switches über 4 Bereiche auf einer Etage
 zeigt ihn rot, "Geräte offline" springt auf 1. `./fix-leipzig-network.sh`
 macht es rückgängig. Live durchgetestet (`net_device_up`/`net_uplink_up`
 vor/nach dem Break bestätigt).
+
+**Jetzt auch im Demo-Kontrollzentrum:** dieses Szenario hatte trotz
+fertigem Break/Fix-Skript und Dashboard bislang keine eigene Karte in
+`./control-panel.sh` - beim Review aller Kontrollzentrum-Karten
+aufgefallen und als siebte Karte "Standort Leipzig – Netzwerk-Vorfall"
+ergänzt (`net_uplink_up{device="Access-Switch Vertrieb-2"}` als
+Live-Status, gleiches Prinzip wie bei den anderen Prometheus-Karten).
+Bewusst Grafana-only wie die DocuWare-Cluster- und Customer-Care-Karten -
+reine Facility-IT-Beobachtung ohne OneUptime-Incident.
 
 ## Website & Zertifikats-Dashboard (Grafana, App-Owner)
 

--- a/demo-cert-monitoring/mockups/benachrichtigung-email.html
+++ b/demo-cert-monitoring/mockups/benachrichtigung-email.html
@@ -197,6 +197,11 @@
           <div class="subject">[Statusseite IT-Services (Mitarbeiter)] Wartung: Patchday Server Gruppe 3</div>
           <div class="preview">Geplante Wartung hat begonnen...</div>
         </div>
+        <div class="mail-item" data-mail="drucker">
+          <div class="from">OneUptime Statuspage</div>
+          <div class="subject">[Standort Leipzig] Wartung: Drucker (Hauptgebäude)</div>
+          <div class="preview">Der Drucker im Hauptgebäude hat eine Störung gemeldet. Die IT hat...</div>
+        </div>
         <div class="list-header">Diese Woche</div>
         <div class="mail-item" data-mail="firewall">
           <div class="from">OneUptime Statuspage</div>
@@ -284,6 +289,35 @@
           </div>
         </article>
 
+        <article class="mail-content" id="mail-drucker" hidden>
+          <span class="badge" style="background:#fff4ce;color:#7a5b00;border-color:#f4dd8c;">Wartung</span>
+          <h1>[Standort Leipzig] Wartung: Drucker (Hauptgebäude)</h1>
+          <div class="meta">
+            <div class="avatar">OU</div>
+            <div class="who">
+              <div class="name">OneUptime Statuspage</div>
+              <div class="addr">notifications@statuspage.pyur.com</div>
+            </div>
+            <div class="when">Heute, 15:32 Uhr</div>
+          </div>
+          <div class="card" style="border-left-color:#e8b800;">
+            <h2>Kurzfristige Wartung – Drucker (Hauptgebäude)</h2>
+            <div class="status-line">Status: <strong>Scheduled</strong></div>
+            <p>Der Drucker im Hauptgebäude hat eine Störung gemeldet. Die IT hat daraufhin kurzfristig
+               ein Wartungsfenster eingeplant: <strong>17:32–20:32 Uhr</strong>.
+               <strong>Der Drucker funktioniert bis zum Beginn der Wartung ganz normal weiter</strong> -
+               erst während des Wartungsfensters bitte auf den Drucker im 2. OG (Raum 214) oder den
+               Farbdrucker in der Teeküche ausweichen. Bei dringenden Druckaufträgen wendet euch an
+               den IT-Helpdesk (Ext. 4242).</p>
+            <a class="cta" href="#">Statusseite öffnen →</a>
+          </div>
+          <div class="signoff">
+            Diese Benachrichtigung wurde automatisch von der Statusseite „Standort Leipzig“
+            verschickt, weil diese Mailbox den Dienst „Drucker (Hauptgebäude)“ abonniert hat.<br>
+            Abo verwalten · Abmelden
+          </div>
+        </article>
+
         <article class="mail-content" id="mail-firewall" hidden>
           <span class="badge" style="background:#eff6fc;color:#0f6cbd;border-color:#c7e0f4;">Ankündigung</span>
           <h1>[Standort Leipzig] Ankündigung: Firewall-Upgrade</h1>
@@ -312,14 +346,26 @@
     </div>
   </div>
   <script>
+    function selectMail(name) {
+      var item = document.querySelector('.mail-item[data-mail="' + name + '"]');
+      var content = document.getElementById("mail-" + name);
+      if (!item || !content) return;
+      document.querySelectorAll(".mail-item").forEach(function (i) { i.classList.remove("active"); });
+      item.classList.add("active");
+      document.querySelectorAll(".mail-content").forEach(function (c) { c.hidden = true; });
+      content.hidden = false;
+    }
+
     document.querySelectorAll(".mail-item").forEach(function (item) {
-      item.addEventListener("click", function () {
-        document.querySelectorAll(".mail-item").forEach(function (i) { i.classList.remove("active"); });
-        item.classList.add("active");
-        document.querySelectorAll(".mail-content").forEach(function (c) { c.hidden = true; });
-        document.getElementById("mail-" + item.dataset.mail).hidden = false;
-      });
+      item.addEventListener("click", function () { selectMail(item.dataset.mail); });
     });
+
+    // Deep-linked from the control panel (e.g. benachrichtigung-email.html#drucker)
+    // so a specific scenario's notification opens directly instead of making
+    // the presenter click through the inbox during a live demo.
+    if (location.hash) {
+      selectMail(location.hash.slice(1));
+    }
   </script>
 </body>
 </html>

--- a/demo-cert-monitoring/scripts/control-panel.html
+++ b/demo-cert-monitoring/scripts/control-panel.html
@@ -37,8 +37,13 @@
     gap: 20px;
   }
   .card {
-    background: var(--card-bg);
+    /* Each scenario card sets --accent/--accent-bg inline (see the markup
+       below) so it's recognizable by color alone during a live demo, not
+       just by its small icon - a full grid of otherwise-identical white
+       cards was too slow to scan through under time pressure. */
+    background: var(--accent-bg, var(--card-bg));
     border: 1px solid var(--border);
+    border-top: 4px solid var(--accent, var(--border));
     border-radius: 12px;
     padding: 22px;
     display: flex;
@@ -68,9 +73,18 @@
 
   .story { font-size: 13px; color: var(--muted); line-height: 1.6; margin: 0; }
 
-  .links { display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; }
-  .links a { color: #0f6cbd; text-decoration: none; }
+  .links { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; font-size: 12px; }
+  .links a { color: var(--accent, #0f6cbd); text-decoration: none; font-weight: 600; }
   .links a:hover { text-decoration: underline; }
+  .links a.disabled { color: var(--muted); pointer-events: none; text-decoration: none; font-weight: 400; }
+  /* Role labels ("Admin:"/"Nutzer:") group the links that follow them so a
+     scenario with distinct audiences (see the printer card) reads as two
+     short lists instead of one undifferentiated row. */
+  .links .role-label {
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+    color: var(--muted); background: rgba(0,0,0,0.05); padding: 2px 7px; border-radius: 999px;
+  }
+  .links .role-label:not(:first-child) { margin-left: 4px; }
 
   .actions { display: flex; gap: 10px; margin-top: auto; }
   .actions button {
@@ -226,7 +240,7 @@
   <div class="section-title">Vorfall- &amp; Prozess-Szenarien</div>
   <div class="grid">
 
-    <div class="card">
+    <div class="card" style="--accent:#0f6cbd; --accent-bg:#f2f8fd;">
       <div class="card-head">
         <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#0f6cbd"/>
           <path d="M24 10 L36 14 V24 C36 32 30 39 24 42 C18 39 12 32 12 24 V14 Z" fill="none" stroke="#fff" stroke-width="2.5"/>
@@ -243,8 +257,11 @@
         E-Mail (Grafana, OneUptime, Mailpit). Guter Einstieg.
       </p>
       <div class="links">
+        <span class="role-label">Admin</span>
         <a href="http://localhost:3000" target="_blank">Grafana</a>
         <a href="http://localhost:9090/alerts" target="_blank">Prometheus-Alerts</a>
+        <span class="role-label">Nutzer</span>
+        <a class="disabled" id="link-demo-statuspage" href="#" target="_blank">Statusseite</a>
         <a href="http://localhost:8025" target="_blank">Mailpit</a>
       </div>
       <div class="actions">
@@ -253,7 +270,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="--accent:#0e7a4d; --accent-bg:#f1f9f4;">
       <div class="card-head">
         <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#0e7a4d"/>
           <rect x="13" y="12" width="16" height="20" rx="2" fill="none" stroke="#fff" stroke-width="2.2"/>
@@ -270,9 +287,11 @@
         <strong>Passiert:</strong> MSSQL-Knoten fällt aus, WAF-Blocks &amp;
         Antwortzeiten steigen (App-Owner-Dashboard).<br>
         <strong>Zeigt:</strong> Infrastruktur-Vorfall betrifft nicht
-        zwangsläufig Kunden - Kundenportal bleibt grün.
+        zwangsläufig Kunden - Kundenportal bleibt grün. Bewusst nur
+        Grafana - kein Nutzer sieht hiervon etwas.
       </p>
       <div class="links">
+        <span class="role-label">Admin</span>
         <a href="http://localhost:3000/d/docuware-cluster-status" target="_blank">Grafana-Dashboard</a>
       </div>
       <div class="actions">
@@ -281,9 +300,9 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="--accent:#b8860b; --accent-bg:#fbf7ec;">
       <div class="card-head">
-        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#9b3d1a"/>
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#b8860b"/>
           <ellipse cx="24" cy="14" rx="11" ry="4" fill="none" stroke="#fff" stroke-width="2.2"/>
           <path d="M13 14 L13 34 C13 36.2 18 38 24 38 C30 38 35 36.2 35 34 L35 14" fill="none" stroke="#fff" stroke-width="2.2"/>
           <path d="M13 24 C13 26.2 18 28 24 28 C30 28 35 26.2 35 24" fill="none" stroke="#fff" stroke-width="2.2"/>
@@ -298,12 +317,18 @@
         sich auf 90-98% (App-Owner-Dashboard), echter OneUptime-Incident +
         On-Call-Eskalation + Mitarbeiter-Benachrichtigung.<br>
         <strong>Zeigt:</strong> Kapazitätsvorfall bleibt isoliert auf eine
-        Ressource - von Grafana über OneUptime bis zum BMC-Ticket.
+        Ressource - von Grafana über OneUptime bis zum BMC-Ticket, inkl.
+        Vorfallsrollen und echter On-Call-Eskalation.
       </p>
       <div class="links">
+        <span class="role-label">Admin</span>
         <a href="http://localhost:3000/d/docuware-cluster-status" target="_blank">Grafana-Dashboard</a>
         <a href="/mockups/backend-bmc-itsm.html" target="_blank">BMC-Ticket-Mockup</a>
-        <a id="link-docuware-disk-roles" href="#" target="_blank" style="display:none">Vorfallsrollen (OneUptime)</a>
+        <a id="link-docuware-disk-roles" href="#" target="_blank" style="display:none">Vorfallsrollen</a>
+        <a class="disabled" id="link-oncall-escalation-1" href="#" target="_blank">On-Call-Eskalation</a>
+        <a class="disabled" id="link-oncall-logs-1" href="#" target="_blank">On-Call-Protokoll</a>
+        <span class="role-label">Nutzer</span>
+        <a class="disabled" id="link-docuware-disk-statuspage" href="#" target="_blank">Statusseite</a>
       </div>
       <div class="actions">
         <button class="btn-break" onclick="run('break-docuware-disk', 'docuware-disk')">Vorfall auslösen</button>
@@ -311,7 +336,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="--accent:#c25a00; --accent-bg:#fdf5ee;">
       <div class="card-head">
         <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#c25a00"/>
           <path d="M24 10 C18 10 13 15 13 21 C13 30 24 38 24 38 C24 38 35 30 35 21 C35 15 30 10 24 10 Z" fill="#fff"/>
@@ -324,12 +349,15 @@
       </div>
       <p class="story">
         <strong>Passiert:</strong> VPN nach Chemnitz bricht ein
-        (Paketverlust, schlechte Sprachqualität).<br>
+        (Paketverlust, schlechte Sprachqualität), Avaya-Warteschlange
+        läuft voll.<br>
         <strong>Zeigt:</strong> Standort-Ausfall live und geografisch
         verortet - Karte + Warteschlange laufen synchron mit.
       </p>
       <div class="links">
+        <span class="role-label">Admin</span>
         <a href="http://localhost:3000/d/customer-care-overview" target="_blank">Grafana-Dashboard</a>
+        <a href="http://localhost:3000/d/avaya-callcenter-operations" target="_blank">Avaya-Dashboard</a>
       </div>
       <div class="actions">
         <button class="btn-break" onclick="run('break-customer-care', 'customer-care')">Vorfall auslösen</button>
@@ -337,7 +365,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="--accent:#6b2fb3; --accent-bg:#f7f2fc;">
       <div class="card-head">
         <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#6b2fb3"/>
           <path d="M24 9 L38 15 V23 C38 32 32 39 24 41 C16 39 10 32 10 23 V15 Z" fill="none" stroke="#fff" stroke-width="2.3"/>
@@ -350,12 +378,17 @@
       </div>
       <p class="story">
         <strong>Passiert:</strong> Verdächtige Anmeldeversuche, Anmeldung
-        (SSO) wird eingeschränkt.<br>
+        (SSO) wird eingeschränkt, On-Call-Eskalation läuft mit.<br>
         <strong>Zeigt:</strong> mitarbeiterverständliche, transparente
         Sicherheitskommunikation statt Fachjargon.
       </p>
       <div class="links">
+        <span class="role-label">Admin</span>
         <a href="http://localhost" target="_blank">OneUptime</a>
+        <a class="disabled" id="link-oncall-escalation-2" href="#" target="_blank">On-Call-Eskalation</a>
+        <a class="disabled" id="link-oncall-logs-2" href="#" target="_blank">On-Call-Protokoll</a>
+        <span class="role-label">Nutzer</span>
+        <a class="disabled" id="link-security-statuspage" href="#" target="_blank">Statusseite</a>
         <a href="http://localhost:8025" target="_blank">Mailpit</a>
       </div>
       <div class="actions">
@@ -364,9 +397,9 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card" style="--accent:#0e7490; --accent-bg:#eff8fa;">
       <div class="card-head">
-        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#5b5fc7"/>
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#0e7490"/>
           <rect x="12" y="10" width="24" height="10" rx="1.5" fill="none" stroke="#fff" stroke-width="2.2"/>
           <rect x="10" y="20" width="28" height="14" rx="2" fill="none" stroke="#fff" stroke-width="2.2"/>
           <rect x="16" y="30" width="16" height="9" fill="#fff"/>
@@ -379,18 +412,53 @@
       </div>
       <p class="story">
         <strong>Passiert:</strong> Drucker im Hauptgebäude meldet eine
-        Störung, die IT kündigt kurzfristig eine Wartung an.<br>
-        <strong>Zeigt:</strong> Meldung → Terminierung → Mitarbeiter-Info
-        per Statuspage - der Drucker bleibt bis zur Wartung selbst
-        uneingeschränkt nutzbar.
+        Störung → <strong>Admin/Techniker</strong> terminiert kurzfristig
+        eine Wartung in OneUptime → <strong>Nutzer</strong> sehen die
+        Ankündigung auf der Statusseite und per E-Mail.<br>
+        <strong>Zeigt:</strong> die zwei Rollen nebeneinander - der
+        Drucker bleibt bis zur Wartung selbst uneingeschränkt nutzbar.
       </p>
       <div class="links">
-        <a href="http://localhost" target="_blank">OneUptime</a>
-        <a href="/mockups/index.html" target="_blank">Benachrichtigungs-Mockups</a>
+        <span class="role-label">Admin</span>
+        <a class="disabled" id="link-printer-admin" href="#" target="_blank">Wartung planen (OneUptime)</a>
+        <span class="role-label">Nutzer</span>
+        <a class="disabled" id="link-printer-statuspage" href="#" target="_blank">Statusseite</a>
+        <a href="/mockups/benachrichtigung-email.html#drucker" target="_blank">E-Mail-Mockup</a>
       </div>
       <div class="actions">
         <button class="btn-break" onclick="run('break-printer', 'printer')">Wartung ankündigen</button>
         <button class="btn-fix" onclick="run('fix-printer', 'printer')">Abschließen</button>
+      </div>
+    </div>
+
+    <div class="card" style="--accent:#b0266f; --accent-bg:#fbf0f6;">
+      <div class="card-head">
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#b0266f"/>
+          <circle cx="24" cy="12" r="4" fill="none" stroke="#fff" stroke-width="2.2"/>
+          <circle cx="12" cy="34" r="4" fill="none" stroke="#fff" stroke-width="2.2"/>
+          <circle cx="36" cy="34" r="4" fill="#fff"/>
+          <path d="M24 16 L24 24 M24 24 L14 30 M24 24 L34 30" fill="none" stroke="#fff" stroke-width="2.2"/>
+        </svg>
+        <div>
+          <h2>Standort Leipzig – Netzwerk-Vorfall</h2>
+          <span class="status unknown" id="status-leipzig-network"><span class="dot"></span>wird geprüft…</span>
+        </div>
+      </div>
+      <p class="story">
+        <strong>Passiert:</strong> Access-Switch Vertrieb-2 verliert den
+        Uplink zum Core-Switch.<br>
+        <strong>Zeigt:</strong> Netzwerk-Topologie live im Node-Graph -
+        betroffener Knoten und Kante springen auf Rot, "Geräte offline"
+        auf 1. Bewusst nur Grafana - reine Facility-IT-Beobachtung ohne
+        OneUptime-Incident.
+      </p>
+      <div class="links">
+        <span class="role-label">Admin</span>
+        <a href="http://localhost:3000/d/leipzig-network-topology" target="_blank">Grafana-Dashboard</a>
+      </div>
+      <div class="actions">
+        <button class="btn-break" onclick="run('break-leipzig-network', 'leipzig-network')">Vorfall auslösen</button>
+        <button class="btn-fix" onclick="run('fix-leipzig-network', 'leipzig-network')">Beheben</button>
       </div>
     </div>
 
@@ -439,7 +507,7 @@
       try {
         const res = await fetch("/api/status");
         const data = await res.json();
-        for (const key of ["demo", "docuware", "docuware-disk", "customer-care", "security", "printer"]) {
+        for (const key of ["demo", "docuware", "docuware-disk", "customer-care", "security", "printer", "leipzig-network"]) {
           const el = document.getElementById("status-" + key);
           const state = data[key] || "unknown";
           el.className = "status " + state;
@@ -478,6 +546,40 @@
           rolesLink.style.display = "";
         } else {
           rolesLink.style.display = "none";
+        }
+
+        // Same disabled-until-seeded pattern as the hub cards above, for
+        // the per-scenario Admin-/Nutzer-Sublinks - all derived from ids
+        // that are stable across reseeds (status pages, the On-Call
+        // policy), unlike the roles link above which tracks a
+        // currently-active incident and so needs the show/hide handling.
+        const statusPageLinks = {
+          "link-demo-statuspage": data.statusPageId,
+          "link-docuware-disk-statuspage": data.itServiceStatusPageId,
+          "link-security-statuspage": data.itServiceStatusPageId,
+          "link-printer-statuspage": data.leipzigStatusPageId,
+        };
+        for (const [elId, pageId] of Object.entries(statusPageLinks)) {
+          const a = document.getElementById(elId);
+          if (pageId) {
+            a.href = `${base}/status-page/${pageId}`;
+            a.classList.remove("disabled");
+          }
+        }
+
+        const directLinks = {
+          "link-printer-admin": data.scheduledMaintenanceEventsUrl,
+          "link-oncall-escalation-1": data.onCallEscalationUrl,
+          "link-oncall-escalation-2": data.onCallEscalationUrl,
+          "link-oncall-logs-1": data.onCallExecutionLogsUrl,
+          "link-oncall-logs-2": data.onCallExecutionLogsUrl,
+        };
+        for (const [elId, url] of Object.entries(directLinks)) {
+          const a = document.getElementById(elId);
+          if (url) {
+            a.href = url;
+            a.classList.remove("disabled");
+          }
         }
       } catch (e) {
         // Kontrollserver kurz nicht erreichbar - Karten bleiben deaktiviert, kein Absturz.

--- a/demo-cert-monitoring/scripts/control_panel_server.py
+++ b/demo-cert-monitoring/scripts/control_panel_server.py
@@ -47,6 +47,8 @@ ACTIONS = {
     "fix-security": ("fix-security.sh", "Sicherheits-Vorfall beheben"),
     "break-printer": ("break-printer.sh", "Druckerwartung ankündigen"),
     "fix-printer": ("fix-printer.sh", "Druckerwartung abschließen"),
+    "break-leipzig-network": ("break-leipzig-network.sh", "Leipzig-Netzwerk-Vorfall auslösen"),
+    "fix-leipzig-network": ("fix-leipzig-network.sh", "Leipzig-Netzwerk-Vorfall beheben"),
 }
 
 
@@ -88,12 +90,33 @@ def get_links():
     except (FileNotFoundError, json.JSONDecodeError):
         disk_incident = {}
 
+    base = summary.get("base", "http://localhost")
+    project_id = summary.get("projectId")
+    on_call_policy_id = summary.get("onCallPolicyId")
+
+    # On-Call Duty is otherwise buried several clicks deep in OneUptime's
+    # own settings navigation - these two direct links (the configured
+    # escalation rule, and the log of every time it has actually fired,
+    # e.g. from break-security.sh/break-docuware-disk.sh) are what makes
+    # it demoable without hunting for it live.
+    on_call_escalation_url = (
+        f"{base}/dashboard/{project_id}/on-call-duty/policies/{on_call_policy_id}/escalation"
+        if project_id and on_call_policy_id else None)
+    on_call_execution_logs_url = (
+        f"{base}/dashboard/{project_id}/on-call-duty/policies/{on_call_policy_id}/execution-logs"
+        if project_id and on_call_policy_id else None)
+    scheduled_maintenance_events_url = (
+        f"{base}/dashboard/{project_id}/scheduled-maintenance-events" if project_id else None)
+
     return {
-        "oneuptimeBase": summary.get("base", "http://localhost"),
+        "oneuptimeBase": base,
         "statusPageId": summary.get("statusPageId"),
         "itServiceStatusPageId": summary.get("itServiceStatusPageId"),
         "leipzigStatusPageId": summary.get("leipzigStatusPageId"),
         "docuwareDiskIncidentRolesUrl": disk_incident.get("rolesUrl"),
+        "onCallEscalationUrl": on_call_escalation_url,
+        "onCallExecutionLogsUrl": on_call_execution_logs_url,
+        "scheduledMaintenanceEventsUrl": scheduled_maintenance_events_url,
     }
 
 
@@ -213,6 +236,7 @@ def get_status():
     docuware_node2 = prom_query('docuware_mssql_cluster_node_up{node="db2"}')
     docuware_disk = prom_query('docuware_disk_usage_percent{volume="Dokumentenspeicher"}')
     cc_chemnitz = prom_query('cc_site_vpn_up{site="Chemnitz"}')
+    leipzig_switch = prom_query('net_uplink_up{device="Access-Switch Vertrieb-2"}')
 
     def state(value, healthy_fn):
         if value is None:
@@ -226,6 +250,7 @@ def get_status():
         "customer-care": state(cc_chemnitz, lambda v: v >= 1),
         "security": get_security_state(),
         "printer": get_printer_state(),
+        "leipzig-network": state(leipzig_switch, lambda v: v >= 1),
     }
 
 

--- a/demo-cert-monitoring/scripts/seed_oneuptime.py
+++ b/demo-cert-monitoring/scripts/seed_oneuptime.py
@@ -1662,6 +1662,7 @@ with open(".oneuptime-demo-summary", "w") as fh:
     json.dump({"base": BASE, "email": EMAIL, "projectId": project_id,
                "statusPageId": page_id, "itServiceStatusPageId": it_service_page_id,
                "leipzigStatusPageId": leipzig_page_id,
+               "onCallPolicyId": on_call_policy_id,
                "monitors": heartbeats}, fh, indent=1)
 print(f"STATUS_PAGE_ID={page_id}")
 print(f"IT_SERVICE_STATUS_PAGE_ID={it_service_page_id}")


### PR DESCRIPTION
## Summary

Requested review of the demo control panel: whether every scenario card links to all its relevant views, whether the printer-maintenance scenario shows the Admin/Nutzer role split it was meant to, whether any sensible scenario is still missing a card, whether On-Call Duty can be made easier to demo, and whether cards are visually distinguishable enough for a live presentation.

- **Sublink audit, all 6 existing cards**: cert card gets a direct status-page link (previously only Grafana/Prometheus/Mailpit), customer-care gets the Avaya-dashboard link (the scenario already floods that queue live via `break-customer-care.sh`, it just wasn't linked anywhere), security gets a direct status-page link instead of a generic OneUptime-login link.
- **Printer card redesigned with explicit Admin/Nutzer roles**: "Admin" links to OneUptime's Scheduled-Maintenance-Events list (where it's actually planned), "Nutzer" links to the Leipzig status page and a new `benachrichtigung-email.html#drucker` deep link. The email mockup had zero mention of the printer scenario before this — added a proper maintenance-notification entry, plus a `location.hash` auto-select so the link opens straight to it instead of the presenter clicking through the inbox.
- **On-Call Duty made demoable**: it was buried several clicks deep in OneUptime's own settings navigation. `seed_oneuptime.py` now exports the (reseed-stable) policy id in `.oneuptime-demo-summary`; `control_panel_server.py` builds two direct links — the configured escalation rule, and the live execution log of every time it's actually fired — added to the Security and DocuWare-disk cards. Both routes confirmed against OneUptime's own `RouteMap.ts` source, not guessed.
- **Missing scenario found and added**: the Leipzig-network scenario had a working `break-/fix-leipzig-network.sh` pair and a full Grafana Node-Graph dashboard, but no card in the control panel at all — now a 7th card, wired into `control_panel_server.py`'s health check and action whitelist.
- **Distinct card colors**: every card now carries its own accent color as a top border + tinted background (not just the small 48×48 icon like before), plus Admin/Nutzer role-label chips grouping each card's links — the goal being to spot the right card at a glance during a live demo instead of reading titles.

## Verification

Couldn't spin up the actual OneUptime/Grafana stack in this environment (Docker Hub pulls are blocked by this session's egress policy), but `control-panel.html` and the mockups are static — served them locally and drove headless Chromium against them:
- Screenshotted the full redesigned control panel (all 7 cards render with distinct colors, role labels, disabled-until-seeded links behave correctly).
- Screenshotted the email mockup with the `#drucker` hash — auto-selects the new printer entry correctly.
- HTML tag-balance check on both edited HTML files — clean.
- No new console errors on either page (only the expected 404s from `/api/status`, `/api/links` and favicon, since no backend was running for this static check).
- `python3 -m py_compile` on both edited Python files, `sh -n` on the touched shell scripts.

Not verified: the actual OneUptime deep-links (on-call escalation/execution-log pages, scheduled-maintenance list) against a live instance — the route paths are taken directly from OneUptime's own `RouteMap.ts`, but I couldn't click through them end-to-end here.

## Test plan

- [x] `python3 -m py_compile` on `seed_oneuptime.py`, `control_panel_server.py`
- [x] `sh -n` on touched shell scripts
- [x] Headless-Chromium screenshots of `control-panel.html` and `benachrichtigung-email.html#drucker`
- [x] HTML tag-balance check
- [ ] Not verified against a live OneUptime instance in this session (Docker blocked here). To verify: `./start-demo.sh --with-oneuptime && ./seed-oneuptime.sh && ./control-panel.sh`, then check that all "Admin"/"Nutzer" links resolve (not 404s) and that the On-Call-Eskalation/-Protokoll links land on the right OneUptime pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnPKEJEq6XeyPzze5P3BQM)_