### PR TITLE
Demo control panel: hub cards self-enable after seeding, no reload needed

### DIFF
--- a/demo-cert-monitoring/README.md
+++ b/demo-cert-monitoring/README.md
@@ -1553,6 +1553,20 @@ Vordergrund außerhalb von Docker** (Ctrl+C stoppt es) statt als weiterer
 `docker-compose.yml`-Service - `./start-demo.sh` weist am Ende auf
 diesen Befehl hin, startet ihn aber nicht automatisch mit.
 
+**Kleiner Fix: Karten, die auf `./seed-oneuptime.sh` warten, aktivieren
+sich jetzt von selbst.** Alle Links, die eine geseedete OneUptime-Instanz
+brauchen (die drei Statusseiten-Kacheln, die fünf Kacheln unter
+"OneUptime – weitere Bereiche", diverse Admin-/Nutzer-Sublinks auf den
+Szenario-Karten) starten deaktiviert und werden von `loadLinks()`
+freigeschaltet, sobald `/api/links` echte IDs liefert. Bisher lief
+`loadLinks()` nur einmal beim Laden der Seite - wer das Kontrollzentrum
+vor dem Seeding geöffnet hatte, musste die Seite manuell neu laden,
+damit die Kacheln den neuen Stand bemerken. `loadLinks()` ist rein
+additiv (setzt nur `href`/entfernt `.disabled`, nimmt nie etwas zurück),
+läuft jetzt deshalb im selben 5-Sekunden-Intervall wie `refreshStatus()`
+mit - eine Karte schaltet sich von selbst frei, sobald das Seeding
+durchgelaufen ist, ganz ohne Neuladen.
+
 ## Ruhigere Zeitreihen-Graphen
 
 Die Zeitreihen-Panels wirkten zu "spikig" für eine Management-Demo (alle

--- a/demo-cert-monitoring/scripts/control-panel.html
+++ b/demo-cert-monitoring/scripts/control-panel.html
@@ -924,7 +924,11 @@
 
     loadLinks();
     refreshStatus();
-    setInterval(refreshStatus, 5000);
+    // loadLinks() is idempotent (only ever adds hrefs/removes .disabled,
+    // never undoes anything) - polling it here too means a card enables
+    // itself the moment ./seed-oneuptime.sh finishes, without requiring a
+    // manual page reload in between.
+    setInterval(() => { refreshStatus(); loadLinks(); }, 5000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Answers "why is 'OneUptime – weitere Bereiche' not clickable?" — and fixes the root UX gap behind it, not just the immediate cause.

Root cause: those 5 cards (and the 3 status-page cards, and several scenario sublinks) start disabled and only get their real URL once `loadLinks()` sees a seeded `.oneuptime-demo-summary` via `/api/links`. That part was already correct — but `loadLinks()` only ran once, at page load. If the control panel was opened *before* `./seed-oneuptime.sh` finished, the cards stayed disabled forever, even after seeding completed, until the page was manually reloaded.

Fix: `loadLinks()` is purely additive (only ever sets `href`/removes `.disabled`, never reverts anything already enabled), so it's safe to run on the same 5-second interval `refreshStatus()` already uses. Cards now enable themselves automatically the moment seeding finishes — no manual reload required.

## Test plan

- [x] HTML tag-balance check on `control-panel.html`
- [x] Confirmed `loadLinks()` is idempotent by reading its implementation (every branch is guarded by `if (url)`/`if (pageId)` before touching the DOM, no code path removes an href or re-adds `.disabled`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TnPKEJEq6XeyPzze5P3BQM)_