### PR TITLE
Demo control panel: real-product link, Cognigy outage, Blueant + Jira scenarios

### DIFF
--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -7,6 +7,35 @@
 > App-Owner (technisches Grafana-Dashboard) und Endnutzer (öffentliche
 > OneUptime-Statuspage).
 
+**Link zum echten Produkt.** Alle sieben Vorfall-Szenarien hier sind eigens
+für die Demo gebaute Infrastruktur (DocuWare, Standort Leipzig, Customer
+Care, ...) - keines davon ist die eigentliche M365-Statuspage-App aus
+diesem Repo-Root. Damit eine Vorführung trotzdem beim echten Produkt landen
+kann, hat das Demo-Kontrollzentrum (`./control-panel.sh`) jetzt eine eigene
+Karte **"M365 Dienststatus"** ganz oben, die auf `http://localhost:8000`
+verlinkt - die echte App, kein Fixture. Sie läuft **unabhängig vom
+Docker-Stack hier** direkt über `uv`, kein Docker nötig (der Haupt-App-Build
+zieht `python:3.12-slim` von Docker Hub, was in dieser Sandbox blockiert
+war - `uv run uvicorn` umgeht das komplett):
+
+```bash
+cd .. # zurück ins Repo-Root
+cp .env.example .env   # falls noch nicht geschehen
+# DISABLE_AUTH=true setzen für lokale Vorführungen ohne echten Entra-ID-Login
+uv sync
+make dev   # http://localhost:8000
+```
+
+Ohne echte `AZURE_TENANT_ID`/`AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`
+(Vorführung ohne eigenen Tenant) startet die App trotzdem und ist mit
+`DISABLE_AUTH=true` ohne Login erreichbar - der Graph-API-Poll läuft dann
+aber ins Leere (kein echter Tenant, live bestätigt:
+`AADSTS90002: Tenant 'demo-tenant' not found`, sauber abgefangen, kein
+Absturz) und die Dienste zeigen entsprechend keine echten Daten. Für einen
+Auftritt mit echten M365-Statusdaten braucht es die echten Werte aus der
+Entra-ID-App-Registrierung (siehe Haupt-README, Abschnitt "Entra ID
+App-Registrierung").
+
 ## Architektur
 
 ```
@@ -817,6 +846,48 @@ MOS-Score, Bandbreiten-Kollaps) und die Avaya-Warteschlange
 volllaufen; `./fix-customer-care.sh` macht es rückgängig. Live
 verifiziert: Chemnitz-VPN ging auf 0, "Standorte mit VPN-Störung"
 sprang auf 1, die Warteschlange auf 39 Anrufe.
+
+**Drittes, unabhängiges Vorfall-Szenario - Cognigy-Vendor-Ausfall:**
+`./break-cognigy.sh` lässt gezielt die Cognigy-API (Panel "Cognigy (Cloud)
+– API-Latenz & Bot-Sessions") einbrechen - Latenz springt auf
+2,2-4,8 Sekunden, Bot-Sessions kollabieren Richtung 0, die
+Intent-Erfolgsquote fällt auf 12-30 % (Panel-Schwellenwert bei <90 % bereits
+rot, kein Dashboard-Umbau nötig). `./fix-cognigy.sh` macht es rückgängig.
+Eigener State-File (`COGNIGY_STATE_FILE`, Default `/tmp/cognigy-state` im
+Container) unabhängig von `STATE_FILE` oben, gleiches Prinzip wie bei
+`break-docuware-disk.sh` - beide Szenarien einzeln oder zusammen vorführbar.
+Bewusst als **dritter Vorfall-Typ** neben "eigene Infra kaputt" (Chemnitz-VPN
+oben, DocuWare-Cluster) und "Sicherheitsvorfall": ein externer
+SaaS-Anbieter, von dem der Bot abhängt, hat selbst ein Problem - Telefonie,
+Agenten-Desktops und die Standort-VPNs bleiben davon unberührt, exakt die
+gleiche Blast-Radius-Erzählung wie bei den anderen isolierten Szenarien,
+nur mit einer Ursache außerhalb der eigenen Infrastruktur. Auch im
+Demo-Kontrollzentrum als achte Karte "Cognigy-Vorfall (Chat-/Voicebot)".
+
+**Kleinere Lücken - zwei zusätzliche, echte OneUptime-Vorfälle:**
+`./break-blueant.sh` / `./fix-blueant.sh` (Skript:
+`scripts/blueant_incident.py`) simulieren einen **ungeplanten**
+Blueant-Ausfall - bewusst der Gegenpol zur bereits im Seeding
+enthaltenen, immer "gerade laufenden" Patchday-Wartung (die einzige
+andere Blueant-Störung in dieser Demo, aber angekündigt und erwartet).
+Setzt den Monitor "Blueant" auf Offline und erzeugt einen echten
+Incident "Blueant nicht erreichbar" auf der IT-Services-Statusseite -
+unabhängig von Patchday einzeln auslösbar. `./break-jira-attachments.sh`
+/ `./fix-jira-attachments.sh` (Skript:
+`scripts/jira_attachments_incident.py`) zeigen eine eng abgegrenzte
+Teil-Störung statt "Jira ist komplett down": nur neue Datei-Uploads in
+Jira schlagen fehl, bereits vorhandene Anhänge bleiben abrufbar, Tickets,
+Kommentare und Suche sind nicht betroffen - Monitor "Anhänge & Dateien"
+auf Degraded, eigener Incident "Datei-Uploads in Jira schlagen fehl",
+bewusst getrennt vom "Benachrichtigungen"-Monitor, den der rotierende
+Vorfall-Pool in `refresh_demo.py` bereits nutzt. Beide folgen exakt dem
+gleichen break/fix-Muster wie `security_incident.py` (gleiches
+Login/Query-Vorgehen, gleiche Forward-Only-State-Transition-Behandlung
+bei bereits resolvten Incidents) und benötigen kein Docker-Rebuild - nur
+`./seed-oneuptime.sh` muss einmal gelaufen sein. Im
+Demo-Kontrollzentrum als neunte und zehnte Karte "Blueant-Ausfall
+(ungeplant)" und "Jira: Datei-Uploads gestört", beide mit
+Admin-/Nutzer-Sublinks (OneUptime bzw. IT-Services-Statusseite).
 
 ## Avaya Call Center – Betriebsansicht (Grafana, Callcenter-Optimierung)
 

--- a/demo-cert-monitoring/break-blueant.sh
+++ b/demo-cert-monitoring/break-blueant.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Triggers the Blueant demo scenario, live: OneUptime's "Blueant" monitor
+# flips to Offline and a real Incident ("Blueant nicht erreichbar") appears
+# on the IT-Services status page.
+#
+# Story: an ad-hoc, unplanned Blueant outage - deliberately the opposite of
+# the only other Blueant disruption in this demo (the always-"currently
+# happening" Patchday maintenance in seed_oneuptime.py), which is planned
+# and expected. This one is a genuine, unannounced incident, independent of
+# Patchday and triggerable on its own.
+#
+# Requires OneUptime to be up and already seeded (./seed-oneuptime.sh).
+# Run from demo-cert-monitoring/. Reverse with ./fix-blueant.sh.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  echo "       Run: ./start-demo.sh --with-oneuptime && ./seed-oneuptime.sh" >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Triggering the Blueant scenario ..."
+python3 scripts/blueant_incident.py break
+
+echo ""
+echo "==> Done. Within a few seconds the IT-Services status page shows:"
+echo "      - \"Blueant\" offline"
+echo "      - New incident \"Blueant nicht erreichbar\""
+echo "    IT-Services: $OU_BASE (see .oneuptime-demo-summary for the exact URL)"
+echo "    Recover with: ./fix-blueant.sh"

--- a/demo-cert-monitoring/break-cognigy.sh
+++ b/demo-cert-monitoring/break-cognigy.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Flips the Cognigy (chat-/voicebot) vendor-outage demo into "unhealthy" -
+# live, in the same Customer-Care exporter as break-customer-care.sh, but
+# via a separate state file (COGNIGY_STATE_FILE) so this can be shown alone
+# or alongside the Chemnitz-VPN scenario.
+#
+# Story: a SaaS vendor we depend on (Cognigy.AI) is degraded - not our own
+# infrastructure, not a security issue. On-prem telephony, agents and the
+# Chemnitz VPN are all untouched; only the one cloud dependency fails.
+# API latency spikes, intent recognition collapses, bot sessions drop
+# toward zero - customers/calls still try the bot, they just fail through
+# it (falling back to human agents in the real world, not modelled here).
+#
+# Run this from demo-cert-monitoring/ while the stack is up. Use
+# fix-cognigy.sh to reverse it.
+set -eu
+
+cd "$(dirname "$0")"
+
+echo "==> Flipping the Cognigy vendor exporter to 'unhealthy' ..."
+docker compose exec -T customer-care-metrics-exporter sh -c 'echo unhealthy > /tmp/cognigy-state'
+
+echo ""
+echo "==> Done. Within ~15-30s the Customer-Care Grafana dashboard shows:"
+echo "      - 'Cognigy (Cloud) – API-Latenz & Bot-Sessions' latency spikes, sessions collapse"
+echo "      - 'Cognigy – Intent-Erfolgsquote' drops into the red (<90%)"
+echo "    On-prem telephony, agents and the Chemnitz VPN stay healthy - isolated vendor outage."
+echo "    Grafana: http://localhost:\${GRAFANA_PORT:-3000} (dashboard 'Customer Care – Standortübersicht')"

--- a/demo-cert-monitoring/break-jira-attachments.sh
+++ b/demo-cert-monitoring/break-jira-attachments.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Triggers the Jira-Anhänge demo scenario, live: OneUptime's "Anhänge &
+# Dateien" monitor flips to Degraded and a real Incident ("Datei-Uploads in
+# Jira schlagen fehl") appears on the IT-Services status page.
+#
+# Story: a narrow, sub-feature outage rather than "Jira is down" - only
+# uploading new attachments fails, tickets/comments/search stay unaffected.
+# Deliberately distinct from the "Benachrichtigungen" sub-service already
+# used by refresh_demo.py's rotating-incident pool.
+#
+# Requires OneUptime to be up and already seeded (./seed-oneuptime.sh).
+# Run from demo-cert-monitoring/. Reverse with ./fix-jira-attachments.sh.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  echo "       Run: ./start-demo.sh --with-oneuptime && ./seed-oneuptime.sh" >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Triggering the Jira-Anhänge scenario ..."
+python3 scripts/jira_attachments_incident.py break
+
+echo ""
+echo "==> Done. Within a few seconds the IT-Services status page shows:"
+echo "      - \"Anhänge & Dateien\" degraded"
+echo "      - New incident \"Datei-Uploads in Jira schlagen fehl\""
+echo "    IT-Services: $OU_BASE (see .oneuptime-demo-summary for the exact URL)"
+echo "    Recover with: ./fix-jira-attachments.sh"

--- a/demo-cert-monitoring/fix-blueant.sh
+++ b/demo-cert-monitoring/fix-blueant.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Reverses break-blueant.sh: posts a resolution update to the incident's
+# public timeline, sets it to Resolved, and puts "Blueant" back to
+# Operational.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Resolving the Blueant scenario ..."
+python3 scripts/blueant_incident.py fix
+
+echo ""
+echo "==> Done. The incident is Resolved, \"Blueant\" is Operational again."

--- a/demo-cert-monitoring/fix-cognigy.sh
+++ b/demo-cert-monitoring/fix-cognigy.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Reverses break-cognigy.sh: flips the Cognigy vendor exporter state back
+# to healthy, live.
+set -eu
+
+cd "$(dirname "$0")"
+
+echo "==> Flipping the Cognigy vendor exporter back to 'healthy' ..."
+docker compose exec -T customer-care-metrics-exporter sh -c 'rm -f /tmp/cognigy-state'
+
+echo ""
+echo "==> Done. The Cognigy API/bot metrics recover within ~15-30s."

--- a/demo-cert-monitoring/fix-jira-attachments.sh
+++ b/demo-cert-monitoring/fix-jira-attachments.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Reverses break-jira-attachments.sh: posts a resolution update to the
+# incident's public timeline, sets it to Resolved, and puts "Anhänge &
+# Dateien" back to Operational.
+set -eu
+
+cd "$(dirname "$0")"
+
+ONEUPTIME_CONFIG="oneuptime-selfhosted/oneuptime/config.env"
+[ -f "$ONEUPTIME_CONFIG" ] || {
+  echo "ERROR: $ONEUPTIME_CONFIG not found - OneUptime isn't set up yet." >&2
+  exit 1
+}
+
+OU_PORT=$(grep -E '^ONEUPTIME_HTTP_PORT=' "$ONEUPTIME_CONFIG" | tail -1 | cut -d= -f2-)
+OU_PORT="${OU_PORT:-80}"
+if [ "$OU_PORT" = "80" ]; then
+  OU_BASE="http://localhost"
+else
+  OU_BASE="http://localhost:$OU_PORT"
+fi
+export OU_BASE
+
+echo "==> Resolving the Jira-Anhänge scenario ..."
+python3 scripts/jira_attachments_incident.py fix
+
+echo ""
+echo "==> Done. The incident is Resolved, \"Anhänge & Dateien\" is Operational again."

--- a/demo-cert-monitoring/scripts/blueant_incident.py
+++ b/demo-cert-monitoring/scripts/blueant_incident.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Live break/fix for the Blueant demo scenario.
+
+Same standalone pattern as security_incident.py: only touches the one
+Manual monitor and the one Incident this scenario owns, both already
+created by seed_oneuptime.py, so ./seed-oneuptime.sh must have run at
+least once before this works.
+
+Story: an ad-hoc, unplanned Blueant outage - deliberately the opposite
+of the only other Blueant disruption in this demo (the always-"currently
+happening" Patchday maintenance in seed_oneuptime.py), which is planned
+and expected. This one is a genuine, unannounced incident.
+
+Usage: python3 blueant_incident.py break|fix
+Invoked by ../break-blueant.sh / ../fix-blueant.sh, which set OU_BASE.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ["OU_BASE"]
+EMAIL = os.environ.get("OU_EMAIL", "demo@example.com")
+PASSWORD = os.environ.get("OU_PASSWORD", "DemoDemo123!")
+PROJECT_NAME = os.environ.get("OU_PROJECT", "Zertifikats-Monitoring Demo")
+
+MONITOR_NAME = "Blueant"
+INCIDENT_TITLE = "Blueant nicht erreichbar"
+
+token = None
+project_id = None
+
+
+def call(path, payload, method="POST"):
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(payload).encode() if payload is not None else None,
+        method=method,
+    )
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if project_id:
+        req.add_header("ProjectID", project_id)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        sys.exit(f"ERROR: {path} -> HTTP {exc.code}: {exc.read().decode()[:300]}")
+    parsed = json.loads(body) if body else {}
+    if isinstance(parsed, dict) and "error" in parsed:
+        sys.exit(f"ERROR: {path} -> {parsed['error']}")
+    return parsed
+
+
+def typed(t, v):
+    return {"_type": t, "value": v}
+
+
+def entity_ref(obj_id):
+    return {"_id": obj_id}
+
+
+def get_list(model, query=None, select=None, limit=100):
+    return call(f"/api/{model}/get-list", {
+        "query": query or {}, "select": select or {"_id": True, "name": True},
+        "sort": {}, "skip": 0, "limit": limit,
+    }).get("data", [])
+
+
+def find_by_name(model, name, select=None, name_field="name"):
+    for row in get_list(model, select=select or {"_id": True, name_field: True}):
+        if row.get(name_field) == name:
+            return row
+    return None
+
+
+login = call("/api/identity/login", {"data": {
+    "email": typed("Email", EMAIL), "password": typed("HashedString", PASSWORD),
+}})
+token = login.get("_miscData", {}).get("accessToken")
+if not token:
+    sys.exit(f"ERROR: login for {EMAIL} failed - has ./seed-oneuptime.sh run yet?")
+
+project = find_by_name("project", PROJECT_NAME)
+if not project:
+    sys.exit(f"ERROR: project '{PROJECT_NAME}' not found - run ./seed-oneuptime.sh first.")
+project_id = project["_id"]
+
+monitor = find_by_name("monitor", MONITOR_NAME)
+if not monitor:
+    sys.exit(f"ERROR: monitor '{MONITOR_NAME}' not found - run ./seed-oneuptime.sh first.")
+monitor_id = monitor["_id"]
+
+statuses = get_list("monitor-status", select={
+    "_id": True, "isOperationalState": True, "isOfflineState": True})
+operational_status_id = next(s["_id"] for s in statuses if s.get("isOperationalState"))
+offline_status_id = next(
+    (s["_id"] for s in statuses if s.get("isOfflineState")), operational_status_id)
+
+
+def set_monitor_status(status_id):
+    call(f"/api/monitor/{monitor_id}", {"data": {
+        "currentMonitorStatusId": status_id,
+    }}, method="PUT")
+
+
+mode = sys.argv[1] if len(sys.argv) > 1 else ""
+if mode == "break":
+    severities = get_list("incident-severity")
+    severity_id = next((s["_id"] for s in severities if "Minor" in s.get("name", "")),
+                        severities[0]["_id"])
+    incident_states = get_list("incident-state", select={
+        "_id": True, "name": True, "isAcknowledgedState": True, "isResolvedState": True})
+    identified_state_id = next(
+        (s["_id"] for s in incident_states if s.get("name") == "Identified"),
+        next((s["_id"] for s in incident_states
+              if not s.get("isAcknowledgedState") and not s.get("isResolvedState")),
+             incident_states[0]["_id"]))
+
+    description = (
+        "Blueant reagiert seit einigen Minuten nicht mehr - Anrufe und "
+        "Chats über Blueant sind aktuell nicht möglich. **Betroffen ist "
+        "ausschließlich Blueant**, alle anderen Dienste laufen normal. "
+        "Die IT arbeitet an der Behebung."
+    )
+    # Same forward-only-state-transition constraint as the other live
+    # scenarios (see security_incident.py) - a resolved incident can't be
+    # reopened via PUT, only recreated.
+    existing = find_by_name("incident", INCIDENT_TITLE, name_field="title",
+                            select={"_id": True, "title": True, "currentIncidentState": {"isResolvedState": True}})
+    if existing and (existing.get("currentIncidentState") or {}).get("isResolvedState"):
+        call(f"/api/incident/{existing['_id']}", None, method="DELETE")
+        existing = None
+
+    if existing:
+        payload = {"title": INCIDENT_TITLE, "description": description,
+                  "incidentSeverityId": severity_id, "monitors": [entity_ref(monitor_id)]}
+        call(f"/api/incident/{existing['_id']}", {"data": payload}, method="PUT")
+    else:
+        payload = {"title": INCIDENT_TITLE, "description": description,
+                  "incidentSeverityId": severity_id,
+                  "currentIncidentStateId": identified_state_id,
+                  "monitors": [entity_ref(monitor_id)], "projectId": project_id}
+        call("/api/incident", {"data": payload})
+
+    set_monitor_status(offline_status_id)
+    print(f"==> '{INCIDENT_TITLE}' ist jetzt aktiv (Status: Identified).")
+    print(f"    Monitor '{MONITOR_NAME}' auf Offline gesetzt.")
+
+elif mode == "fix":
+    incident = find_by_name("incident", INCIDENT_TITLE, name_field="title")
+    if not incident:
+        sys.exit(f"ERROR: incident '{INCIDENT_TITLE}' not found - run './blueant_incident.py break' first.")
+    incident_id = incident["_id"]
+
+    resolution_note = (
+        "**Update:** Blueant läuft wieder normal. Anrufe und Chats "
+        "funktionieren uneingeschränkt."
+    )
+    existing_notes = get_list("incident-public-note", query={"incidentId": incident_id},
+                              select={"_id": True, "note": True})
+    if not any(n.get("note") == resolution_note for n in existing_notes):
+        call("/api/incident-public-note", {"data": {
+            "projectId": project_id,
+            "incidentId": incident_id,
+            "note": resolution_note,
+            "shouldStatusPageSubscribersBeNotifiedOnNoteCreated": True,
+        }})
+
+    incident_states = get_list("incident-state", select={"_id": True, "isResolvedState": True})
+    resolved_state_id = next(s["_id"] for s in incident_states if s.get("isResolvedState"))
+    call(f"/api/incident/{incident_id}", {"data": {
+        "currentIncidentStateId": resolved_state_id,
+    }}, method="PUT")
+
+    set_monitor_status(operational_status_id)
+    print(f"==> '{INCIDENT_TITLE}' ist jetzt Resolved.")
+    print(f"    Monitor '{MONITOR_NAME}' wieder auf Operational gesetzt.")
+
+else:
+    sys.exit("Usage: blueant_incident.py break|fix")

--- a/demo-cert-monitoring/scripts/control-panel.html
+++ b/demo-cert-monitoring/scripts/control-panel.html
@@ -210,6 +210,12 @@
 
   <div class="section-title">Alle Seiten</div>
   <div class="hub" id="hub">
+    <div class="hub-group">Echtes Produkt (kein Demo-Fixture)</div>
+    <a class="hub-card" href="http://localhost:8000" target="_blank">
+      <div class="hub-icon" style="background:#005ea8;">M</div>
+      <div class="hub-text"><div class="t">M365 Dienststatus</div><div class="d">Das eigentliche Produkt - <code>make dev</code> im Repo-Root starten</div></div>
+    </a>
+
     <div class="hub-group">Statusseiten (Mitarbeiter/Kunden)</div>
     <a class="hub-card disabled" id="hub-cert" href="#" target="_blank">
       <div class="hub-icon" style="background:#0f6cbd;">Z</div>
@@ -320,6 +326,24 @@
           <td><a href="#card-leipzig-network">Standort Leipzig – Netzwerk-Vorfall</a></td>
           <td><span class="audience it">Nur IT</span></td>
           <td class="value">Facility-IT sieht den Netzwerkausfall sofort im Node-Graph - rein interne Beobachtung ohne Nutzer-Auswirkung.</td>
+        </tr>
+        <tr>
+          <td class="dot-cell"><span class="dot" style="background:#5b5fc7;"></span></td>
+          <td><a href="#card-cognigy">Cognigy-Vorfall (Chat-/Voicebot)</a></td>
+          <td><span class="audience it">Nur IT</span></td>
+          <td class="value">Zeigt, dass nicht jeder Vorfall selbstverschuldet ist - Technical Owner sieht sofort, dass ein externer SaaS-Anbieter die Ursache ist, nicht die eigene Infra.</td>
+        </tr>
+        <tr>
+          <td class="dot-cell"><span class="dot" style="background:#5c7a1e;"></span></td>
+          <td><a href="#card-blueant">Blueant-Ausfall (ungeplant)</a></td>
+          <td><span class="audience both">IT + Nutzer</span></td>
+          <td class="value">Nutzer sieht auf einen Blick, dass Telefonie ungeplant gestört ist - klar getrennt von der bereits angekündigten Patchday-Wartung.</td>
+        </tr>
+        <tr>
+          <td class="dot-cell"><span class="dot" style="background:#b0203f;"></span></td>
+          <td><a href="#card-jira-attachments">Jira: Datei-Uploads gestört</a></td>
+          <td><span class="audience both">IT + Nutzer</span></td>
+          <td class="value">Nutzer erfährt präzise, was wirklich nicht funktioniert (nur Uploads), statt pauschal zu vermuten, Jira sei komplett down.</td>
         </tr>
       </table>
     </div>
@@ -570,6 +594,107 @@
       </div>
     </div>
 
+    <div class="card" id="card-cognigy" style="--accent:#5b5fc7; --accent-bg:#f2f2fb;">
+      <div class="card-head">
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#5b5fc7"/>
+          <path d="M15 30 C10 30 8 26.5 8 23.5 C8 20 11 17.5 14.5 17.8 C15.5 13.5 19.5 11 24 11.5 C29 12 32 16 31.5 20.2 C35.5 20.5 38.5 23.5 38.5 27 C38.5 30.5 35.5 33 32 33 L16 33 Z" fill="#fff"/>
+        </svg>
+        <div>
+          <h2>Cognigy-Vorfall (Chat-/Voicebot)</h2>
+          <span class="status unknown" id="status-cognigy"><span class="dot"></span>wird geprüft…</span>
+        </div>
+      </div>
+      <p class="story">
+        <strong>Passiert:</strong> die Cognigy-Cloud-API wird langsam und
+        instabil, Bot-Sessions brechen weg - Telefonie, Agenten und die
+        Chemnitz-VPN bleiben unberührt.<br>
+        <strong>Zeigt:</strong> einen dritten Vorfall-Typ neben "eigene
+        Infra kaputt" und "Sicherheitsvorfall" - ein externer
+        SaaS-Anbieter, von dem wir abhängen, hat ein Problem.
+      </p>
+      <div class="links">
+        <div class="link-row">
+          <span class="role-label">Admin</span>
+          <a href="http://localhost:3000/d/customer-care-overview" target="_blank">Grafana-Dashboard</a>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="btn-break" onclick="run('break-cognigy', 'cognigy')">Vorfall auslösen</button>
+        <button class="btn-fix" onclick="run('fix-cognigy', 'cognigy')">Beheben</button>
+      </div>
+    </div>
+
+    <div class="card" id="card-blueant" style="--accent:#5c7a1e; --accent-bg:#f5f8ec;">
+      <div class="card-head">
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#5c7a1e"/>
+          <path d="M15 12 C15 10 17 9 18.5 10 L22 12.5 C23 13.2 23.2 14.6 22.4 15.5 L20.5 17.7 C22 21 25 24 28.3 25.5 L30.5 23.6 C31.4 22.8 32.8 23 33.5 24 L36 27.5 C37 29 36 31 34 31 C25.5 31 15 22 15 12 Z" fill="none" stroke="#fff" stroke-width="2.3" stroke-linejoin="round"/>
+          <path d="M31 15 L36 20 M36 15 L31 20" stroke="#fff" stroke-width="2.3" stroke-linecap="round"/>
+        </svg>
+        <div>
+          <h2>Blueant-Ausfall (ungeplant)</h2>
+          <span class="status unknown" id="status-blueant"><span class="dot"></span>wird geprüft…</span>
+        </div>
+      </div>
+      <p class="story">
+        <strong>Passiert:</strong> Blueant reagiert plötzlich nicht mehr -
+        unangekündigt und unabhängig von der geplanten Patchday-Wartung.
+        Anrufe und Chats sind nicht möglich, alle anderen Dienste laufen
+        normal.<br>
+        <strong>Zeigt:</strong> den Unterschied zwischen einer angekündigten
+        Wartung und einem echten, ungeplanten Ausfall - beide betreffen
+        Blueant, sind aber im System klar unterscheidbar und unabhängig
+        voneinander auslösbar.
+      </p>
+      <div class="links">
+        <div class="link-row">
+          <span class="role-label">Admin</span>
+          <a href="http://localhost" target="_blank">OneUptime</a>
+        </div>
+        <div class="link-row">
+          <span class="role-label">Nutzer</span>
+          <a class="disabled" id="link-blueant-statuspage" href="#" target="_blank">Statusseite</a>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="btn-break" onclick="run('break-blueant', 'blueant')">Vorfall auslösen</button>
+        <button class="btn-fix" onclick="run('fix-blueant', 'blueant')">Beheben</button>
+      </div>
+    </div>
+
+    <div class="card" id="card-jira-attachments" style="--accent:#b0203f; --accent-bg:#fbf0f3;">
+      <div class="card-head">
+        <svg viewBox="0 0 48 48"><rect width="48" height="48" rx="10" fill="#b0203f"/>
+          <path d="M18 26 L18 16 C18 12.5 21 10 24 10 C27 10 30 12.5 30 16 L30 30 C30 33 27.5 35 25 35 C22.5 35 20 33 20 30 L20 18 C20 16.5 21.5 15 23 15 C24.5 15 26 16.5 26 18 L26 28" fill="none" stroke="#fff" stroke-width="2.3" stroke-linecap="round"/>
+        </svg>
+        <div>
+          <h2>Jira: Datei-Uploads gestört</h2>
+          <span class="status unknown" id="status-jira-attachments"><span class="dot"></span>wird geprüft…</span>
+        </div>
+      </div>
+      <p class="story">
+        <strong>Passiert:</strong> Neue Datei-Anhänge lassen sich in Jira
+        nicht mehr hochladen, bereits vorhandene Anhänge bleiben abrufbar.
+        Tickets, Kommentare und die Suche sind nicht betroffen.<br>
+        <strong>Zeigt:</strong> eine eng abgegrenzte Teil-Störung statt "Jira
+        ist komplett down" - wichtig für präzise, ehrliche
+        Nutzerkommunikation statt pauschaler Panik.
+      </p>
+      <div class="links">
+        <div class="link-row">
+          <span class="role-label">Admin</span>
+          <a href="http://localhost" target="_blank">OneUptime</a>
+        </div>
+        <div class="link-row">
+          <span class="role-label">Nutzer</span>
+          <a class="disabled" id="link-jira-attachments-statuspage" href="#" target="_blank">Statusseite</a>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="btn-break" onclick="run('break-jira-attachments', 'jira-attachments')">Vorfall auslösen</button>
+        <button class="btn-fix" onclick="run('fix-jira-attachments', 'jira-attachments')">Beheben</button>
+      </div>
+    </div>
+
   </div>
 
   <div class="log-section">
@@ -615,7 +740,7 @@
       try {
         const res = await fetch("/api/status");
         const data = await res.json();
-        for (const key of ["demo", "docuware", "docuware-disk", "customer-care", "security", "printer", "leipzig-network"]) {
+        for (const key of ["demo", "docuware", "docuware-disk", "customer-care", "security", "printer", "leipzig-network", "cognigy", "blueant", "jira-attachments"]) {
           const el = document.getElementById("status-" + key);
           const state = data[key] || "unknown";
           el.className = "status " + state;
@@ -666,6 +791,8 @@
           "link-docuware-disk-statuspage": data.itServiceStatusPageId,
           "link-security-statuspage": data.itServiceStatusPageId,
           "link-printer-statuspage": data.leipzigStatusPageId,
+          "link-blueant-statuspage": data.itServiceStatusPageId,
+          "link-jira-attachments-statuspage": data.itServiceStatusPageId,
         };
         for (const [elId, pageId] of Object.entries(statusPageLinks)) {
           const a = document.getElementById(elId);

--- a/demo-cert-monitoring/scripts/control_panel_server.py
+++ b/demo-cert-monitoring/scripts/control_panel_server.py
@@ -49,6 +49,12 @@ ACTIONS = {
     "fix-printer": ("fix-printer.sh", "Druckerwartung abschließen"),
     "break-leipzig-network": ("break-leipzig-network.sh", "Leipzig-Netzwerk-Vorfall auslösen"),
     "fix-leipzig-network": ("fix-leipzig-network.sh", "Leipzig-Netzwerk-Vorfall beheben"),
+    "break-cognigy": ("break-cognigy.sh", "Cognigy-Vorfall auslösen"),
+    "fix-cognigy": ("fix-cognigy.sh", "Cognigy-Vorfall beheben"),
+    "break-blueant": ("break-blueant.sh", "Blueant-Vorfall auslösen"),
+    "fix-blueant": ("fix-blueant.sh", "Blueant-Vorfall beheben"),
+    "break-jira-attachments": ("break-jira-attachments.sh", "Jira-Anhänge-Vorfall auslösen"),
+    "fix-jira-attachments": ("fix-jira-attachments.sh", "Jira-Anhänge-Vorfall beheben"),
 }
 
 
@@ -138,14 +144,18 @@ def _ou_login():
     return _ou_token
 
 
-def get_security_state():
-    """healthy/unhealthy/unknown for the security-incident scenario - this
-    one lives in OneUptime, not Prometheus (a Manual monitor + Incident,
-    no metric backs it), so it needs the OneUptime API instead of
-    prom_query(). The login token is cached at module level and reused
-    across polls (the panel polls /api/status every 5s) - OneUptime's
-    login endpoint is rate-limited (10 attempts/15min), so logging in on
-    every poll would lock the demo account out within seconds."""
+def get_monitor_state(monitor_name):
+    """healthy/unhealthy/unknown for a scenario whose truth lives in
+    OneUptime, not Prometheus (a Manual monitor + Incident, no metric
+    backs it), so it needs the OneUptime API instead of prom_query().
+    Shared by every scenario that just checks one monitor's operational
+    status (security, Blueant, Jira attachments, ...) - the printer
+    scenario is the one exception (checks a Scheduled Maintenance, not a
+    monitor, see get_printer_state()). The login token is cached at
+    module level and reused across polls (the panel polls /api/status
+    every 5s) - OneUptime's login endpoint is rate-limited (10
+    attempts/15min), so logging in on every poll would lock the demo
+    account out within seconds."""
     global _ou_token
     try:
         if not _ou_token and not _ou_login():
@@ -172,7 +182,7 @@ def get_security_state():
             else:
                 raise
         for m in body.get("data", []):
-            if m.get("name") == "Anmeldung (SSO)":
+            if m.get("name") == monitor_name:
                 op = (m.get("currentMonitorStatus") or {}).get("isOperationalState", True)
                 return "healthy" if op else "unhealthy"
         return "unknown"
@@ -229,14 +239,15 @@ def get_status():
     """healthy/unhealthy/unknown per scenario, read live from Prometheus -
     no separate state file invented here, Prometheus already is the
     stack's single source of truth (see docker-compose.yml header).
-    The security and printer scenarios are the exceptions (see
-    get_security_state()/get_printer_state()) - both live in OneUptime,
-    not Prometheus."""
+    Security, Blueant, Jira-attachments and printer are the exceptions
+    (see get_monitor_state()/get_printer_state()) - they live in
+    OneUptime, not Prometheus."""
     cert_days = prom_query('(probe_ssl_earliest_cert_expiry{demo_fixture="true"} - time()) / 86400')
     docuware_node2 = prom_query('docuware_mssql_cluster_node_up{node="db2"}')
     docuware_disk = prom_query('docuware_disk_usage_percent{volume="Dokumentenspeicher"}')
     cc_chemnitz = prom_query('cc_site_vpn_up{site="Chemnitz"}')
     leipzig_switch = prom_query('net_uplink_up{device="Access-Switch Vertrieb-2"}')
+    cognigy_intent_success = prom_query('cc_cognigy_intent_success_rate_percent')
 
     def state(value, healthy_fn):
         if value is None:
@@ -248,9 +259,12 @@ def get_status():
         "docuware": state(docuware_node2, lambda v: v >= 1),
         "docuware-disk": state(docuware_disk, lambda v: v < 90),
         "customer-care": state(cc_chemnitz, lambda v: v >= 1),
-        "security": get_security_state(),
+        "security": get_monitor_state("Anmeldung (SSO)"),
         "printer": get_printer_state(),
         "leipzig-network": state(leipzig_switch, lambda v: v >= 1),
+        "cognigy": state(cognigy_intent_success, lambda v: v >= 90),
+        "blueant": get_monitor_state("Blueant"),
+        "jira-attachments": get_monitor_state("Anhänge & Dateien"),
     }
 
 

--- a/demo-cert-monitoring/scripts/customer-care-metrics-exporter.py
+++ b/demo-cert-monitoring/scripts/customer-care-metrics-exporter.py
@@ -26,6 +26,11 @@ import time
 
 PORT = int(os.environ.get("METRICS_PORT", "9300"))
 STATE_FILE = os.environ.get("STATE_FILE", "/tmp/customer-care-state")
+# Separate state file for the Cognigy vendor-outage scenario (#break-cognigy.sh)
+# - independent of STATE_FILE above so the Chemnitz-VPN and Cognigy-vendor
+# scenarios can each be shown alone or together, same idea as
+# docuware-disk-state being separate from docuware-state.
+COGNIGY_STATE_FILE = os.environ.get("COGNIGY_STATE_FILE", "/tmp/cognigy-state")
 
 START = time.time()
 _calls_offered_total = 0.0
@@ -78,6 +83,14 @@ def is_unhealthy():
         return False
 
 
+def is_cognigy_unhealthy():
+    try:
+        with open(COGNIGY_STATE_FILE) as fh:
+            return fh.read().strip() == "unhealthy"
+    except FileNotFoundError:
+        return False
+
+
 def wave(period_s, low, high, phase=0.0):
     t = time.time() - START
     frac = (math.sin(2 * math.pi * (t / period_s) + phase) + 1) / 2
@@ -89,6 +102,7 @@ def render_metrics():
     global _calls_offered_total, _calls_abandoned_total
     global _cognigy_requests_total, _llm_requests_total
     unhealthy = is_unhealthy()
+    cognigy_unhealthy = is_cognigy_unhealthy()
 
     lines = []
 
@@ -234,18 +248,35 @@ def render_metrics():
     ]
 
     # ── Cognigy (cloud/SaaS - the one non-on-prem component) + LLM usage ──
+    # break-cognigy.sh: a vendor-side outage, not our own infrastructure -
+    # the API itself degrades (high latency, low intent success), sessions
+    # collapse as the bot becomes unusable, but requests keep arriving
+    # (customers/calls still try the bot, they just fail) - deliberately
+    # isolated from the Chemnitz-VPN/Avaya story above, on-prem telephony
+    # and agents are untouched, only the one cloud dependency is down.
     _cognigy_requests_total += random.uniform(3, 9)
-    _llm_requests_total += random.uniform(2, 7)
+    _llm_requests_from_bot_delta = random.uniform(2, 7)
+    if cognigy_unhealthy:
+        _llm_requests_from_bot_delta *= 0.1  # bot barely reaches intent stage, so barely calls the LLM
+    _llm_requests_total += _llm_requests_from_bot_delta
+    if cognigy_unhealthy:
+        cognigy_api_latency = wave(20, 2200, 4800, phase=0.6)
+        cognigy_sessions_active = wave(20, 0, 4, phase=0.9)
+        cognigy_intent_success = wave(20, 12, 30, phase=1.2)
+    else:
+        cognigy_api_latency = wave(45, 60, 180, phase=0.6)
+        cognigy_sessions_active = wave(40, 8, 35, phase=0.9)
+        cognigy_intent_success = wave(55, 91, 98, phase=1.2)
     cognigy_lines = [
         "# HELP cc_cognigy_api_latency_ms Latency of the Cognigy.AI cloud API (the one SaaS component - everything else on-prem).",
         "# TYPE cc_cognigy_api_latency_ms gauge",
-        f"cc_cognigy_api_latency_ms {wave(45, 60, 180, phase=0.6):.0f}",
+        f"cc_cognigy_api_latency_ms {cognigy_api_latency:.0f}",
         "# HELP cc_cognigy_bot_sessions_active Active voice-/chatbot sessions in Cognigy.",
         "# TYPE cc_cognigy_bot_sessions_active gauge",
-        f"cc_cognigy_bot_sessions_active {wave(40, 8, 35, phase=0.9):.0f}",
+        f"cc_cognigy_bot_sessions_active {cognigy_sessions_active:.0f}",
         "# HELP cc_cognigy_intent_success_rate_percent Share of bot turns where intent recognition succeeded.",
         "# TYPE cc_cognigy_intent_success_rate_percent gauge",
-        f"cc_cognigy_intent_success_rate_percent {wave(55, 91, 98, phase=1.2):.1f}",
+        f"cc_cognigy_intent_success_rate_percent {cognigy_intent_success:.1f}",
         "# HELP cc_cognigy_requests_total Requests handled by the Cognigy bot.",
         "# TYPE cc_cognigy_requests_total counter",
         f"cc_cognigy_requests_total {_cognigy_requests_total:.0f}",

--- a/demo-cert-monitoring/scripts/jira_attachments_incident.py
+++ b/demo-cert-monitoring/scripts/jira_attachments_incident.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Live break/fix for the Jira-Anhänge demo scenario.
+
+Same standalone pattern as security_incident.py / blueant_incident.py: only
+touches the one Manual monitor and the one Incident this scenario owns, both
+already created by seed_oneuptime.py, so ./seed-oneuptime.sh must have run
+at least once before this works.
+
+Story: a narrow, sub-feature outage rather than "Jira is down" - uploading
+new file attachments fails, but tickets, comments and search keep working
+normally, and already-uploaded attachments stay reachable. Deliberately
+distinct from the "Benachrichtigungen" sub-service already used by the
+refresh_demo.py rotating-incident pool, so the two can be shown side by
+side without colliding.
+
+Usage: python3 jira_attachments_incident.py break|fix
+Invoked by ../break-jira-attachments.sh / ../fix-jira-attachments.sh, which
+set OU_BASE.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ["OU_BASE"]
+EMAIL = os.environ.get("OU_EMAIL", "demo@example.com")
+PASSWORD = os.environ.get("OU_PASSWORD", "DemoDemo123!")
+PROJECT_NAME = os.environ.get("OU_PROJECT", "Zertifikats-Monitoring Demo")
+
+MONITOR_NAME = "Anhänge & Dateien"
+INCIDENT_TITLE = "Datei-Uploads in Jira schlagen fehl"
+
+token = None
+project_id = None
+
+
+def call(path, payload, method="POST"):
+    req = urllib.request.Request(
+        f"{BASE}{path}",
+        data=json.dumps(payload).encode() if payload is not None else None,
+        method=method,
+    )
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    if project_id:
+        req.add_header("ProjectID", project_id)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        sys.exit(f"ERROR: {path} -> HTTP {exc.code}: {exc.read().decode()[:300]}")
+    parsed = json.loads(body) if body else {}
+    if isinstance(parsed, dict) and "error" in parsed:
+        sys.exit(f"ERROR: {path} -> {parsed['error']}")
+    return parsed
+
+
+def typed(t, v):
+    return {"_type": t, "value": v}
+
+
+def entity_ref(obj_id):
+    return {"_id": obj_id}
+
+
+def get_list(model, query=None, select=None, limit=100):
+    return call(f"/api/{model}/get-list", {
+        "query": query or {}, "select": select or {"_id": True, "name": True},
+        "sort": {}, "skip": 0, "limit": limit,
+    }).get("data", [])
+
+
+def find_by_name(model, name, select=None, name_field="name"):
+    for row in get_list(model, select=select or {"_id": True, name_field: True}):
+        if row.get(name_field) == name:
+            return row
+    return None
+
+
+login = call("/api/identity/login", {"data": {
+    "email": typed("Email", EMAIL), "password": typed("HashedString", PASSWORD),
+}})
+token = login.get("_miscData", {}).get("accessToken")
+if not token:
+    sys.exit(f"ERROR: login for {EMAIL} failed - has ./seed-oneuptime.sh run yet?")
+
+project = find_by_name("project", PROJECT_NAME)
+if not project:
+    sys.exit(f"ERROR: project '{PROJECT_NAME}' not found - run ./seed-oneuptime.sh first.")
+project_id = project["_id"]
+
+monitor = find_by_name("monitor", MONITOR_NAME)
+if not monitor:
+    sys.exit(f"ERROR: monitor '{MONITOR_NAME}' not found - run ./seed-oneuptime.sh first.")
+monitor_id = monitor["_id"]
+
+statuses = get_list("monitor-status", select={
+    "_id": True, "isOperationalState": True, "isDegradedState": True})
+operational_status_id = next(s["_id"] for s in statuses if s.get("isOperationalState"))
+degraded_status_id = next(
+    (s["_id"] for s in statuses if s.get("isDegradedState")), operational_status_id)
+
+
+def set_monitor_status(status_id):
+    call(f"/api/monitor/{monitor_id}", {"data": {
+        "currentMonitorStatusId": status_id,
+    }}, method="PUT")
+
+
+mode = sys.argv[1] if len(sys.argv) > 1 else ""
+if mode == "break":
+    severities = get_list("incident-severity")
+    severity_id = next((s["_id"] for s in severities if "Minor" in s.get("name", "")),
+                        severities[0]["_id"])
+    incident_states = get_list("incident-state", select={
+        "_id": True, "name": True, "isAcknowledgedState": True, "isResolvedState": True})
+    identified_state_id = next(
+        (s["_id"] for s in incident_states if s.get("name") == "Identified"),
+        next((s["_id"] for s in incident_states
+              if not s.get("isAcknowledgedState") and not s.get("isResolvedState")),
+             incident_states[0]["_id"]))
+
+    description = (
+        "Das Hochladen neuer Datei-Anhänge in Jira schlägt aktuell fehl. "
+        "Bereits vorhandene Anhänge lassen sich weiterhin öffnen und "
+        "herunterladen. **Tickets, Kommentare und die Suche sind nicht "
+        "betroffen.** Die IT arbeitet an der Behebung."
+    )
+    # Same forward-only-state-transition constraint as the other live
+    # scenarios (see security_incident.py) - a resolved incident can't be
+    # reopened via PUT, only recreated.
+    existing = find_by_name("incident", INCIDENT_TITLE, name_field="title",
+                            select={"_id": True, "title": True, "currentIncidentState": {"isResolvedState": True}})
+    if existing and (existing.get("currentIncidentState") or {}).get("isResolvedState"):
+        call(f"/api/incident/{existing['_id']}", None, method="DELETE")
+        existing = None
+
+    if existing:
+        payload = {"title": INCIDENT_TITLE, "description": description,
+                  "incidentSeverityId": severity_id, "monitors": [entity_ref(monitor_id)]}
+        call(f"/api/incident/{existing['_id']}", {"data": payload}, method="PUT")
+    else:
+        payload = {"title": INCIDENT_TITLE, "description": description,
+                  "incidentSeverityId": severity_id,
+                  "currentIncidentStateId": identified_state_id,
+                  "monitors": [entity_ref(monitor_id)], "projectId": project_id}
+        call("/api/incident", {"data": payload})
+
+    set_monitor_status(degraded_status_id)
+    print(f"==> '{INCIDENT_TITLE}' ist jetzt aktiv (Status: Identified).")
+    print(f"    Monitor '{MONITOR_NAME}' auf Degraded gesetzt.")
+
+elif mode == "fix":
+    incident = find_by_name("incident", INCIDENT_TITLE, name_field="title")
+    if not incident:
+        sys.exit(f"ERROR: incident '{INCIDENT_TITLE}' not found - run './jira_attachments_incident.py break' first.")
+    incident_id = incident["_id"]
+
+    resolution_note = (
+        "**Update:** Datei-Uploads in Jira funktionieren wieder "
+        "uneingeschränkt."
+    )
+    existing_notes = get_list("incident-public-note", query={"incidentId": incident_id},
+                              select={"_id": True, "note": True})
+    if not any(n.get("note") == resolution_note for n in existing_notes):
+        call("/api/incident-public-note", {"data": {
+            "projectId": project_id,
+            "incidentId": incident_id,
+            "note": resolution_note,
+            "shouldStatusPageSubscribersBeNotifiedOnNoteCreated": True,
+        }})
+
+    incident_states = get_list("incident-state", select={"_id": True, "isResolvedState": True})
+    resolved_state_id = next(s["_id"] for s in incident_states if s.get("isResolvedState"))
+    call(f"/api/incident/{incident_id}", {"data": {
+        "currentIncidentStateId": resolved_state_id,
+    }}, method="PUT")
+
+    set_monitor_status(operational_status_id)
+    print(f"==> '{INCIDENT_TITLE}' ist jetzt Resolved.")
+    print(f"    Monitor '{MONITOR_NAME}' wieder auf Operational gesetzt.")
+
+else:
+    sys.exit("Usage: jira_attachments_incident.py break|fix")


### PR DESCRIPTION
## Summary

Follow-up to #160/#161's control-panel review. Answers the still-open "which additional cases are worth showing?" question with three concrete additions, plus a direct link to the real product:

- **Link to the real product.** A new "Echtes Produkt (kein Demo-Fixture)" hub card links straight to the actual M365 status app at `http://localhost:8000`. It's started via `make dev` (`uv run uvicorn`) rather than Docker, since Docker Hub pulls are blocked in this environment — for both the demo stack's images and the main app's own `python:3.12-slim` base image. Documented in the README, including the expected `AADSTS90002` graceful-failure behavior without real Azure credentials.
- **8th scenario card — Cognigy vendor outage.** A third incident *type*, alongside "our own infra broke" and "security incident": an external SaaS vendor the chatbot depends on has a problem. Driven by the existing Customer-Care Prometheus exporter with its own isolated state file (`COGNIGY_STATE_FILE`), so it can be triggered independently of (or together with) the Chemnitz-VPN scenario. No Grafana dashboard changes needed — the existing panel thresholds already color the planned degraded ranges correctly.
- **9th card — ad-hoc Blueant outage.** The deliberate opposite of the only other Blueant disruption in the demo (the always-"currently happening" Patchday maintenance): a genuine, unannounced outage, independently triggerable.
- **10th card — Jira file-upload failure.** A narrow, sub-feature outage rather than "Jira is down": only new attachment uploads fail, existing attachments/tickets/comments/search stay unaffected. Kept separate from the "Benachrichtigungen" monitor already used by the rotating incident pool in `refresh_demo.py`.

Both new live-incident scenarios (Blueant, Jira) follow the exact same standalone break/fix script pattern as `security_incident.py` (login, forward-only incident-state handling, idempotent resolution notes).

All ten scenario cards now have distinct accent colors, and the legend panel above the grid lists all ten with their audience (IT-only vs. IT+Nutzer) and concrete value.

## Test plan

- [x] `python3 -m py_compile` on all touched/new Python scripts
- [x] `sh -n` on all new/touched shell wrapper scripts
- [x] HTML tag-balance check on `control-panel.html`
- [x] Headless-Chromium screenshot of the control panel confirming all 10 cards render with correct colors/content and the legend lists all 10 rows
- [x] Live-verified the Cognigy exporter branch (healthy ↔ unhealthy ↔ healthy) outside Docker via direct script execution + state-file toggling
- [ ] Full end-to-end `break-blueant.sh`/`break-jira-attachments.sh` against a live OneUptime instance (not run in this sandbox — Docker Hub is blocked here; both scripts mirror the already-verified `security_incident.py` pattern exactly)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TnPKEJEq6XeyPzze5P3BQM)_